### PR TITLE
feat: 增加根级服务启动入口

### DIFF
--- a/apps/bff-server/package.json
+++ b/apps/bff-server/package.json
@@ -5,7 +5,7 @@
   "type": "commonjs",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "start": "node --env-file=../../.env dist/apps/bff-server/src/main.js",
+    "start": "sh -c 'if [ -f ../../.env ]; then exec node --env-file=../../.env dist/apps/bff-server/src/main.js; else exec node dist/apps/bff-server/src/main.js; fi'",
     "test": "npm run build && node --test \"dist/**/test/*.test.js\"",
     "test:query-gate": "bash ../../packages/bff/scripts/e2e-query-isolation.sh",
     "lint": "echo lint:bff-server"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "build": "pnpm -r build",
     "test": "pnpm -r test",
     "lint": "pnpm run lint:boundaries && pnpm -r lint",
+    "start": "pnpm run start:bff",
+    "start:bff": "pnpm --filter @meta-lc/bff-server... build && sh -c 'if [ -f .env ]; then exec node --env-file=.env apps/bff-server/dist/apps/bff-server/src/main.js; else exec node apps/bff-server/dist/apps/bff-server/src/main.js; fi'",
     "query-gate": "pnpm --filter @meta-lc/bff-server run test:query-gate",
     "lint:boundaries": "node scripts/check-boundaries.mjs"
   },

--- a/packages/bff/package.json
+++ b/packages/bff/package.json
@@ -7,7 +7,7 @@
     "build": "tsc -p tsconfig.json",
     "test": "npm run build && node --test \"dist/**/test/*.test.js\"",
     "lint": "echo lint:bff",
-    "start": "node --env-file=../../.env dist/bff/src/main.js"
+    "start": "sh -c 'if [ -f ../../.env ]; then exec node --env-file=../../.env dist/bff/src/main.js; else exec node dist/bff/src/main.js; fi'"
   },
   "dependencies": {
     "@nestjs/common": "^10.4.12",

--- a/packages/bff/src/bootstrap/migration-runner.ts
+++ b/packages/bff/src/bootstrap/migration-runner.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { Pool } from "pg";
 import type { DbConfig } from "../types";
@@ -15,7 +15,7 @@ export class MigrationRunner {
   constructor(private readonly rootDir: string) {}
 
   async apply(target: MigrationTarget, config: DbConfig): Promise<void> {
-    const sqlFile = path.join(this.rootDir, "scripts", "sql", "bootstrap", TARGET_TO_FILE[target]);
+    const sqlFile = resolveBootstrapSqlFile(this.rootDir, target);
     const sql = readFileSync(sqlFile, "utf8");
     const pool = createPool(config);
     try {
@@ -41,4 +41,20 @@ export function createPool(config: DbConfig): Pool {
     database: config.database,
     ssl: config.ssl ? { rejectUnauthorized: false } : false
   });
+}
+
+function resolveBootstrapSqlFile(rootDir: string, target: MigrationTarget): string {
+  const relativeFile = path.join("scripts", "sql", "bootstrap", TARGET_TO_FILE[target]);
+  const candidates = [
+    path.join(rootDir, relativeFile),
+    path.join(rootDir, "packages", "bff", relativeFile),
+    path.resolve(rootDir, "..", "..", "packages", "bff", relativeFile)
+  ];
+
+  const match = candidates.find((candidate) => existsSync(candidate));
+  if (!match) {
+    throw new Error(`bootstrap sql not found for ${target}: ${candidates.join(", ")}`);
+  }
+
+  return match;
 }


### PR DESCRIPTION
what
- 在 meta-lc-platform 根 package.json 增加统一 start/start:bff 入口
- 支持在仓库根直接执行 pnpm start 启动 bff-server
- 修复 bootstrap SQL 路径解析，避免根入口启动时 baseline 迁移文件查找失败

check
- pnpm --filter @meta-lc/bff-server... build
- pnpm start
- curl -fsS http://127.0.0.1:3000/health
- 启动日志出现 database baseline bootstrap completed

risk/rollback
- 风险较低，主要影响根脚本与 bootstrap SQL 路径解析
- 如有回归，回退本 PR 即可恢复到原有分包启动方式