### PR TITLE
chore: default bff port to 6000

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # BFF runtime
-PORT=3000
+PORT=6000
 NODE_ENV=development
 
 # Bootstrap mode: auto | manual

--- a/packages/bff/scripts/e2e-query-isolation.sh
+++ b/packages/bff/scripts/e2e-query-isolation.sh
@@ -15,8 +15,8 @@ if [[ -f "${ENV_FILE}" ]]; then
   set +a
 fi
 
-BFF_URL="${BFF_URL:-http://127.0.0.1:3000}"
-PORT="${PORT:-3000}"
+BFF_URL="${BFF_URL:-http://127.0.0.1:6000}"
+PORT="${PORT:-6000}"
 RUN_ID="${RUN_ID:-$(date +%s)}"
 NODE_ENV="${NODE_ENV:-development}"
 LC_DB_BOOTSTRAP_MODE="${LC_DB_BOOTSTRAP_MODE:-auto}"

--- a/packages/bff/src/main.ts
+++ b/packages/bff/src/main.ts
@@ -13,7 +13,7 @@ export async function startBffServer(): Promise<void> {
     origin: true,
     credentials: true
   });
-  await app.listen(process.env.PORT ? Number(process.env.PORT) : 3000);
+  await app.listen(process.env.PORT ? Number(process.env.PORT) : 6000);
 }
 
 if (require.main === module) {


### PR DESCRIPTION
## 变更摘要\n- 将 BFF 默认监听端口从 3000 调整为 6000\n- 将 .env.example 默认 PORT 同步为 6000\n- 将 query-gate 脚本默认 BFF_URL/PORT 同步为 6000\n\n## 验证\n- pnpm query-gate（通过）\n\n## 风险与回滚\n- 风险：依赖默认 3000 的本地脚本需要显式传入 PORT\n- 回滚：将以上 3 处默认值改回 3000 并重跑 query-gate