### PR TITLE
ci: 移除 pnpm action runtime 告警

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,19 +8,19 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  PNPM_VERSION: 10.14.0
 
 jobs:
   build-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.14.0
       - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: pnpm
+      - run: corepack enable
+      - run: corepack prepare "pnpm@${PNPM_VERSION}" --activate
       - run: pnpm install --frozen-lockfile
       - run: pnpm -r build
       - run: pnpm -r test
@@ -31,13 +31,12 @@ jobs:
     needs: build-test
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.14.0
       - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: pnpm
+      - run: corepack enable
+      - run: corepack prepare "pnpm@${PNPM_VERSION}" --activate
       - run: pnpm install --frozen-lockfile
       - name: query-gate (e2e)
         env:


### PR DESCRIPTION
## Summary
- remove pnpm/action-setup from CI
- activate pnpm 10.14.0 via corepack on Node 24
- keep checkout/setup-node on v5 so the workflow no longer depends on Node 20-targeting actions

## Verification
- workflow YAML self-check
- remote GitHub Actions CI after merge
