### PR TITLE
feat: 打通 demo mutation 数据链路

### DIFF
--- a/packages/bff/scripts/sql/bootstrap/300_audit_baseline.sql
+++ b/packages/bff/scripts/sql/bootstrap/300_audit_baseline.sql
@@ -22,6 +22,9 @@ CREATE TABLE IF NOT EXISTS mutation_logs (
   operation TEXT NOT NULL,
   before_data JSONB NULL,
   after_data JSONB NULL,
+  duration_ms INTEGER NOT NULL DEFAULT 0,
+  status TEXT NOT NULL DEFAULT 'success',
+  error_message TEXT NULL,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 

--- a/packages/bff/src/app.module.ts
+++ b/packages/bff/src/app.module.ts
@@ -5,6 +5,7 @@ import { HttpExceptionFilter } from "./common/http-exception.filter";
 import { QueryController } from "./gateway/query.controller";
 import { AuditPersistenceService } from "./integration/audit-persistence.service";
 import { PostgresQueryExecutorService } from "./integration/postgres-query-executor.service";
+import { MutationOrchestratorService } from "./orchestration/mutation-orchestrator.service";
 import { QueryOrchestratorService } from "./orchestration/query-orchestrator.service";
 
 @Module({
@@ -14,6 +15,7 @@ import { QueryOrchestratorService } from "./orchestration/query-orchestrator.ser
     PostgresQueryExecutorService,
     AuditPersistenceService,
     QueryOrchestratorService,
+    MutationOrchestratorService,
     AuditLogService,
     {
       provide: APP_FILTER,

--- a/packages/bff/src/common/audit-log.service.ts
+++ b/packages/bff/src/common/audit-log.service.ts
@@ -13,6 +13,18 @@ export interface QueryAuditPayload {
   error?: string;
 }
 
+export interface MutationAuditPayload {
+  requestId: string;
+  tenantId: string;
+  userId: string;
+  table: string;
+  operation: string;
+  durationMs: number;
+  beforeData?: Record<string, unknown> | null;
+  afterData?: Record<string, unknown> | null;
+  error?: string;
+}
+
 @Injectable()
 export class AuditLogService {
   private readonly logger = new Logger("AuditLog");
@@ -71,6 +83,62 @@ export class AuditLogService {
     } catch (error) {
       this.logger.warn(
         `persist failure audit failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  async logMutationSuccess(payload: MutationAuditPayload): Promise<void> {
+    this.logger.log(
+      JSON.stringify({
+        event: "mutation.success",
+        timestamp: new Date().toISOString(),
+        ...payload
+      })
+    );
+    try {
+      await this.auditPersistenceService.persistMutation({
+        requestId: payload.requestId,
+        tenantId: payload.tenantId,
+        userId: payload.userId,
+        tableName: payload.table,
+        operation: payload.operation,
+        beforeData: payload.beforeData ?? null,
+        afterData: payload.afterData ?? null,
+        durationMs: payload.durationMs,
+        status: "success",
+        errorMessage: null
+      });
+    } catch (error) {
+      this.logger.warn(
+        `persist mutation success audit failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  async logMutationFailure(payload: MutationAuditPayload): Promise<void> {
+    this.logger.error(
+      JSON.stringify({
+        event: "mutation.failure",
+        timestamp: new Date().toISOString(),
+        ...payload
+      })
+    );
+    try {
+      await this.auditPersistenceService.persistMutation({
+        requestId: payload.requestId,
+        tenantId: payload.tenantId,
+        userId: payload.userId,
+        tableName: payload.table,
+        operation: payload.operation,
+        beforeData: payload.beforeData ?? null,
+        afterData: payload.afterData ?? null,
+        durationMs: payload.durationMs,
+        status: "failure",
+        errorMessage: payload.error ?? null
+      });
+    } catch (error) {
+      this.logger.warn(
+        `persist mutation failure audit failed: ${error instanceof Error ? error.message : String(error)}`
       );
     }
   }

--- a/packages/bff/src/gateway/query.controller.ts
+++ b/packages/bff/src/gateway/query.controller.ts
@@ -1,13 +1,15 @@
 import { Body, Controller, Get, Post, Req, Res } from "@nestjs/common";
 import { AuditLogService } from "../common/audit-log.service";
 import { resolveRequestId } from "../common/request-id";
+import { MutationOrchestratorService } from "../orchestration/mutation-orchestrator.service";
 import { QueryOrchestratorService } from "../orchestration/query-orchestrator.service";
-import type { QueryApiRequest } from "../types";
+import type { MutationApiRequest, QueryApiRequest } from "../types";
 
 @Controller()
 export class QueryController {
   constructor(
     private readonly queryOrchestrator: QueryOrchestratorService,
+    private readonly mutationOrchestrator: MutationOrchestratorService,
     private readonly auditLogService: AuditLogService
   ) {}
 
@@ -59,6 +61,52 @@ export class QueryController {
         userId: request.userId,
         table: request.table,
         queryDsl,
+        durationMs: Date.now() - startedAt,
+        error: error instanceof Error ? error.message : "unknown_error"
+      });
+      throw error;
+    }
+  }
+
+  @Post("mutation")
+  async mutation(
+    @Body() request: MutationApiRequest,
+    @Req()
+    req: {
+      headers: Record<string, string | string[] | undefined>;
+    },
+    @Res({ passthrough: true })
+    res: {
+      setHeader(name: string, value: string): void;
+    }
+  ): Promise<{ rowCount: number; row: Record<string, unknown> | null }> {
+    const requestId = resolveRequestId(req.headers["x-request-id"]);
+    res.setHeader("x-request-id", requestId);
+
+    const startedAt = Date.now();
+    try {
+      const result = await this.mutationOrchestrator.execute(request);
+      await this.auditLogService.logMutationSuccess({
+        requestId,
+        tenantId: request.tenantId,
+        userId: request.userId,
+        table: request.table,
+        operation: request.operation,
+        durationMs: Date.now() - startedAt,
+        beforeData: result.beforeData,
+        afterData: result.afterData
+      });
+      return {
+        rowCount: result.rowCount,
+        row: result.afterData ?? result.beforeData
+      };
+    } catch (error) {
+      await this.auditLogService.logMutationFailure({
+        requestId,
+        tenantId: request.tenantId,
+        userId: request.userId,
+        table: request.table,
+        operation: request.operation,
         durationMs: Date.now() - startedAt,
         error: error instanceof Error ? error.message : "unknown_error"
       });

--- a/packages/bff/src/integration/audit-persistence.service.ts
+++ b/packages/bff/src/integration/audit-persistence.service.ts
@@ -15,6 +15,19 @@ export interface QueryAuditRecord {
   errorMessage: string | null;
 }
 
+export interface MutationAuditRecord {
+  requestId: string;
+  tenantId: string;
+  userId: string;
+  tableName: string;
+  operation: string;
+  beforeData: Record<string, unknown> | null;
+  afterData: Record<string, unknown> | null;
+  durationMs: number;
+  status: "success" | "failure";
+  errorMessage: string | null;
+}
+
 @Injectable()
 export class AuditPersistenceService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger("AuditPersistence");
@@ -60,8 +73,23 @@ export class AuditPersistenceService implements OnModuleInit, OnModuleDestroy {
         operation TEXT NOT NULL,
         before_data JSONB NULL,
         after_data JSONB NULL,
+        duration_ms INTEGER NOT NULL DEFAULT 0,
+        status TEXT NOT NULL DEFAULT 'success',
+        error_message TEXT NULL,
         created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
       )
+    `);
+    await this.pool.query(`
+      ALTER TABLE mutation_logs
+      ADD COLUMN IF NOT EXISTS duration_ms INTEGER NOT NULL DEFAULT 0
+    `);
+    await this.pool.query(`
+      ALTER TABLE mutation_logs
+      ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'success'
+    `);
+    await this.pool.query(`
+      ALTER TABLE mutation_logs
+      ADD COLUMN IF NOT EXISTS error_message TEXT NULL
     `);
     await this.pool.query(`
       CREATE TABLE IF NOT EXISTS migration_logs (
@@ -173,6 +201,41 @@ export class AuditPersistenceService implements OnModuleInit, OnModuleDestroy {
     } catch (error) {
       this.logger.warn(
         `persist audit failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  async persistMutation(record: MutationAuditRecord): Promise<void> {
+    try {
+      await this.pool.query(
+        `INSERT INTO mutation_logs (
+          request_id,
+          tenant_id,
+          user_id,
+          table_name,
+          operation,
+          before_data,
+          after_data,
+          duration_ms,
+          status,
+          error_message
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+        [
+          record.requestId,
+          record.tenantId,
+          record.userId,
+          record.tableName,
+          record.operation,
+          record.beforeData,
+          record.afterData,
+          record.durationMs,
+          record.status,
+          record.errorMessage
+        ]
+      );
+    } catch (error) {
+      this.logger.warn(
+        `persist mutation audit failed: ${error instanceof Error ? error.message : String(error)}`
       );
     }
   }

--- a/packages/bff/src/integration/postgres-query-executor.service.ts
+++ b/packages/bff/src/integration/postgres-query-executor.service.ts
@@ -1,6 +1,29 @@
 import { Injectable, OnModuleDestroy } from "@nestjs/common";
-import { Pool } from "pg";
+import { Pool, type PoolClient } from "pg";
 import { loadDbConfig } from "../config";
+import type { MutationOperation } from "../types";
+
+interface OrderMutationPayload {
+  id: string;
+  owner?: string;
+  channel?: string;
+  priority?: string;
+  status?: string;
+}
+
+export interface OrderMutationCommand {
+  operation: MutationOperation;
+  tenantId: string;
+  userId: string;
+  superAdmin: boolean;
+  payload: OrderMutationPayload;
+}
+
+export interface MutationExecutionRecord {
+  rowCount: number;
+  beforeData: Record<string, unknown> | null;
+  afterData: Record<string, unknown> | null;
+}
 
 @Injectable()
 export class PostgresQueryExecutorService implements OnModuleDestroy {
@@ -28,7 +51,115 @@ export class PostgresQueryExecutorService implements OnModuleDestroy {
     return result.rows[0]?.ok === 1;
   }
 
+  async mutateOrder(command: OrderMutationCommand): Promise<MutationExecutionRecord> {
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN");
+
+      if (command.operation === "create") {
+        const created = await client.query<Record<string, unknown>>(
+          `INSERT INTO orders (id, owner, channel, priority, status, tenant_id, created_by)
+           VALUES ($1, $2, $3, $4, $5, $6, $7)
+           RETURNING id, owner, channel, priority, status, tenant_id, created_by`,
+          [
+            command.payload.id,
+            command.payload.owner ?? "",
+            command.payload.channel ?? "web",
+            command.payload.priority ?? "medium",
+            command.payload.status ?? "active",
+            command.tenantId,
+            command.userId
+          ]
+        );
+        await client.query("COMMIT");
+        return {
+          rowCount: created.rowCount ?? 0,
+          beforeData: null,
+          afterData: created.rows[0] ?? null
+        };
+      }
+
+      const before = await this.selectCurrentOrder(client, command);
+      if (!before) {
+        await client.query("ROLLBACK");
+        return {
+          rowCount: 0,
+          beforeData: null,
+          afterData: null
+        };
+      }
+
+      if (command.operation === "update") {
+        const updated = await client.query<Record<string, unknown>>(
+          `UPDATE orders
+           SET owner = $1,
+               channel = $2,
+               priority = $3,
+               status = $4
+           WHERE ${buildUpdateWhereClause(command.superAdmin)}
+           RETURNING id, owner, channel, priority, status, tenant_id, created_by`,
+          [
+            command.payload.owner ?? "",
+            command.payload.channel ?? "web",
+            command.payload.priority ?? "medium",
+            command.payload.status ?? "active",
+            command.payload.id,
+            ...buildScopeParams(command)
+          ]
+        );
+        await client.query("COMMIT");
+        return {
+          rowCount: updated.rowCount ?? 0,
+          beforeData: before,
+          afterData: updated.rows[0] ?? null
+        };
+      }
+
+      const deleted = await client.query(
+        `DELETE FROM orders
+         WHERE id = $1${buildScopedWhereClause(command.superAdmin)}`,
+        [command.payload.id, ...buildScopeParams(command)]
+      );
+      await client.query("COMMIT");
+      return {
+        rowCount: deleted.rowCount ?? 0,
+        beforeData: before,
+        afterData: null
+      };
+    } catch (error) {
+      await client.query("ROLLBACK");
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
   async onModuleDestroy(): Promise<void> {
     await this.pool.end();
   }
+
+  private async selectCurrentOrder(
+    client: PoolClient,
+    command: OrderMutationCommand
+  ): Promise<Record<string, unknown> | null> {
+    const result = await client.query<Record<string, unknown>>(
+      `SELECT id, owner, channel, priority, status, tenant_id, created_by
+       FROM orders
+       WHERE id = $1${buildScopedWhereClause(command.superAdmin)}`,
+      [command.payload.id, ...buildScopeParams(command)]
+    );
+    return result.rows[0] ?? null;
+  }
+}
+
+function buildScopedWhereClause(superAdmin: boolean): string {
+  return superAdmin ? "" : " AND tenant_id = $2 AND created_by = $3";
+}
+
+function buildUpdateWhereClause(superAdmin: boolean): string {
+  return superAdmin ? "id = $5" : "id = $5 AND tenant_id = $6 AND created_by = $7";
+}
+
+function buildScopeParams(command: OrderMutationCommand): string[] {
+  return command.superAdmin ? [] : [command.tenantId, command.userId];
 }

--- a/packages/bff/src/orchestration/mutation-orchestrator.service.ts
+++ b/packages/bff/src/orchestration/mutation-orchestrator.service.ts
@@ -1,0 +1,108 @@
+import { BadRequestException, ConflictException, Injectable, NotFoundException } from "@nestjs/common";
+import { PostgresQueryExecutorService } from "../integration/postgres-query-executor.service";
+import type { MutationApiRequest, MutationOperation } from "../types";
+
+interface OrderMutationPayload {
+  id: string;
+  owner?: string;
+  channel?: string;
+  priority?: string;
+  status?: string;
+}
+
+export interface MutationExecutionResult {
+  rowCount: number;
+  operation: MutationOperation;
+  table: string;
+  beforeData: Record<string, unknown> | null;
+  afterData: Record<string, unknown> | null;
+}
+
+@Injectable()
+export class MutationOrchestratorService {
+  constructor(private readonly queryExecutor: PostgresQueryExecutorService) {}
+
+  async execute(request: MutationApiRequest): Promise<MutationExecutionResult> {
+    if (!request.tenantId || !request.userId) {
+      throw new BadRequestException("tenantId and userId are required.");
+    }
+    if (request.table !== "orders") {
+      throw new BadRequestException("only orders table is supported.");
+    }
+
+    const payload = normalizeMutationPayload(request);
+
+    try {
+      const result = await this.queryExecutor.mutateOrder({
+        operation: request.operation,
+        tenantId: request.tenantId,
+        userId: request.userId,
+        superAdmin: request.roles.includes("SUPER_ADMIN"),
+        payload
+      });
+
+      if (result.rowCount < 1) {
+        throw new NotFoundException(`order ${payload.id} not found`);
+      }
+
+      return {
+        rowCount: result.rowCount,
+        operation: request.operation,
+        table: request.table,
+        beforeData: result.beforeData,
+        afterData: result.afterData
+      };
+    } catch (error) {
+      if (isPgDuplicateKey(error)) {
+        throw new ConflictException(`order ${payload.id} already exists`);
+      }
+      throw error;
+    }
+  }
+}
+
+function normalizeMutationPayload(request: MutationApiRequest): OrderMutationPayload {
+  const source = request.data ?? {};
+  const id = resolveId(request).trim();
+  if (!id) {
+    throw new BadRequestException("mutation key.id is required.");
+  }
+
+  if (request.operation === "delete") {
+    return { id };
+  }
+
+  const owner = String(source["owner"] ?? "").trim();
+  if (!owner) {
+    throw new BadRequestException("owner is required.");
+  }
+
+  return {
+    id,
+    owner,
+    channel: String(source["channel"] ?? "web"),
+    priority: String(source["priority"] ?? "medium"),
+    status: String(source["status"] ?? "active")
+  };
+}
+
+function resolveId(request: MutationApiRequest): string {
+  const keyId = request.key?.["id"];
+  if (typeof keyId === "string" || typeof keyId === "number") {
+    return String(keyId);
+  }
+  const dataId = request.data?.["id"];
+  if (typeof dataId === "string" || typeof dataId === "number") {
+    return String(dataId);
+  }
+  return "";
+}
+
+function isPgDuplicateKey(error: unknown): boolean {
+  return Boolean(
+    error &&
+      typeof error === "object" &&
+      "code" in error &&
+      String((error as { code?: unknown }).code) === "23505"
+  );
+}

--- a/packages/bff/src/types.ts
+++ b/packages/bff/src/types.ts
@@ -1,1 +1,8 @@
-export type { BootstrapMode, DbConfig, DbTargets, QueryApiRequest } from "@meta-lc/contracts";
+export type {
+  BootstrapMode,
+  DbConfig,
+  DbTargets,
+  MutationApiRequest,
+  MutationOperation,
+  QueryApiRequest
+} from "@meta-lc/contracts";

--- a/packages/bff/test/mutation-orchestrator.test.ts
+++ b/packages/bff/test/mutation-orchestrator.test.ts
@@ -1,0 +1,42 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { MutationOrchestratorService } from "../src/orchestration/mutation-orchestrator.service";
+
+test("mutation orchestrator rejects unsupported tables", async () => {
+  const service = new MutationOrchestratorService({} as never);
+
+  await assert.rejects(
+    async () =>
+      service.execute({
+        table: "users",
+        operation: "create",
+        tenantId: "tenant-a",
+        userId: "user-a",
+        roles: ["USER"],
+        data: {
+          id: "U-1",
+          owner: "Alice"
+        }
+      }),
+    /only orders table is supported/i
+  );
+});
+
+test("mutation orchestrator requires owner for create and update", async () => {
+  const service = new MutationOrchestratorService({} as never);
+
+  await assert.rejects(
+    async () =>
+      service.execute({
+        table: "orders",
+        operation: "create",
+        tenantId: "tenant-a",
+        userId: "user-a",
+        roles: ["USER"],
+        data: {
+          id: "SO-1"
+        }
+      }),
+    /owner is required/i
+  );
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -8,6 +8,18 @@ export interface QueryApiRequest {
   limit?: number;
 }
 
+export type MutationOperation = "create" | "update" | "delete";
+
+export interface MutationApiRequest {
+  table: string;
+  operation: MutationOperation;
+  tenantId: string;
+  userId: string;
+  roles: string[];
+  key?: Record<string, string | number | boolean>;
+  data?: Record<string, string | number | boolean | null>;
+}
+
 export interface DbConfig {
   url?: string;
   host: string;


### PR DESCRIPTION
## Summary
- add a minimal  flow in bff for demo orders create/update/delete
- persist mutation success/failure into 
- keep demo query path on  and share the same tenant-scoped postgres data

## Verification
- pnpm -r build
- pnpm -r test
- pnpm lint
- curl create/query/update/delete smoke against local bff
