### PR TITLE
fix: 兼容 CI 无 .env 启动场景

### DIFF
--- a/apps/bff-server/package.json
+++ b/apps/bff-server/package.json
@@ -5,7 +5,7 @@
   "type": "commonjs",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "start": "node --env-file=../../.env dist/apps/bff-server/src/main.js",
+    "start": "sh -c 'if [ -f ../../.env ]; then exec node --env-file=../../.env dist/apps/bff-server/src/main.js; else exec node dist/apps/bff-server/src/main.js; fi'",
     "test": "npm run build && node --test \"dist/**/test/*.test.js\"",
     "test:query-gate": "bash ../../packages/bff/scripts/e2e-query-isolation.sh",
     "lint": "echo lint:bff-server"

--- a/packages/bff/package.json
+++ b/packages/bff/package.json
@@ -7,7 +7,7 @@
     "build": "tsc -p tsconfig.json",
     "test": "npm run build && node --test \"dist/**/test/*.test.js\"",
     "lint": "echo lint:bff",
-    "start": "node --env-file=../../.env dist/bff/src/main.js"
+    "start": "sh -c 'if [ -f ../../.env ]; then exec node --env-file=../../.env dist/bff/src/main.js; else exec node dist/bff/src/main.js; fi'"
   },
   "dependencies": {
     "@nestjs/common": "^10.4.12",


### PR DESCRIPTION
what
- 将 bff-server 与 bff 的 start 脚本改为条件加载 .env
- 本地存在 .env 时继续沿用 --env-file
- CI 不存在 .env 时直接使用 GitHub Actions 注入的环境变量启动

check
- pnpm lint
- pnpm query-gate
- 模拟移除仓库内 .env 后，启动链路可进入 Nest/DB 连接阶段，不再因缺文件直接退出

risk/rollback
- 风险较低，仅影响启动脚本
- 如出现回归，回退本 PR 可恢复为强依赖本地 .env 的旧行为