### PR TITLE
feat: consolidate infra into meta-lc-platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ pnpm -r build
 pnpm -r test
 pnpm lint
 pnpm --filter @meta-lc/bff-server start
+pnpm infra:up
+pnpm infra:query-gate
 ```
 
 ## Architectural constraints

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,36 @@
+# Infra (meta-lc-platform)
+
+`meta-lc-platform/infra` is the only infra entry for local middleware integration.
+
+## Bring up dependencies
+
+```bash
+cd ./meta-lc-platform
+docker compose -f infra/docker-compose.yml up -d postgres redis
+```
+
+or
+
+```bash
+cd ./meta-lc-platform
+bash infra/scripts/up.sh
+```
+
+## Run query gate
+
+```bash
+cd ./meta-lc-platform
+bash infra/scripts/query-gate.sh
+```
+
+The gate validates:
+
+- BFF startup via `apps/bff-server`
+- tenant isolation on `/query`
+- query/mutation audit persistence in `audit_db`
+
+## Defaults
+
+- `PORT=6000`
+- `LC_DB_BOOTSTRAP_MODE=auto` (dev/test)
+- databases: `meta_db`, `business_db`, `audit_db`

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,36 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${LC_DB_USER:-lowcode}
+      POSTGRES_PASSWORD: ${LC_DB_PASSWORD:-lowcode}
+      POSTGRES_DB: ${LC_DB_BOOTSTRAP_DB:-postgres}
+      TZ: Asia/Shanghai
+    ports:
+      - "${LC_DB_PORT:-5432}:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${LC_DB_USER:-lowcode} -d ${LC_DB_BOOTSTRAP_DB:-postgres}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: ["redis-server", "--appendonly", "yes", "--save", "60", "1000"]
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+
+volumes:
+  postgres_data:
+  redis_data:

--- a/infra/scripts/down.sh
+++ b/infra/scripts/down.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+docker compose -f "${ROOT_DIR}/docker-compose.yml" down

--- a/infra/scripts/query-gate.sh
+++ b/infra/scripts/query-gate.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+WORKSPACE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+"${WORKSPACE_DIR}/infra/scripts/up.sh"
+cd "${WORKSPACE_DIR}"
+pnpm query-gate

--- a/infra/scripts/up.sh
+++ b/infra/scripts/up.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+docker compose -f "${ROOT_DIR}/docker-compose.yml" up -d postgres redis

--- a/infra/sql/001_orders_demo.sql
+++ b/infra/sql/001_orders_demo.sql
@@ -1,0 +1,28 @@
+CREATE TABLE IF NOT EXISTS orders (
+  id TEXT PRIMARY KEY,
+  owner TEXT NOT NULL,
+  channel TEXT NOT NULL,
+  priority TEXT NOT NULL,
+  status TEXT NOT NULL,
+  tenant_id TEXT NOT NULL,
+  created_by TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_orders_tenant_id ON orders (tenant_id);
+CREATE INDEX IF NOT EXISTS idx_orders_status ON orders (status);
+CREATE INDEX IF NOT EXISTS idx_orders_owner ON orders (owner);
+
+INSERT INTO orders (id, owner, channel, priority, status, tenant_id, created_by)
+VALUES
+  ('SO-A1001', 'Alice', 'web', 'high', 'active', 'tenant-a', 'demo-tenant-a-user'),
+  ('SO-A1002', 'Aria', 'store', 'medium', 'paused', 'tenant-a', 'demo-tenant-a-user'),
+  ('SO-B1001', 'Brenda', 'partner', 'high', 'active', 'tenant-b', 'demo-tenant-b-user'),
+  ('SO-B1002', 'Bryan', 'web', 'low', 'paused', 'tenant-b', 'demo-tenant-b-user')
+ON CONFLICT (id) DO UPDATE
+SET
+  owner = EXCLUDED.owner,
+  channel = EXCLUDED.channel,
+  priority = EXCLUDED.priority,
+  status = EXCLUDED.status,
+  tenant_id = EXCLUDED.tenant_id,
+  created_by = EXCLUDED.created_by;

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "start": "pnpm run start:bff",
     "start:bff": "pnpm --filter @meta-lc/bff-server... build && sh -c 'if [ -f .env ]; then exec node --env-file=.env apps/bff-server/dist/apps/bff-server/src/main.js; else exec node apps/bff-server/dist/apps/bff-server/src/main.js; fi'",
     "query-gate": "pnpm --filter @meta-lc/bff-server run test:query-gate",
+    "infra:up": "docker compose -f infra/docker-compose.yml up -d postgres redis",
+    "infra:down": "docker compose -f infra/docker-compose.yml down",
+    "infra:query-gate": "bash infra/scripts/query-gate.sh",
     "lint:boundaries": "node scripts/check-boundaries.mjs"
   },
   "devDependencies": {


### PR DESCRIPTION
## 变更摘要
- 新增 `meta-lc-platform/infra` 作为统一 infra 入口（docker-compose、seed SQL、up/down/query-gate 脚本）
- 根级命令补充 `infra:up` / `infra:down` / `infra:query-gate`
- README 同步 infra 入口与命令

## 验证
- `pnpm -r build`（通过）
- `pnpm -r test`（通过）
- `pnpm query-gate`（通过）
- `pnpm infra:up`（失败：本机 Docker daemon 未启动）

## 风险/回滚
- 风险：依赖本机 Docker 的联调命令要求 daemon 先启动
- 回滚：移除新增 infra 目录与 package scripts，恢复原脚本入口
