### PR TITLE
ci: 关闭 setup-node 隐式 pnpm 缓存

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24
+          package-manager-cache: false
       - run: corepack enable
       - run: corepack prepare "pnpm@${PNPM_VERSION}" --activate
       - run: pnpm install --frozen-lockfile
@@ -32,6 +33,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24
+          package-manager-cache: false
       - run: corepack enable
       - run: corepack prepare "pnpm@${PNPM_VERSION}" --activate
       - run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- disable setup-node package-manager-cache when pnpm is activated later via corepack
- keep the workflow free of Node 20-targeting actions
- restore CI without reintroducing the pnpm action warning

## Verification
- workflow YAML self-check
- remote GitHub Actions CI after merge
