### PR TITLE
feat: add org-scope data permission pipeline

### DIFF
--- a/infra/sql/001_orders_demo.sql
+++ b/infra/sql/001_orders_demo.sql
@@ -5,19 +5,21 @@ CREATE TABLE IF NOT EXISTS orders (
   priority TEXT NOT NULL,
   status TEXT NOT NULL,
   tenant_id TEXT NOT NULL,
-  created_by TEXT NOT NULL
+  created_by TEXT NOT NULL,
+  org_id TEXT NULL
 );
 
 CREATE INDEX IF NOT EXISTS idx_orders_tenant_id ON orders (tenant_id);
 CREATE INDEX IF NOT EXISTS idx_orders_status ON orders (status);
 CREATE INDEX IF NOT EXISTS idx_orders_owner ON orders (owner);
 
-INSERT INTO orders (id, owner, channel, priority, status, tenant_id, created_by)
+INSERT INTO orders (id, owner, channel, priority, status, tenant_id, created_by, org_id)
 VALUES
-  ('SO-A1001', 'Alice', 'web', 'high', 'active', 'tenant-a', 'demo-tenant-a-user'),
-  ('SO-A1002', 'Aria', 'store', 'medium', 'paused', 'tenant-a', 'demo-tenant-a-user'),
-  ('SO-B1001', 'Brenda', 'partner', 'high', 'active', 'tenant-b', 'demo-tenant-b-user'),
-  ('SO-B1002', 'Bryan', 'web', 'low', 'paused', 'tenant-b', 'demo-tenant-b-user')
+  ('SO-A1001', 'Alice', 'web', 'high', 'active', 'tenant-a', 'demo-tenant-a-user', 'dept-a'),
+  ('SO-A1002', 'Aria', 'store', 'medium', 'paused', 'tenant-a', 'demo-tenant-a-user', 'dept-a'),
+  ('SO-A2001', 'A-Manager-Only', 'partner', 'high', 'active', 'tenant-a', 'manager-tenant-a', 'dept-b'),
+  ('SO-B1001', 'Brenda', 'partner', 'high', 'active', 'tenant-b', 'demo-tenant-b-user', 'dept-c'),
+  ('SO-B1002', 'Bryan', 'web', 'low', 'paused', 'tenant-b', 'demo-tenant-b-user', 'dept-c')
 ON CONFLICT (id) DO UPDATE
 SET
   owner = EXCLUDED.owner,
@@ -25,4 +27,5 @@ SET
   priority = EXCLUDED.priority,
   status = EXCLUDED.status,
   tenant_id = EXCLUDED.tenant_id,
-  created_by = EXCLUDED.created_by;
+  created_by = EXCLUDED.created_by,
+  org_id = EXCLUDED.org_id;

--- a/packages/bff/scripts/e2e-query-isolation.sh
+++ b/packages/bff/scripts/e2e-query-isolation.sh
@@ -268,6 +268,40 @@ assert_mutation_audit_record() {
   fi
 }
 
+assert_query_denied() {
+  local request_id="$1"
+  local tenant_id="$2"
+  local user_id="$3"
+  local org_id="$4"
+  local output_file="$5"
+
+  local status_code
+  status_code="$(curl -sS -o "${output_file}" -w "%{http_code}" -X POST "${BFF_URL}/query" \
+    -H "content-type: application/json" \
+    -H "x-request-id: ${request_id}" \
+    -d "$(cat <<JSON
+{
+  "table": "orders",
+  "fields": ["id", "owner", "org_id", "tenant_id", "created_by"],
+  "filters": {
+    "org_id": "${org_id}"
+  },
+  "tenantId": "${tenant_id}",
+  "userId": "${user_id}",
+  "roles": ["USER"],
+  "limit": 20
+}
+JSON
+)")"
+
+  if [[ "${status_code}" != "403" ]]; then
+    cat "${output_file}"
+    exit 1
+  fi
+
+  assert_audit_record "${request_id}" "denied" "NULL"
+}
+
 require_cmd node
 require_cmd curl
 
@@ -514,6 +548,10 @@ fi
 
 assert_audit_record "${failure_request_id}" "failure" "NULL"
 
+log "validating query permission denied sample"
+query_denied_request_id="e2e-query-denied-${RUN_ID}"
+assert_query_denied "${query_denied_request_id}" "tenant-a" "demo-tenant-a-user" "dept-b" "${TMP_DIR}/query-denied.json"
+
 tenant_id="tenant-a"
 user_id="demo-tenant-a-user"
 test_order_id="SO-AE2E-${RUN_ID}"
@@ -527,6 +565,7 @@ create_status_code="$(run_mutation_request "${create_request_id}" "$(cat <<JSON
   "tenantId": "${tenant_id}",
   "userId": "${user_id}",
   "roles": ["USER"],
+  "orgId": "dept-a",
   "data": {
     "id": "${test_order_id}",
     "owner": "Gate Create",
@@ -562,6 +601,7 @@ duplicate_status_code="$(run_mutation_request "${duplicate_request_id}" "$(cat <
   "tenantId": "${tenant_id}",
   "userId": "${user_id}",
   "roles": ["USER"],
+  "orgId": "dept-a",
   "data": {
     "id": "${test_order_id}",
     "owner": "Gate Create",
@@ -587,6 +627,7 @@ update_status_code="$(run_mutation_request "${update_request_id}" "$(cat <<JSON
   "tenantId": "${tenant_id}",
   "userId": "${user_id}",
   "roles": ["USER"],
+  "orgId": "dept-a",
   "key": {
     "id": "${test_order_id}"
   },
@@ -646,6 +687,35 @@ if (data.rowCount !== 1 || data.row?.id !== process.argv[2]) {
 assert_mutation_audit_record "${delete_request_id}" "delete" "success" "${tenant_id}" "${user_id}"
 read -r delete_query_request_id delete_query_row_count <<< "$(query_order_and_assert_missing "${tenant_id}" "${user_id}" "${test_order_id}")"
 assert_audit_record "${delete_query_request_id}" "success" "${delete_query_row_count}"
+
+log "validating mutation permission denied sample"
+mutation_denied_request_id="e2e-mutation-denied-${RUN_ID}"
+mutation_denied_status_code="$(run_mutation_request "${mutation_denied_request_id}" "$(cat <<JSON
+{
+  "table": "orders",
+  "operation": "update",
+  "tenantId": "tenant-a",
+  "userId": "demo-tenant-a-user",
+  "roles": ["USER"],
+  "orgId": "dept-b",
+  "key": {
+    "id": "SO-A2001"
+  },
+  "data": {
+    "id": "SO-A2001",
+    "owner": "should-fail",
+    "channel": "web",
+    "priority": "low",
+    "status": "active"
+  }
+}
+JSON
+)" "${TMP_DIR}/mutation-denied.json")"
+if [[ "${mutation_denied_status_code}" != "403" ]]; then
+  cat "${TMP_DIR}/mutation-denied.json"
+  exit 1
+fi
+assert_mutation_audit_record "${mutation_denied_request_id}" "update" "denied" "tenant-a" "demo-tenant-a-user"
 
 log "audit snapshot"
 print_audit_snapshot

--- a/packages/bff/scripts/sql/001_orders_demo.sql
+++ b/packages/bff/scripts/sql/001_orders_demo.sql
@@ -5,19 +5,21 @@ CREATE TABLE IF NOT EXISTS orders (
   priority TEXT NOT NULL,
   status TEXT NOT NULL,
   tenant_id TEXT NOT NULL,
-  created_by TEXT NOT NULL
+  created_by TEXT NOT NULL,
+  org_id TEXT NULL
 );
 
 CREATE INDEX IF NOT EXISTS idx_orders_tenant_id ON orders (tenant_id);
 CREATE INDEX IF NOT EXISTS idx_orders_status ON orders (status);
 CREATE INDEX IF NOT EXISTS idx_orders_owner ON orders (owner);
 
-INSERT INTO orders (id, owner, channel, priority, status, tenant_id, created_by)
+INSERT INTO orders (id, owner, channel, priority, status, tenant_id, created_by, org_id)
 VALUES
-  ('SO-A1001', 'Alice', 'web', 'high', 'active', 'tenant-a', 'demo-tenant-a-user'),
-  ('SO-A1002', 'Aria', 'store', 'medium', 'paused', 'tenant-a', 'demo-tenant-a-user'),
-  ('SO-B1001', 'Brenda', 'partner', 'high', 'active', 'tenant-b', 'demo-tenant-b-user'),
-  ('SO-B1002', 'Bryan', 'web', 'low', 'paused', 'tenant-b', 'demo-tenant-b-user')
+  ('SO-A1001', 'Alice', 'web', 'high', 'active', 'tenant-a', 'demo-tenant-a-user', 'dept-a'),
+  ('SO-A1002', 'Aria', 'store', 'medium', 'paused', 'tenant-a', 'demo-tenant-a-user', 'dept-a'),
+  ('SO-A2001', 'A-Manager-Only', 'partner', 'high', 'active', 'tenant-a', 'manager-tenant-a', 'dept-b'),
+  ('SO-B1001', 'Brenda', 'partner', 'high', 'active', 'tenant-b', 'demo-tenant-b-user', 'dept-c'),
+  ('SO-B1002', 'Bryan', 'web', 'low', 'paused', 'tenant-b', 'demo-tenant-b-user', 'dept-c')
 ON CONFLICT (id) DO UPDATE
 SET
   owner = EXCLUDED.owner,
@@ -25,4 +27,5 @@ SET
   priority = EXCLUDED.priority,
   status = EXCLUDED.status,
   tenant_id = EXCLUDED.tenant_id,
-  created_by = EXCLUDED.created_by;
+  created_by = EXCLUDED.created_by,
+  org_id = EXCLUDED.org_id;

--- a/packages/bff/scripts/sql/bootstrap/200_business_baseline.sql
+++ b/packages/bff/scripts/sql/bootstrap/200_business_baseline.sql
@@ -4,10 +4,104 @@ CREATE TABLE IF NOT EXISTS orders (
   status TEXT NOT NULL,
   tenant_id TEXT NOT NULL,
   created_by TEXT NOT NULL,
+  org_id TEXT NULL,
   channel TEXT NOT NULL DEFAULT 'web',
   priority TEXT NOT NULL DEFAULT 'medium',
   amount INTEGER NOT NULL DEFAULT 0
 );
 
+ALTER TABLE orders
+  ADD COLUMN IF NOT EXISTS org_id TEXT NULL;
+
 CREATE INDEX IF NOT EXISTS idx_orders_tenant_created_by
   ON orders (tenant_id, created_by);
+
+CREATE INDEX IF NOT EXISTS idx_orders_tenant_org
+  ON orders (tenant_id, org_id);
+
+CREATE TABLE IF NOT EXISTS org_nodes (
+  id TEXT NOT NULL,
+  tenant_id TEXT NOT NULL,
+  parent_id TEXT NULL,
+  path TEXT NOT NULL,
+  name TEXT NOT NULL,
+  type TEXT NOT NULL DEFAULT 'department',
+  PRIMARY KEY (tenant_id, id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_org_nodes_tenant_path
+  ON org_nodes (tenant_id, path);
+
+CREATE TABLE IF NOT EXISTS user_org_memberships (
+  id BIGSERIAL PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  org_id TEXT NOT NULL,
+  position TEXT NULL,
+  is_primary BOOLEAN NOT NULL DEFAULT false,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, user_id, org_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_org_memberships_tenant_user
+  ON user_org_memberships (tenant_id, user_id);
+
+CREATE TABLE IF NOT EXISTS role_data_policies (
+  id BIGSERIAL PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  role_code TEXT NOT NULL,
+  data_scope TEXT NOT NULL,
+  custom_org_ids TEXT[] NOT NULL DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, role_code)
+);
+
+CREATE TABLE IF NOT EXISTS user_role_bindings (
+  id BIGSERIAL PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  role_code TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, user_id, role_code)
+);
+
+INSERT INTO org_nodes (id, tenant_id, parent_id, path, name, type)
+VALUES
+  ('mgr-1', 'tenant-a', NULL, 'mgr-1', '经理1', 'manager'),
+  ('dept-a', 'tenant-a', 'mgr-1', 'mgr-1/dept-a', '部门A', 'department'),
+  ('dept-b', 'tenant-a', 'mgr-1', 'mgr-1/dept-b', '部门B', 'department'),
+  ('mgr-2', 'tenant-b', NULL, 'mgr-2', '经理2', 'manager'),
+  ('dept-c', 'tenant-b', 'mgr-2', 'mgr-2/dept-c', '部门C', 'department')
+ON CONFLICT (tenant_id, id) DO UPDATE
+SET parent_id = EXCLUDED.parent_id,
+    path = EXCLUDED.path,
+    name = EXCLUDED.name,
+    type = EXCLUDED.type;
+
+INSERT INTO role_data_policies (tenant_id, role_code, data_scope, custom_org_ids)
+VALUES
+  ('tenant-a', 'MANAGER', 'DEPT_AND_CHILDREN', '{}'),
+  ('tenant-a', 'USER', 'DEPT', '{}'),
+  ('tenant-a', 'SUPER_ADMIN', 'TENANT_ALL', '{}'),
+  ('tenant-b', 'MANAGER', 'DEPT_AND_CHILDREN', '{}'),
+  ('tenant-b', 'USER', 'DEPT', '{}'),
+  ('tenant-b', 'SUPER_ADMIN', 'TENANT_ALL', '{}')
+ON CONFLICT (tenant_id, role_code) DO UPDATE
+SET data_scope = EXCLUDED.data_scope,
+    custom_org_ids = EXCLUDED.custom_org_ids;
+
+INSERT INTO user_org_memberships (tenant_id, user_id, org_id, position, is_primary)
+VALUES
+  ('tenant-a', 'demo-tenant-a-user', 'dept-a', 'staff', true),
+  ('tenant-a', 'manager-tenant-a', 'mgr-1', 'manager', true),
+  ('tenant-b', 'demo-tenant-b-user', 'dept-c', 'staff', true)
+ON CONFLICT (tenant_id, user_id, org_id) DO UPDATE
+SET position = EXCLUDED.position,
+    is_primary = EXCLUDED.is_primary;
+
+INSERT INTO user_role_bindings (tenant_id, user_id, role_code)
+VALUES
+  ('tenant-a', 'demo-tenant-a-user', 'USER'),
+  ('tenant-a', 'manager-tenant-a', 'MANAGER'),
+  ('tenant-b', 'demo-tenant-b-user', 'USER')
+ON CONFLICT (tenant_id, user_id, role_code) DO NOTHING;

--- a/packages/bff/scripts/sql/bootstrap/300_audit_baseline.sql
+++ b/packages/bff/scripts/sql/bootstrap/300_audit_baseline.sql
@@ -10,6 +10,10 @@ CREATE TABLE IF NOT EXISTS query_logs (
   result_count INTEGER NULL,
   status TEXT NOT NULL,
   error_message TEXT NULL,
+  permission_scope TEXT NULL,
+  permission_org_count INTEGER NULL,
+  permission_fallback_used BOOLEAN NULL,
+  permission_reason TEXT NULL,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
@@ -25,6 +29,10 @@ CREATE TABLE IF NOT EXISTS mutation_logs (
   duration_ms INTEGER NOT NULL DEFAULT 0,
   status TEXT NOT NULL DEFAULT 'success',
   error_message TEXT NULL,
+  permission_scope TEXT NULL,
+  permission_org_count INTEGER NULL,
+  permission_fallback_used BOOLEAN NULL,
+  permission_reason TEXT NULL,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 

--- a/packages/bff/src/app.module.ts
+++ b/packages/bff/src/app.module.ts
@@ -4,6 +4,7 @@ import { AuditLogService } from "./common/audit-log.service";
 import { HttpExceptionFilter } from "./common/http-exception.filter";
 import { QueryController } from "./gateway/query.controller";
 import { AuditPersistenceService } from "./integration/audit-persistence.service";
+import { OrgScopeService } from "./integration/org-scope.service";
 import { PostgresQueryExecutorService } from "./integration/postgres-query-executor.service";
 import { MutationOrchestratorService } from "./orchestration/mutation-orchestrator.service";
 import { QueryOrchestratorService } from "./orchestration/query-orchestrator.service";
@@ -13,6 +14,7 @@ import { QueryOrchestratorService } from "./orchestration/query-orchestrator.ser
   controllers: [QueryController],
   providers: [
     PostgresQueryExecutorService,
+    OrgScopeService,
     AuditPersistenceService,
     QueryOrchestratorService,
     MutationOrchestratorService,

--- a/packages/bff/src/common/audit-log.service.ts
+++ b/packages/bff/src/common/audit-log.service.ts
@@ -11,6 +11,10 @@ export interface QueryAuditPayload {
   durationMs: number;
   resultCount?: number;
   error?: string;
+  permissionScope?: string | null;
+  permissionOrgCount?: number | null;
+  permissionFallbackUsed?: boolean | null;
+  permissionReason?: string | null;
 }
 
 export interface MutationAuditPayload {
@@ -23,6 +27,10 @@ export interface MutationAuditPayload {
   beforeData?: Record<string, unknown> | null;
   afterData?: Record<string, unknown> | null;
   error?: string;
+  permissionScope?: string | null;
+  permissionOrgCount?: number | null;
+  permissionFallbackUsed?: boolean | null;
+  permissionReason?: string | null;
 }
 
 @Injectable()
@@ -50,7 +58,11 @@ export class AuditLogService {
         durationMs: payload.durationMs,
         resultCount: payload.resultCount ?? null,
         status: "success",
-        errorMessage: null
+        errorMessage: null,
+        permissionScope: payload.permissionScope ?? null,
+        permissionOrgCount: payload.permissionOrgCount ?? null,
+        permissionFallbackUsed: payload.permissionFallbackUsed ?? null,
+        permissionReason: payload.permissionReason ?? null
       });
     } catch (error) {
       this.logger.warn(
@@ -77,8 +89,12 @@ export class AuditLogService {
         finalSql: payload.finalSql ?? null,
         durationMs: payload.durationMs,
         resultCount: null,
-        status: "failure",
-        errorMessage: payload.error ?? null
+        status: payload.error === "data scope permission denied" ? "denied" : "failure",
+        errorMessage: payload.error ?? null,
+        permissionScope: payload.permissionScope ?? null,
+        permissionOrgCount: payload.permissionOrgCount ?? null,
+        permissionFallbackUsed: payload.permissionFallbackUsed ?? null,
+        permissionReason: payload.permissionReason ?? null
       });
     } catch (error) {
       this.logger.warn(
@@ -106,7 +122,11 @@ export class AuditLogService {
         afterData: payload.afterData ?? null,
         durationMs: payload.durationMs,
         status: "success",
-        errorMessage: null
+        errorMessage: null,
+        permissionScope: payload.permissionScope ?? null,
+        permissionOrgCount: payload.permissionOrgCount ?? null,
+        permissionFallbackUsed: payload.permissionFallbackUsed ?? null,
+        permissionReason: payload.permissionReason ?? null
       });
     } catch (error) {
       this.logger.warn(
@@ -133,8 +153,12 @@ export class AuditLogService {
         beforeData: payload.beforeData ?? null,
         afterData: payload.afterData ?? null,
         durationMs: payload.durationMs,
-        status: "failure",
-        errorMessage: payload.error ?? null
+        status: payload.error === "data scope permission denied" ? "denied" : "failure",
+        errorMessage: payload.error ?? null,
+        permissionScope: payload.permissionScope ?? null,
+        permissionOrgCount: payload.permissionOrgCount ?? null,
+        permissionFallbackUsed: payload.permissionFallbackUsed ?? null,
+        permissionReason: payload.permissionReason ?? null
       });
     } catch (error) {
       this.logger.warn(

--- a/packages/bff/src/common/permission-errors.ts
+++ b/packages/bff/src/common/permission-errors.ts
@@ -1,0 +1,8 @@
+import { ForbiddenException } from "@nestjs/common";
+import type { DataScopeDecision } from "@meta-lc/contracts";
+
+export class ForbiddenDataScopeError extends ForbiddenException {
+  constructor(public readonly details: { decision: DataScopeDecision; reason: string }) {
+    super("data scope permission denied");
+  }
+}

--- a/packages/bff/src/gateway/query.controller.ts
+++ b/packages/bff/src/gateway/query.controller.ts
@@ -1,4 +1,5 @@
 import { Body, Controller, Get, Post, Req, Res } from "@nestjs/common";
+import { ForbiddenDataScopeError } from "../common/permission-errors";
 import { AuditLogService } from "../common/audit-log.service";
 import { resolveRequestId } from "../common/request-id";
 import { MutationOrchestratorService } from "../orchestration/mutation-orchestrator.service";
@@ -51,7 +52,11 @@ export class QueryController {
         queryDsl,
         finalSql: result.finalSql,
         durationMs: Date.now() - startedAt,
-        resultCount: result.rows.length
+        resultCount: result.rows.length,
+        permissionScope: result.permissionDecision.scope,
+        permissionOrgCount: result.permissionDecision.allowedOrgIds.length,
+        permissionFallbackUsed: result.permissionDecision.legacyFallbackToCreatedBy,
+        permissionReason: result.permissionDecision.reason
       });
       return { rows: result.rows };
     } catch (error) {
@@ -62,7 +67,15 @@ export class QueryController {
         table: request.table,
         queryDsl,
         durationMs: Date.now() - startedAt,
-        error: error instanceof Error ? error.message : "unknown_error"
+        error: error instanceof Error ? error.message : "unknown_error",
+        permissionScope: error instanceof ForbiddenDataScopeError ? error.details.decision.scope : null,
+        permissionOrgCount:
+          error instanceof ForbiddenDataScopeError ? error.details.decision.allowedOrgIds.length : null,
+        permissionFallbackUsed:
+          error instanceof ForbiddenDataScopeError
+            ? error.details.decision.legacyFallbackToCreatedBy
+            : null,
+        permissionReason: error instanceof ForbiddenDataScopeError ? error.details.reason : null
       });
       throw error;
     }
@@ -94,7 +107,11 @@ export class QueryController {
         operation: request.operation,
         durationMs: Date.now() - startedAt,
         beforeData: result.beforeData,
-        afterData: result.afterData
+        afterData: result.afterData,
+        permissionScope: result.permissionDecision.scope,
+        permissionOrgCount: result.permissionDecision.allowedOrgIds.length,
+        permissionFallbackUsed: result.permissionDecision.legacyFallbackToCreatedBy,
+        permissionReason: result.permissionDecision.reason
       });
       return {
         rowCount: result.rowCount,
@@ -108,7 +125,15 @@ export class QueryController {
         table: request.table,
         operation: request.operation,
         durationMs: Date.now() - startedAt,
-        error: error instanceof Error ? error.message : "unknown_error"
+        error: error instanceof Error ? error.message : "unknown_error",
+        permissionScope: error instanceof ForbiddenDataScopeError ? error.details.decision.scope : null,
+        permissionOrgCount:
+          error instanceof ForbiddenDataScopeError ? error.details.decision.allowedOrgIds.length : null,
+        permissionFallbackUsed:
+          error instanceof ForbiddenDataScopeError
+            ? error.details.decision.legacyFallbackToCreatedBy
+            : null,
+        permissionReason: error instanceof ForbiddenDataScopeError ? error.details.reason : null
       });
       throw error;
     }

--- a/packages/bff/src/integration/audit-persistence.service.ts
+++ b/packages/bff/src/integration/audit-persistence.service.ts
@@ -11,8 +11,12 @@ export interface QueryAuditRecord {
   finalSql: string | null;
   durationMs: number;
   resultCount: number | null;
-  status: "success" | "failure";
+  status: "success" | "failure" | "denied";
   errorMessage: string | null;
+  permissionScope: string | null;
+  permissionOrgCount: number | null;
+  permissionFallbackUsed: boolean | null;
+  permissionReason: string | null;
 }
 
 export interface MutationAuditRecord {
@@ -24,8 +28,12 @@ export interface MutationAuditRecord {
   beforeData: Record<string, unknown> | null;
   afterData: Record<string, unknown> | null;
   durationMs: number;
-  status: "success" | "failure";
+  status: "success" | "failure" | "denied";
   errorMessage: string | null;
+  permissionScope: string | null;
+  permissionOrgCount: number | null;
+  permissionFallbackUsed: boolean | null;
+  permissionReason: string | null;
 }
 
 @Injectable()
@@ -60,6 +68,10 @@ export class AuditPersistenceService implements OnModuleInit, OnModuleDestroy {
         result_count INTEGER NULL,
         status TEXT NOT NULL,
         error_message TEXT NULL,
+        permission_scope TEXT NULL,
+        permission_org_count INTEGER NULL,
+        permission_fallback_used BOOLEAN NULL,
+        permission_reason TEXT NULL,
         created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
       )
     `);
@@ -76,8 +88,28 @@ export class AuditPersistenceService implements OnModuleInit, OnModuleDestroy {
         duration_ms INTEGER NOT NULL DEFAULT 0,
         status TEXT NOT NULL DEFAULT 'success',
         error_message TEXT NULL,
+        permission_scope TEXT NULL,
+        permission_org_count INTEGER NULL,
+        permission_fallback_used BOOLEAN NULL,
+        permission_reason TEXT NULL,
         created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
       )
+    `);
+    await this.pool.query(`
+      ALTER TABLE query_logs
+      ADD COLUMN IF NOT EXISTS permission_scope TEXT NULL
+    `);
+    await this.pool.query(`
+      ALTER TABLE query_logs
+      ADD COLUMN IF NOT EXISTS permission_org_count INTEGER NULL
+    `);
+    await this.pool.query(`
+      ALTER TABLE query_logs
+      ADD COLUMN IF NOT EXISTS permission_fallback_used BOOLEAN NULL
+    `);
+    await this.pool.query(`
+      ALTER TABLE query_logs
+      ADD COLUMN IF NOT EXISTS permission_reason TEXT NULL
     `);
     await this.pool.query(`
       ALTER TABLE mutation_logs
@@ -90,6 +122,22 @@ export class AuditPersistenceService implements OnModuleInit, OnModuleDestroy {
     await this.pool.query(`
       ALTER TABLE mutation_logs
       ADD COLUMN IF NOT EXISTS error_message TEXT NULL
+    `);
+    await this.pool.query(`
+      ALTER TABLE mutation_logs
+      ADD COLUMN IF NOT EXISTS permission_scope TEXT NULL
+    `);
+    await this.pool.query(`
+      ALTER TABLE mutation_logs
+      ADD COLUMN IF NOT EXISTS permission_org_count INTEGER NULL
+    `);
+    await this.pool.query(`
+      ALTER TABLE mutation_logs
+      ADD COLUMN IF NOT EXISTS permission_fallback_used BOOLEAN NULL
+    `);
+    await this.pool.query(`
+      ALTER TABLE mutation_logs
+      ADD COLUMN IF NOT EXISTS permission_reason TEXT NULL
     `);
     await this.pool.query(`
       CREATE TABLE IF NOT EXISTS migration_logs (
@@ -161,8 +209,12 @@ export class AuditPersistenceService implements OnModuleInit, OnModuleDestroy {
           duration_ms,
           result_count,
           status,
-          error_message
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+          error_message,
+          permission_scope,
+          permission_org_count,
+          permission_fallback_used,
+          permission_reason
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
         [
           record.requestId,
           record.tenantId,
@@ -173,7 +225,11 @@ export class AuditPersistenceService implements OnModuleInit, OnModuleDestroy {
           record.durationMs,
           record.resultCount,
           record.status,
-          record.errorMessage
+          record.errorMessage,
+          record.permissionScope,
+          record.permissionOrgCount,
+          record.permissionFallbackUsed,
+          record.permissionReason
         ]
       );
       await this.pool.query(
@@ -218,8 +274,12 @@ export class AuditPersistenceService implements OnModuleInit, OnModuleDestroy {
           after_data,
           duration_ms,
           status,
-          error_message
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+          error_message,
+          permission_scope,
+          permission_org_count,
+          permission_fallback_used,
+          permission_reason
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
         [
           record.requestId,
           record.tenantId,
@@ -230,7 +290,11 @@ export class AuditPersistenceService implements OnModuleInit, OnModuleDestroy {
           record.afterData,
           record.durationMs,
           record.status,
-          record.errorMessage
+          record.errorMessage,
+          record.permissionScope,
+          record.permissionOrgCount,
+          record.permissionFallbackUsed,
+          record.permissionReason
         ]
       );
     } catch (error) {

--- a/packages/bff/src/integration/org-scope.service.ts
+++ b/packages/bff/src/integration/org-scope.service.ts
@@ -1,0 +1,148 @@
+import { Injectable, Logger, OnModuleDestroy } from "@nestjs/common";
+import type { OrgNode, OrgScopeContext, RoleDataPolicy } from "@meta-lc/contracts";
+import { Pool } from "pg";
+import { loadDbConfig } from "../config";
+
+interface RolePolicyRow {
+  role_code: string;
+  data_scope: string;
+  custom_org_ids: string[] | null;
+}
+
+interface OrgNodeRow {
+  id: string;
+  tenant_id: string;
+  parent_id: string | null;
+  path: string;
+  name: string;
+  type: string;
+}
+
+@Injectable()
+export class OrgScopeService implements OnModuleDestroy {
+  private readonly logger = new Logger("OrgScopeService");
+  private readonly pool: Pool;
+
+  constructor() {
+    const config = loadDbConfig();
+    this.pool = new Pool({
+      host: config.host,
+      port: config.port,
+      user: config.user,
+      password: config.password,
+      database: config.database,
+      ssl: config.ssl ? { rejectUnauthorized: false } : false
+    });
+  }
+
+  async resolveContext(input: {
+    tenantId: string;
+    userId: string;
+    roles: string[];
+  }): Promise<OrgScopeContext> {
+    try {
+      const [orgIds, rolePolicies, roleBindings, orgNodes] = await Promise.all([
+        this.loadUserOrgIds(input.tenantId, input.userId),
+        this.loadRolePolicies(input.tenantId),
+        this.loadUserRoleBindings(input.tenantId, input.userId),
+        this.loadOrgNodes(input.tenantId)
+      ]);
+
+      const mergedRoles = Array.from(new Set([...input.roles, ...roleBindings]));
+
+      return {
+        tenantId: input.tenantId,
+        userId: input.userId,
+        roles: mergedRoles,
+        userOrgIds: orgIds,
+        rolePolicies: rolePolicies.filter((policy) => mergedRoles.includes(policy.role)),
+        orgNodes
+      };
+    } catch (error) {
+      const code = String((error as { code?: string })?.code ?? "");
+      if (code === "42P01") {
+        this.logger.warn("org scope tables not ready, falling back to request roles only");
+        return {
+          tenantId: input.tenantId,
+          userId: input.userId,
+          roles: input.roles,
+          userOrgIds: [],
+          rolePolicies: [],
+          orgNodes: []
+        };
+      }
+      throw error;
+    }
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.pool.end();
+  }
+
+  private async loadUserOrgIds(tenantId: string, userId: string): Promise<string[]> {
+    const result = await this.pool.query<{ org_id: string }>(
+      `SELECT org_id
+       FROM user_org_memberships
+       WHERE tenant_id = $1 AND user_id = $2`,
+      [tenantId, userId]
+    );
+    return result.rows.map((row) => row.org_id);
+  }
+
+  private async loadRolePolicies(tenantId: string): Promise<RoleDataPolicy[]> {
+    const result = await this.pool.query<RolePolicyRow>(
+      `SELECT role_code, data_scope, custom_org_ids
+       FROM role_data_policies
+       WHERE tenant_id = $1`,
+      [tenantId]
+    );
+
+    return result.rows.map((row) => ({
+      role: row.role_code,
+      scope: normalizeScope(row.data_scope),
+      customOrgIds: row.custom_org_ids ?? []
+    }));
+  }
+
+  private async loadUserRoleBindings(tenantId: string, userId: string): Promise<string[]> {
+    const result = await this.pool.query<{ role_code: string }>(
+      `SELECT role_code
+       FROM user_role_bindings
+       WHERE tenant_id = $1 AND user_id = $2`,
+      [tenantId, userId]
+    );
+    return result.rows.map((row) => row.role_code);
+  }
+
+  private async loadOrgNodes(tenantId: string): Promise<OrgNode[]> {
+    const result = await this.pool.query<OrgNodeRow>(
+      `SELECT id, tenant_id, parent_id, path, name, type
+       FROM org_nodes
+       WHERE tenant_id = $1`,
+      [tenantId]
+    );
+
+    return result.rows.map((row) => ({
+      id: row.id,
+      tenantId: row.tenant_id,
+      parentId: row.parent_id,
+      path: row.path,
+      name: row.name,
+      type: row.type
+    }));
+  }
+}
+
+function normalizeScope(value: string): RoleDataPolicy["scope"] {
+  const normalized = value.toUpperCase();
+  if (
+    normalized === "SELF" ||
+    normalized === "DEPT" ||
+    normalized === "DEPT_AND_CHILDREN" ||
+    normalized === "CUSTOM_ORG_SET" ||
+    normalized === "TENANT_ALL"
+  ) {
+    return normalized;
+  }
+  return "SELF";
+}

--- a/packages/bff/src/integration/postgres-query-executor.service.ts
+++ b/packages/bff/src/integration/postgres-query-executor.service.ts
@@ -5,6 +5,7 @@ import type { MutationOperation } from "../types";
 
 interface OrderMutationPayload {
   id: string;
+  orgId: string | null;
   owner?: string;
   channel?: string;
   priority?: string;
@@ -16,6 +17,7 @@ export interface OrderMutationCommand {
   tenantId: string;
   userId: string;
   superAdmin: boolean;
+  orgId: string | null;
   payload: OrderMutationPayload;
 }
 
@@ -41,7 +43,7 @@ export class PostgresQueryExecutorService implements OnModuleDestroy {
     });
   }
 
-  async query(sql: string, params: Array<string | number | boolean>): Promise<Record<string, unknown>[]> {
+  async query(sql: string, params: Array<string | number | boolean | string[]>): Promise<Record<string, unknown>[]> {
     const result = await this.pool.query(sql, params);
     return result.rows;
   }
@@ -58,9 +60,9 @@ export class PostgresQueryExecutorService implements OnModuleDestroy {
 
       if (command.operation === "create") {
         const created = await client.query<Record<string, unknown>>(
-          `INSERT INTO orders (id, owner, channel, priority, status, tenant_id, created_by)
-           VALUES ($1, $2, $3, $4, $5, $6, $7)
-           RETURNING id, owner, channel, priority, status, tenant_id, created_by`,
+          `INSERT INTO orders (id, owner, channel, priority, status, tenant_id, created_by, org_id)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+           RETURNING id, owner, channel, priority, status, tenant_id, created_by, org_id`,
           [
             command.payload.id,
             command.payload.owner ?? "",
@@ -68,7 +70,8 @@ export class PostgresQueryExecutorService implements OnModuleDestroy {
             command.payload.priority ?? "medium",
             command.payload.status ?? "active",
             command.tenantId,
-            command.userId
+            command.userId,
+            command.orgId
           ]
         );
         await client.query("COMMIT");
@@ -95,16 +98,18 @@ export class PostgresQueryExecutorService implements OnModuleDestroy {
            SET owner = $1,
                channel = $2,
                priority = $3,
-               status = $4
-           WHERE ${buildUpdateWhereClause(command.superAdmin)}
-           RETURNING id, owner, channel, priority, status, tenant_id, created_by`,
+               status = $4,
+               org_id = $5
+           WHERE id = $6 AND tenant_id = $7
+           RETURNING id, owner, channel, priority, status, tenant_id, created_by, org_id`,
           [
             command.payload.owner ?? "",
             command.payload.channel ?? "web",
             command.payload.priority ?? "medium",
             command.payload.status ?? "active",
+            command.orgId,
             command.payload.id,
-            ...buildScopeParams(command)
+            command.tenantId
           ]
         );
         await client.query("COMMIT");
@@ -117,8 +122,8 @@ export class PostgresQueryExecutorService implements OnModuleDestroy {
 
       const deleted = await client.query(
         `DELETE FROM orders
-         WHERE id = $1${buildScopedWhereClause(command.superAdmin)}`,
-        [command.payload.id, ...buildScopeParams(command)]
+         WHERE id = $1 AND tenant_id = $2`,
+        [command.payload.id, command.tenantId]
       );
       await client.query("COMMIT");
       return {
@@ -143,23 +148,21 @@ export class PostgresQueryExecutorService implements OnModuleDestroy {
     command: OrderMutationCommand
   ): Promise<Record<string, unknown> | null> {
     const result = await client.query<Record<string, unknown>>(
-      `SELECT id, owner, channel, priority, status, tenant_id, created_by
+      `SELECT id, owner, channel, priority, status, tenant_id, created_by, org_id
        FROM orders
-       WHERE id = $1${buildScopedWhereClause(command.superAdmin)}`,
-      [command.payload.id, ...buildScopeParams(command)]
+       WHERE id = $1 AND tenant_id = $2`,
+      [command.payload.id, command.tenantId]
     );
     return result.rows[0] ?? null;
   }
-}
 
-function buildScopedWhereClause(superAdmin: boolean): string {
-  return superAdmin ? "" : " AND tenant_id = $2 AND created_by = $3";
-}
-
-function buildUpdateWhereClause(superAdmin: boolean): string {
-  return superAdmin ? "id = $5" : "id = $5 AND tenant_id = $6 AND created_by = $7";
-}
-
-function buildScopeParams(command: OrderMutationCommand): string[] {
-  return command.superAdmin ? [] : [command.tenantId, command.userId];
+  async findOrderById(input: { id: string; tenantId: string }): Promise<Record<string, unknown> | null> {
+    const result = await this.pool.query<Record<string, unknown>>(
+      `SELECT id, owner, channel, priority, status, tenant_id, created_by, org_id
+       FROM orders
+       WHERE id = $1 AND tenant_id = $2`,
+      [input.id, input.tenantId]
+    );
+    return result.rows[0] ?? null;
+  }
 }

--- a/packages/bff/src/orchestration/mutation-orchestrator.service.ts
+++ b/packages/bff/src/orchestration/mutation-orchestrator.service.ts
@@ -1,9 +1,14 @@
 import { BadRequestException, ConflictException, Injectable, NotFoundException } from "@nestjs/common";
+import { canAccessOrg, resolveDataScope } from "@meta-lc/permission";
+import type { DataScopeDecision } from "@meta-lc/contracts";
+import { ForbiddenDataScopeError } from "../common/permission-errors";
+import { OrgScopeService } from "../integration/org-scope.service";
 import { PostgresQueryExecutorService } from "../integration/postgres-query-executor.service";
 import type { MutationApiRequest, MutationOperation } from "../types";
 
 interface OrderMutationPayload {
   id: string;
+  orgId: string | null;
   owner?: string;
   channel?: string;
   priority?: string;
@@ -16,11 +21,15 @@ export interface MutationExecutionResult {
   table: string;
   beforeData: Record<string, unknown> | null;
   afterData: Record<string, unknown> | null;
+  permissionDecision: DataScopeDecision;
 }
 
 @Injectable()
 export class MutationOrchestratorService {
-  constructor(private readonly queryExecutor: PostgresQueryExecutorService) {}
+  constructor(
+    private readonly queryExecutor: PostgresQueryExecutorService,
+    private readonly orgScopeService: OrgScopeService
+  ) {}
 
   async execute(request: MutationApiRequest): Promise<MutationExecutionResult> {
     if (!request.tenantId || !request.userId) {
@@ -31,13 +40,76 @@ export class MutationOrchestratorService {
     }
 
     const payload = normalizeMutationPayload(request);
+    const orgScopeContext = await this.orgScopeService.resolveContext({
+      tenantId: request.tenantId,
+      userId: request.userId,
+      roles: request.roles
+    });
+    const permissionDecision = resolveDataScope(orgScopeContext);
+
+    if (request.operation === "create") {
+      if (!payload.orgId) {
+        throw new BadRequestException("orgId is required for create.");
+      }
+      const createAccess = canAccessOrg(
+        permissionDecision,
+        {
+          orgId: payload.orgId,
+          createdBy: request.userId
+        },
+        {
+          tenantId: request.tenantId,
+          userId: request.userId,
+          roles: request.roles
+        }
+      );
+      if (!createAccess.allowed) {
+        throw new ForbiddenDataScopeError({
+          decision: permissionDecision,
+          reason: createAccess.reason
+        });
+      }
+    }
 
     try {
+      if (request.operation !== "create") {
+        const existing = await this.queryExecutor.findOrderById({
+          id: payload.id,
+          tenantId: request.tenantId
+        });
+        if (!existing) {
+          throw new NotFoundException(`order ${payload.id} not found`);
+        }
+        const access = canAccessOrg(
+          permissionDecision,
+          {
+            orgId: (existing.org_id as string | null) ?? null,
+            createdBy: (existing.created_by as string | null) ?? null
+          },
+          {
+            tenantId: request.tenantId,
+            userId: request.userId,
+            roles: request.roles
+          }
+        );
+        if (!access.allowed) {
+          throw new ForbiddenDataScopeError({
+            decision: permissionDecision,
+            reason: access.reason
+          });
+        }
+
+        if (request.operation === "update" && !payload.orgId) {
+          payload.orgId = (existing.org_id as string | null) ?? null;
+        }
+      }
+
       const result = await this.queryExecutor.mutateOrder({
         operation: request.operation,
         tenantId: request.tenantId,
         userId: request.userId,
         superAdmin: request.roles.includes("SUPER_ADMIN"),
+        orgId: payload.orgId,
         payload
       });
 
@@ -50,7 +122,8 @@ export class MutationOrchestratorService {
         operation: request.operation,
         table: request.table,
         beforeData: result.beforeData,
-        afterData: result.afterData
+        afterData: result.afterData,
+        permissionDecision
       };
     } catch (error) {
       if (isPgDuplicateKey(error)) {
@@ -69,7 +142,12 @@ function normalizeMutationPayload(request: MutationApiRequest): OrderMutationPay
   }
 
   if (request.operation === "delete") {
-    return { id };
+    return { id, orgId: request.orgId ?? null };
+  }
+
+  const orgId = resolveOrgId(request);
+  if (request.operation === "create" && !orgId) {
+    throw new BadRequestException("orgId is required.");
   }
 
   const owner = String(source["owner"] ?? "").trim();
@@ -79,6 +157,7 @@ function normalizeMutationPayload(request: MutationApiRequest): OrderMutationPay
 
   return {
     id,
+    orgId,
     owner,
     channel: String(source["channel"] ?? "web"),
     priority: String(source["priority"] ?? "medium"),
@@ -96,6 +175,17 @@ function resolveId(request: MutationApiRequest): string {
     return String(dataId);
   }
   return "";
+}
+
+function resolveOrgId(request: MutationApiRequest): string | null {
+  if (typeof request.orgId === "string" && request.orgId.trim()) {
+    return request.orgId.trim();
+  }
+  const fromData = request.data?.["org_id"];
+  if (typeof fromData === "string" && fromData.trim()) {
+    return fromData.trim();
+  }
+  return null;
 }
 
 function isPgDuplicateKey(error: unknown): boolean {

--- a/packages/bff/src/orchestration/query-orchestrator.service.ts
+++ b/packages/bff/src/orchestration/query-orchestrator.service.ts
@@ -1,25 +1,40 @@
 import { Injectable } from "@nestjs/common";
-import { buildRowLevelFilter, injectPermissionClause } from "@meta-lc/permission";
+import { buildDataScopeFilter, injectPermissionClause, resolveDataScope } from "@meta-lc/permission";
 import { compileSelectQuery } from "@meta-lc/query";
 import { formatSqlWithParams, shiftSqlParams } from "@meta-lc/shared";
+import type { DataScopeDecision, QueryApiRequest } from "@meta-lc/contracts";
+import { ForbiddenDataScopeError } from "../common/permission-errors";
+import { OrgScopeService } from "../integration/org-scope.service";
 import { PostgresQueryExecutorService } from "../integration/postgres-query-executor.service";
-import type { QueryApiRequest } from "../types";
 
 export interface QueryExecutionResult {
   rows: Record<string, unknown>[];
   finalSql: string;
+  permissionDecision: DataScopeDecision;
 }
 
 @Injectable()
 export class QueryOrchestratorService {
-  constructor(private readonly queryExecutor: PostgresQueryExecutorService) {}
+  constructor(
+    private readonly queryExecutor: PostgresQueryExecutorService,
+    private readonly orgScopeService: OrgScopeService
+  ) {}
 
   async execute(request: QueryApiRequest): Promise<QueryExecutionResult> {
-    const { sql, params } = compileQueryWithPermission(request);
+    const orgScopeContext = await this.orgScopeService.resolveContext({
+      tenantId: request.tenantId,
+      userId: request.userId,
+      roles: request.roles
+    });
+    const permissionDecision = resolveDataScope(orgScopeContext);
+    ensureOrgFilterInScope(request, permissionDecision);
+
+    const { sql, params } = compileQueryWithPermission(request, permissionDecision);
     const rows = await this.queryExecutor.query(sql, params);
     return {
       rows,
-      finalSql: formatSqlWithParams(sql, params)
+      finalSql: formatSqlWithParams(sql, params),
+      permissionDecision
     };
   }
 
@@ -28,9 +43,12 @@ export class QueryOrchestratorService {
   }
 }
 
-export function compileQueryWithPermission(request: QueryApiRequest): {
+export function compileQueryWithPermission(
+  request: QueryApiRequest,
+  decision: DataScopeDecision
+): {
   sql: string;
-  params: Array<string | number | boolean>;
+  params: Array<string | number | boolean | string[]>;
 } {
   if (!request.tenantId || !request.userId) {
     throw new Error("tenantId and userId are required.");
@@ -42,14 +60,14 @@ export function compileQueryWithPermission(request: QueryApiRequest): {
     filters: request.filters,
     limit: request.limit
   });
-  const permission = buildRowLevelFilter({
+  const permission = buildDataScopeFilter(decision, {
     tenantId: request.tenantId,
     userId: request.userId,
     roles: request.roles
   });
 
   let sql = compiled.sql;
-  const params = [...compiled.params];
+  const params: Array<string | number | boolean | string[]> = [...compiled.params];
   if (permission.clause !== "1=1") {
     const shiftedClause = shiftSqlParams(permission.clause, params.length);
     sql = injectPermissionClause(sql, { clause: shiftedClause, params: [] });
@@ -60,4 +78,20 @@ export function compileQueryWithPermission(request: QueryApiRequest): {
     sql,
     params
   };
+}
+
+function ensureOrgFilterInScope(request: QueryApiRequest, decision: DataScopeDecision): void {
+  const requestedOrgIdRaw = request.filters?.["org_id"];
+  if (!requestedOrgIdRaw || typeof requestedOrgIdRaw !== "string") {
+    return;
+  }
+  if (decision.tenantAll) {
+    return;
+  }
+  if (!decision.allowedOrgIds.includes(requestedOrgIdRaw)) {
+    throw new ForbiddenDataScopeError({
+      decision,
+      reason: `org_id ${requestedOrgIdRaw} is out of scope`
+    });
+  }
 }

--- a/packages/bff/src/query-pipeline.service.ts
+++ b/packages/bff/src/query-pipeline.service.ts
@@ -1,2 +1,24 @@
-export { QueryOrchestratorService as QueryPipelineService } from "./orchestration/query-orchestrator.service";
-export { compileQueryWithPermission } from "./orchestration/query-orchestrator.service";
+import { resolveDataScope } from "@meta-lc/permission";
+import type { QueryApiRequest } from "@meta-lc/contracts";
+import {
+  compileQueryWithPermission as compileQueryWithScopedPermission,
+  QueryOrchestratorService as QueryPipelineService
+} from "./orchestration/query-orchestrator.service";
+
+export { QueryPipelineService };
+
+export function compileQueryWithPermission(request: QueryApiRequest): {
+  sql: string;
+  params: Array<string | number | boolean | string[]>;
+} {
+  const decision = resolveDataScope({
+    tenantId: request.tenantId,
+    userId: request.userId,
+    roles: request.roles,
+    userOrgIds: [],
+    rolePolicies: [],
+    orgNodes: []
+  });
+
+  return compileQueryWithScopedPermission(request, decision);
+}

--- a/packages/bff/src/types.ts
+++ b/packages/bff/src/types.ts
@@ -2,7 +2,10 @@ export type {
   BootstrapMode,
   DbConfig,
   DbTargets,
+  DataScopeDecision,
+  DataScopeType,
   MutationApiRequest,
   MutationOperation,
+  OrgScopeContext,
   QueryApiRequest
 } from "@meta-lc/contracts";

--- a/packages/bff/test/mutation-orchestrator.test.ts
+++ b/packages/bff/test/mutation-orchestrator.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { MutationOrchestratorService } from "../src/orchestration/mutation-orchestrator.service";
 
 test("mutation orchestrator rejects unsupported tables", async () => {
-  const service = new MutationOrchestratorService({} as never);
+  const service = new MutationOrchestratorService({} as never, {} as never);
 
   await assert.rejects(
     async () =>
@@ -23,7 +23,7 @@ test("mutation orchestrator rejects unsupported tables", async () => {
 });
 
 test("mutation orchestrator requires owner for create and update", async () => {
-  const service = new MutationOrchestratorService({} as never);
+  const service = new MutationOrchestratorService({} as never, {} as never);
 
   await assert.rejects(
     async () =>
@@ -35,8 +35,50 @@ test("mutation orchestrator requires owner for create and update", async () => {
         roles: ["USER"],
         data: {
           id: "SO-1"
-        }
+        },
+        orgId: "dept-a"
       }),
     /owner is required/i
+  );
+});
+
+test("mutation orchestrator denies out-of-scope update with 403", async () => {
+  const service = new MutationOrchestratorService(
+    {
+      findOrderById: async () => ({
+        id: "SO-2001",
+        tenant_id: "tenant-a",
+        created_by: "manager-1",
+        org_id: "dept-b"
+      })
+    } as never,
+    {
+      resolveContext: async () => ({
+        tenantId: "tenant-a",
+        userId: "user-a",
+        roles: ["USER"],
+        userOrgIds: ["dept-a"],
+        rolePolicies: [{ role: "USER", scope: "DEPT" }],
+        orgNodes: []
+      })
+    } as never
+  );
+
+  await assert.rejects(
+    async () =>
+      service.execute({
+        table: "orders",
+        operation: "update",
+        tenantId: "tenant-a",
+        userId: "user-a",
+        roles: ["USER"],
+        orgId: "dept-b",
+        key: { id: "SO-2001" },
+        data: {
+          id: "SO-2001",
+          owner: "No Access"
+        }
+      }),
+    /data scope permission denied/i
   );
 });

--- a/packages/bff/test/query-pipeline.test.ts
+++ b/packages/bff/test/query-pipeline.test.ts
@@ -30,6 +30,6 @@ test("compileQueryWithPermission skips tenant/user filters for SUPER_ADMIN", () 
     roles: ["SUPER_ADMIN"]
   });
 
-  assert.equal(compiled.sql, 'SELECT "id" FROM "orders" WHERE "status" = $1 LIMIT 100');
-  assert.deepEqual(compiled.params, ["PAID"]);
+  assert.equal(compiled.sql, 'SELECT "id" FROM "orders" WHERE "status" = $1 AND tenant_id = $2 LIMIT 100');
+  assert.deepEqual(compiled.params, ["PAID", "t1"]);
 });

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -16,8 +16,48 @@ export interface MutationApiRequest {
   tenantId: string;
   userId: string;
   roles: string[];
+  orgId?: string;
   key?: Record<string, string | number | boolean>;
   data?: Record<string, string | number | boolean | null>;
+}
+
+export type DataScopeType =
+  | "SELF"
+  | "DEPT"
+  | "DEPT_AND_CHILDREN"
+  | "CUSTOM_ORG_SET"
+  | "TENANT_ALL";
+
+export interface RoleDataPolicy {
+  role: string;
+  scope: DataScopeType;
+  customOrgIds?: string[];
+}
+
+export interface OrgNode {
+  id: string;
+  tenantId: string;
+  parentId: string | null;
+  path: string;
+  name: string;
+  type: string;
+}
+
+export interface OrgScopeContext {
+  tenantId: string;
+  userId: string;
+  roles: string[];
+  userOrgIds: string[];
+  rolePolicies: RoleDataPolicy[];
+  orgNodes: OrgNode[];
+}
+
+export interface DataScopeDecision {
+  scope: DataScopeType;
+  allowedOrgIds: string[];
+  tenantAll: boolean;
+  legacyFallbackToCreatedBy: boolean;
+  reason: string;
 }
 
 export interface DbConfig {

--- a/packages/permission/src/permission-engine.ts
+++ b/packages/permission/src/permission-engine.ts
@@ -1,18 +1,207 @@
-import type { PermissionContext, PermissionFilter } from "./types";
+import type {
+  DataScopeDecision,
+  DataScopeType,
+  OrgScopeContext,
+  PermissionContext,
+  PermissionFilter,
+  RoleDataPolicy
+} from "./types";
 
-export function buildRowLevelFilter(context: PermissionContext): PermissionFilter {
-  const hasAdminRole = context.roles.includes("SUPER_ADMIN");
-  if (hasAdminRole) {
+const SCOPE_PRIORITY: Record<DataScopeType, number> = {
+  SELF: 10,
+  DEPT: 20,
+  DEPT_AND_CHILDREN: 30,
+  CUSTOM_ORG_SET: 40,
+  TENANT_ALL: 50
+};
+
+function defaultPolicyForRole(role: string): RoleDataPolicy | null {
+  if (role === "SUPER_ADMIN") {
+    return { role, scope: "TENANT_ALL" };
+  }
+  if (role === "MANAGER") {
+    return { role, scope: "DEPT_AND_CHILDREN" };
+  }
+  return null;
+}
+
+function pickStrongestPolicy(policies: RoleDataPolicy[]): RoleDataPolicy {
+  if (!policies.length) {
+    return { role: "__default__", scope: "SELF" };
+  }
+
+  return [...policies].sort((a, b) => SCOPE_PRIORITY[b.scope] - SCOPE_PRIORITY[a.scope])[0];
+}
+
+function expandDeptAndChildrenOrgIds(context: OrgScopeContext): string[] {
+  if (!context.userOrgIds.length) {
+    return [];
+  }
+
+  const baseNodes = context.orgNodes.filter((node) => context.userOrgIds.includes(node.id));
+  if (!baseNodes.length) {
+    return [...context.userOrgIds];
+  }
+
+  const visible = new Set<string>(context.userOrgIds);
+  for (const baseNode of baseNodes) {
+    const prefix = `${baseNode.path}${baseNode.path.endsWith("/") ? "" : "/"}`;
+    for (const node of context.orgNodes) {
+      if (node.path === baseNode.path || node.path.startsWith(prefix)) {
+        visible.add(node.id);
+      }
+    }
+  }
+
+  return [...visible];
+}
+
+export function resolveDataScope(context: OrgScopeContext): DataScopeDecision {
+  const userRoles = new Set(context.roles);
+  const effectivePolicies: RoleDataPolicy[] = [];
+
+  for (const role of userRoles) {
+    const configured = context.rolePolicies.find((policy) => policy.role === role);
+    if (configured) {
+      effectivePolicies.push(configured);
+      continue;
+    }
+    const fallback = defaultPolicyForRole(role);
+    if (fallback) {
+      effectivePolicies.push(fallback);
+    }
+  }
+
+  const strongest = pickStrongestPolicy(effectivePolicies);
+
+  if (strongest.scope === "TENANT_ALL") {
     return {
-      clause: "1=1",
-      params: []
+      scope: strongest.scope,
+      allowedOrgIds: [],
+      tenantAll: true,
+      legacyFallbackToCreatedBy: false,
+      reason: `scope:${strongest.scope}`
+    };
+  }
+
+  if (strongest.scope === "CUSTOM_ORG_SET") {
+    return {
+      scope: strongest.scope,
+      allowedOrgIds: [...(strongest.customOrgIds ?? [])],
+      tenantAll: false,
+      legacyFallbackToCreatedBy: true,
+      reason: `scope:${strongest.scope}`
+    };
+  }
+
+  if (strongest.scope === "DEPT") {
+    return {
+      scope: strongest.scope,
+      allowedOrgIds: [...context.userOrgIds],
+      tenantAll: false,
+      legacyFallbackToCreatedBy: true,
+      reason: `scope:${strongest.scope}`
+    };
+  }
+
+  if (strongest.scope === "DEPT_AND_CHILDREN") {
+    return {
+      scope: strongest.scope,
+      allowedOrgIds: expandDeptAndChildrenOrgIds(context),
+      tenantAll: false,
+      legacyFallbackToCreatedBy: true,
+      reason: `scope:${strongest.scope}`
     };
   }
 
   return {
-    clause: "tenant_id = $1 AND created_by = $2",
-    params: [context.tenantId, context.userId]
+    scope: "SELF",
+    allowedOrgIds: [],
+    tenantAll: false,
+    legacyFallbackToCreatedBy: true,
+    reason: "scope:SELF"
   };
+}
+
+export function buildDataScopeFilter(decision: DataScopeDecision, context: PermissionContext): PermissionFilter {
+  if (decision.tenantAll) {
+    return {
+      clause: "tenant_id = $1",
+      params: [context.tenantId]
+    };
+  }
+
+  if (decision.scope === "SELF") {
+    return {
+      clause: "tenant_id = $1 AND created_by = $2",
+      params: [context.tenantId, context.userId]
+    };
+  }
+
+  if (!decision.allowedOrgIds.length) {
+    return {
+      clause: "1=0",
+      params: []
+    };
+  }
+
+  if (!decision.legacyFallbackToCreatedBy) {
+    return {
+      clause: "tenant_id = $1 AND org_id = ANY($2::text[])",
+      params: [context.tenantId, decision.allowedOrgIds]
+    };
+  }
+
+  return {
+    clause: "tenant_id = $1 AND (org_id = ANY($2::text[]) OR (org_id IS NULL AND created_by = $3))",
+    params: [context.tenantId, decision.allowedOrgIds, context.userId]
+  };
+}
+
+export function canAccessOrg(
+  decision: DataScopeDecision,
+  payload: { orgId: string | null; createdBy: string | null },
+  context: PermissionContext
+): { allowed: boolean; fallbackUsed: boolean; reason: string } {
+  if (decision.tenantAll) {
+    return { allowed: true, fallbackUsed: false, reason: "tenant-all" };
+  }
+
+  if (decision.scope === "SELF") {
+    const allowed = payload.createdBy === context.userId;
+    return {
+      allowed,
+      fallbackUsed: true,
+      reason: allowed ? "self-owner" : "self-owner-required"
+    };
+  }
+
+  if (payload.orgId && decision.allowedOrgIds.includes(payload.orgId)) {
+    return { allowed: true, fallbackUsed: false, reason: "org-allowed" };
+  }
+
+  if (!payload.orgId && decision.legacyFallbackToCreatedBy && payload.createdBy === context.userId) {
+    return { allowed: true, fallbackUsed: true, reason: "legacy-created-by-fallback" };
+  }
+
+  return {
+    allowed: false,
+    fallbackUsed: false,
+    reason: payload.orgId ? "org-out-of-scope" : "legacy-fallback-denied"
+  };
+}
+
+export function buildRowLevelFilter(context: PermissionContext): PermissionFilter {
+  return buildDataScopeFilter(
+    {
+      scope: context.roles.includes("SUPER_ADMIN") ? "TENANT_ALL" : "SELF",
+      allowedOrgIds: [],
+      tenantAll: context.roles.includes("SUPER_ADMIN"),
+      legacyFallbackToCreatedBy: true,
+      reason: context.roles.includes("SUPER_ADMIN") ? "scope:TENANT_ALL" : "scope:SELF"
+    },
+    context
+  );
 }
 
 export function injectPermissionClause(baseSql: string, filter: PermissionFilter): string {

--- a/packages/permission/src/types.ts
+++ b/packages/permission/src/types.ts
@@ -6,5 +6,44 @@ export interface PermissionContext {
 
 export interface PermissionFilter {
   clause: string;
-  params: Array<string | number | boolean>;
+  params: Array<string | number | boolean | string[]>;
+}
+
+export type DataScopeType =
+  | "SELF"
+  | "DEPT"
+  | "DEPT_AND_CHILDREN"
+  | "CUSTOM_ORG_SET"
+  | "TENANT_ALL";
+
+export interface RoleDataPolicy {
+  role: string;
+  scope: DataScopeType;
+  customOrgIds?: string[];
+}
+
+export interface OrgNode {
+  id: string;
+  tenantId: string;
+  parentId: string | null;
+  path: string;
+  name: string;
+  type: string;
+}
+
+export interface OrgScopeContext {
+  tenantId: string;
+  userId: string;
+  roles: string[];
+  userOrgIds: string[];
+  rolePolicies: RoleDataPolicy[];
+  orgNodes: OrgNode[];
+}
+
+export interface DataScopeDecision {
+  scope: DataScopeType;
+  allowedOrgIds: string[];
+  tenantAll: boolean;
+  legacyFallbackToCreatedBy: boolean;
+  reason: string;
 }

--- a/packages/permission/test/permission-engine.test.ts
+++ b/packages/permission/test/permission-engine.test.ts
@@ -1,8 +1,14 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { buildRowLevelFilter, injectPermissionClause } from "../src/permission-engine";
+import {
+  buildDataScopeFilter,
+  buildRowLevelFilter,
+  canAccessOrg,
+  injectPermissionClause,
+  resolveDataScope
+} from "../src/permission-engine";
 
-test("non-admin gets tenant and user filter", () => {
+test("non-admin defaults to SELF scope", () => {
   const filter = buildRowLevelFilter({
     tenantId: "t1",
     userId: "u1",
@@ -10,6 +16,93 @@ test("non-admin gets tenant and user filter", () => {
   });
   assert.equal(filter.clause, "tenant_id = $1 AND created_by = $2");
   assert.deepEqual(filter.params, ["t1", "u1"]);
+});
+
+test("resolveDataScope computes manager dept-children org set", () => {
+  const decision = resolveDataScope({
+    tenantId: "tenant-a",
+    userId: "manager-1",
+    roles: ["MANAGER"],
+    userOrgIds: ["dept-a"],
+    rolePolicies: [],
+    orgNodes: [
+      {
+        id: "dept-a",
+        tenantId: "tenant-a",
+        parentId: "root",
+        path: "root/dept-a",
+        name: "部门A",
+        type: "department"
+      },
+      {
+        id: "dept-a-sub",
+        tenantId: "tenant-a",
+        parentId: "dept-a",
+        path: "root/dept-a/dept-a-sub",
+        name: "部门A-子组",
+        type: "department"
+      },
+      {
+        id: "dept-b",
+        tenantId: "tenant-a",
+        parentId: "root",
+        path: "root/dept-b",
+        name: "部门B",
+        type: "department"
+      }
+    ]
+  });
+
+  assert.equal(decision.scope, "DEPT_AND_CHILDREN");
+  assert.deepEqual(new Set(decision.allowedOrgIds), new Set(["dept-a", "dept-a-sub"]));
+});
+
+test("buildDataScopeFilter uses org list and legacy fallback", () => {
+  const filter = buildDataScopeFilter(
+    {
+      scope: "DEPT",
+      allowedOrgIds: ["dept-a"],
+      tenantAll: false,
+      legacyFallbackToCreatedBy: true,
+      reason: "scope:DEPT"
+    },
+    {
+      tenantId: "tenant-a",
+      userId: "u-a",
+      roles: ["USER"]
+    }
+  );
+
+  assert.equal(
+    filter.clause,
+    "tenant_id = $1 AND (org_id = ANY($2::text[]) OR (org_id IS NULL AND created_by = $3))"
+  );
+  assert.deepEqual(filter.params, ["tenant-a", ["dept-a"], "u-a"]);
+});
+
+test("canAccessOrg denies sibling org and allows legacy fallback", () => {
+  const decision = {
+    scope: "DEPT" as const,
+    allowedOrgIds: ["dept-a"],
+    tenantAll: false,
+    legacyFallbackToCreatedBy: true,
+    reason: "scope:DEPT"
+  };
+
+  const denied = canAccessOrg(
+    decision,
+    { orgId: "dept-b", createdBy: "u-a" },
+    { tenantId: "tenant-a", userId: "u-a", roles: ["USER"] }
+  );
+  assert.equal(denied.allowed, false);
+
+  const allowedByLegacy = canAccessOrg(
+    decision,
+    { orgId: null, createdBy: "u-a" },
+    { tenantId: "tenant-a", userId: "u-a", roles: ["USER"] }
+  );
+  assert.equal(allowedByLegacy.allowed, true);
+  assert.equal(allowedByLegacy.fallbackUsed, true);
 });
 
 test("injectPermissionClause appends filter to SQL with WHERE", () => {

--- a/packages/query/src/query-compiler.ts
+++ b/packages/query/src/query-compiler.ts
@@ -44,6 +44,7 @@ const SUPPORTED_EXACT_FILTERS = new Set([
   "owner",
   "channel",
   "priority",
+  "org_id",
   "tenant_id",
   "created_by"
 ]);

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -12,14 +12,21 @@ export function quoteLiteral(value: string | number | boolean): string {
   return `'${value.replace(/'/g, "''")}'`;
 }
 
+function quoteArray(values: string[]): string {
+  return `ARRAY[${values.map((value) => quoteLiteral(value)).join(", ")}]`;
+}
+
 export function formatSqlWithParams(
   sql: string,
-  params: Array<string | number | boolean>
+  params: Array<string | number | boolean | string[]>
 ): string {
   let finalSql = sql;
   params.forEach((value, index) => {
     const marker = new RegExp(`\\$${index + 1}(?!\\d)`, "g");
-    finalSql = finalSql.replace(marker, quoteLiteral(value));
+    finalSql = finalSql.replace(
+      marker,
+      Array.isArray(value) ? quoteArray(value) : quoteLiteral(value)
+    );
   });
   return finalSql;
 }


### PR DESCRIPTION
## 变更摘要
- 在 contracts/permission/bff 链路落地组织树数据权限（SELF/DEPT/DEPT_AND_CHILDREN/CUSTOM_ORG_SET/TENANT_ALL）
- Query/Mutation 增加 org scope 校验与 403 拒绝语义
- 扩展审计落盘字段（permission_scope/org_count/fallback/reason）并新增 denied 记录
- 扩展 bootstrap 与 demo seed（org_nodes、角色策略、成员绑定）
- 扩展 query-gate，新增 query/mutation 越权失败样例

## 验证
- pnpm -r build
- pnpm -r test
- pnpm query-gate

## 风险与回滚
- 风险：历史数据 org_id 为空时走 created_by fallback，需持续关注数据补齐进度
- 回滚：回滚本 PR 即可恢复到仅 tenant + owner 过滤策略