### PR TITLE
feat: add runtime dsl parser and template resolver

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -91,3 +91,62 @@ export interface QueryAuditLog {
   status: AuditStatus;
   errorMessage?: string | null;
 }
+
+export type RuntimeTemplateSource = "state";
+
+export interface RuntimeTemplateDependency {
+  source: RuntimeTemplateSource;
+  key: string;
+  expression: string;
+}
+
+export interface RuntimePageMeta {
+  id: string;
+  title: string;
+  description?: string;
+}
+
+export interface RuntimeNodeSchema {
+  id: string;
+  componentType: string;
+  props: Record<string, unknown>;
+  children?: RuntimeNodeSchema[];
+}
+
+export interface RuntimeDatasourceDefinition {
+  id: string;
+  type: string;
+  request?: {
+    method?: string;
+    url?: string;
+    params?: Record<string, unknown>;
+    body?: unknown;
+  };
+  responseMapping?: {
+    stateKey?: string;
+  };
+}
+
+export interface RuntimeActionStepDefinition {
+  type: string;
+  datasourceId?: string;
+  stateKey?: string;
+  patch?: Record<string, unknown>;
+  message?: string;
+  payloadTemplate?: Record<string, unknown>;
+}
+
+export interface RuntimeActionDefinition {
+  id: string;
+  trigger?: string;
+  steps: RuntimeActionStepDefinition[];
+}
+
+export interface RuntimePageDsl {
+  schemaVersion: string;
+  pageMeta: RuntimePageMeta;
+  state: Record<string, unknown>;
+  datasources: RuntimeDatasourceDefinition[];
+  actions: RuntimeActionDefinition[];
+  layoutTree: RuntimeNodeSchema[];
+}

--- a/packages/contracts/test/smoke.test.ts
+++ b/packages/contracts/test/smoke.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import type { QueryApiRequest } from "../src";
+import type { QueryApiRequest, RuntimePageDsl, RuntimeTemplateDependency } from "../src";
 
 test("contracts exports query request type", () => {
   const req: QueryApiRequest = {
@@ -11,4 +11,28 @@ test("contracts exports query request type", () => {
     roles: ["USER"]
   };
   assert.equal(req.table, "orders");
+});
+
+test("contracts exports runtime dsl types", () => {
+  const dependency: RuntimeTemplateDependency = {
+    source: "state",
+    key: "tenantId",
+    expression: "{{state.tenantId}}"
+  };
+  const dsl: RuntimePageDsl = {
+    schemaVersion: "runtime-page-dsl.v1",
+    pageMeta: {
+      id: "orders-query-page",
+      title: "Orders Query"
+    },
+    state: {
+      tenantId: "tenant-a"
+    },
+    datasources: [],
+    actions: [],
+    layoutTree: []
+  };
+
+  assert.equal(dependency.key, "tenantId");
+  assert.equal(dsl.pageMeta.id, "orders-query-page");
 });

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@meta-lc/runtime",
+  "version": "0.1.0",
+  "private": true,
+  "type": "commonjs",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "npm run build && node --test \"dist/**/test/*.test.js\"",
+    "lint": "echo lint:runtime"
+  },
+  "dependencies": {
+    "@meta-lc/contracts": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "typescript": "^5.7.2"
+  },
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts"
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./runtime-dsl-parser";
+export * from "./template-resolver";
+export * from "./types";

--- a/packages/runtime/src/runtime-dsl-parser.ts
+++ b/packages/runtime/src/runtime-dsl-parser.ts
@@ -1,0 +1,162 @@
+import type {
+  RuntimeActionDefinition,
+  RuntimeDatasourceDefinition,
+  RuntimeNodeSchema,
+  RuntimePageDsl
+} from "@meta-lc/contracts";
+import { collectTemplateDependencies } from "./template-resolver";
+import {
+  type ParsedRuntimeActionDefinition,
+  type ParsedRuntimeDatasourceDefinition,
+  type ParsedRuntimeNodeSchema,
+  type ParsedRuntimePageDsl,
+  RuntimeDslParseError,
+  type RuntimeDslValidationIssue
+} from "./types";
+
+export function parseRuntimePageDsl(input: RuntimePageDsl): ParsedRuntimePageDsl {
+  const issues = validateRuntimePageDsl(input);
+  if (issues.length > 0) {
+    throw new RuntimeDslParseError(issues);
+  }
+
+  const datasources = input.datasources.map<ParsedRuntimeDatasourceDefinition>((datasource) => ({
+    ...datasource,
+    dependencies: collectTemplateDependencies(datasource)
+  }));
+  const actions = input.actions.map<ParsedRuntimeActionDefinition>((action) => ({
+    ...action,
+    dependencies: collectTemplateDependencies(action)
+  }));
+  const layoutTree = input.layoutTree.map((node) => parseLayoutNode(node));
+
+  return {
+    ...input,
+    datasources,
+    actions,
+    layoutTree,
+    dependencies: {
+      datasources: Object.fromEntries(datasources.map((datasource) => [datasource.id, datasource.dependencies])),
+      actions: Object.fromEntries(actions.map((action) => [action.id, action.dependencies])),
+      layoutNodes: Object.fromEntries(flattenLayoutNodes(layoutTree).map((node) => [node.id, node.dependencies]))
+    }
+  };
+}
+
+function validateRuntimePageDsl(input: RuntimePageDsl): RuntimeDslValidationIssue[] {
+  const issues: RuntimeDslValidationIssue[] = [];
+  if (!input.schemaVersion?.trim()) {
+    issues.push({ path: "schemaVersion", message: "is required." });
+  }
+  if (!input.pageMeta?.id?.trim()) {
+    issues.push({ path: "pageMeta.id", message: "is required." });
+  }
+  if (!input.pageMeta?.title?.trim()) {
+    issues.push({ path: "pageMeta.title", message: "is required." });
+  }
+  if (!isPlainObject(input.state)) {
+    issues.push({ path: "state", message: "must be an object." });
+  }
+  if (!Array.isArray(input.datasources)) {
+    issues.push({ path: "datasources", message: "must be an array." });
+  }
+  if (!Array.isArray(input.actions)) {
+    issues.push({ path: "actions", message: "must be an array." });
+  }
+  if (!Array.isArray(input.layoutTree)) {
+    issues.push({ path: "layoutTree", message: "must be an array." });
+  }
+
+  collectDuplicateIdIssues(input.datasources, "datasources", issues);
+  collectDuplicateIdIssues(input.actions, "actions", issues);
+  collectLayoutIssues(input.layoutTree, "layoutTree", issues);
+
+  input.datasources.forEach((datasource, index) => {
+    if (!datasource.id?.trim()) {
+      issues.push({ path: `datasources[${index}].id`, message: "is required." });
+    }
+    if (!datasource.type?.trim()) {
+      issues.push({ path: `datasources[${index}].type`, message: "is required." });
+    }
+  });
+
+  input.actions.forEach((action, index) => {
+    if (!action.id?.trim()) {
+      issues.push({ path: `actions[${index}].id`, message: "is required." });
+    }
+    if (!Array.isArray(action.steps) || action.steps.length === 0) {
+      issues.push({ path: `actions[${index}].steps`, message: "must contain at least one step." });
+    }
+  });
+
+  return issues;
+}
+
+function collectDuplicateIdIssues(
+  items: Array<RuntimeDatasourceDefinition | RuntimeActionDefinition>,
+  path: string,
+  issues: RuntimeDslValidationIssue[]
+): void {
+  const seen = new Set<string>();
+  items.forEach((item, index) => {
+    if (!item.id?.trim()) {
+      return;
+    }
+    if (seen.has(item.id)) {
+      issues.push({ path: `${path}[${index}].id`, message: `duplicates "${item.id}".` });
+      return;
+    }
+    seen.add(item.id);
+  });
+}
+
+function collectLayoutIssues(
+  nodes: RuntimeNodeSchema[],
+  path: string,
+  issues: RuntimeDslValidationIssue[]
+): void {
+  const seen = new Set<string>();
+
+  const visit = (node: RuntimeNodeSchema, nodePath: string): void => {
+    if (!node.id?.trim()) {
+      issues.push({ path: `${nodePath}.id`, message: "is required." });
+    } else if (seen.has(node.id)) {
+      issues.push({ path: `${nodePath}.id`, message: `duplicates "${node.id}".` });
+    } else {
+      seen.add(node.id);
+    }
+
+    if (!node.componentType?.trim()) {
+      issues.push({ path: `${nodePath}.componentType`, message: "is required." });
+    }
+
+    if (!isPlainObject(node.props)) {
+      issues.push({ path: `${nodePath}.props`, message: "must be an object." });
+    }
+
+    if (node.children !== undefined && !Array.isArray(node.children)) {
+      issues.push({ path: `${nodePath}.children`, message: "must be an array when provided." });
+      return;
+    }
+
+    node.children?.forEach((child, childIndex) => visit(child, `${nodePath}.children[${childIndex}]`));
+  };
+
+  nodes.forEach((node, index) => visit(node, `${path}[${index}]`));
+}
+
+function parseLayoutNode(node: RuntimeNodeSchema): ParsedRuntimeNodeSchema {
+  return {
+    ...node,
+    dependencies: collectTemplateDependencies(node),
+    children: node.children?.map((child) => parseLayoutNode(child))
+  };
+}
+
+function flattenLayoutNodes(nodes: ParsedRuntimeNodeSchema[]): ParsedRuntimeNodeSchema[] {
+  return nodes.flatMap((node) => [node, ...flattenLayoutNodes(node.children ?? [])]);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/runtime/src/template-resolver.ts
+++ b/packages/runtime/src/template-resolver.ts
@@ -1,0 +1,74 @@
+import type { RuntimeTemplateDependency } from "@meta-lc/contracts";
+
+const STATE_TEMPLATE_PATTERN = /\{\{\s*state\.([a-zA-Z0-9_]+)\s*\}\}/g;
+
+export function collectTemplateDependencies(value: unknown): RuntimeTemplateDependency[] {
+  const seen = new Set<string>();
+  const dependencies: RuntimeTemplateDependency[] = [];
+
+  visitTemplateValue(value, (template) => {
+    for (const match of template.matchAll(STATE_TEMPLATE_PATTERN)) {
+      const key = match[1];
+      if (!key) {
+        continue;
+      }
+      const identity = `state:${key}`;
+      if (seen.has(identity)) {
+        continue;
+      }
+      seen.add(identity);
+      dependencies.push({
+        source: "state",
+        key,
+        expression: match[0]
+      });
+    }
+  });
+
+  return dependencies;
+}
+
+export function resolveTemplateValue(value: unknown, state: Record<string, unknown>): unknown {
+  if (typeof value === "string") {
+    return resolveTemplateString(value, state);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => resolveTemplateValue(item, state));
+  }
+
+  if (isPlainObject(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [key, resolveTemplateValue(nestedValue, state)])
+    );
+  }
+
+  return value;
+}
+
+export function resolveTemplateString(template: string, state: Record<string, unknown>): string {
+  return template.replace(STATE_TEMPLATE_PATTERN, (_match, key: string) => {
+    const resolved = state[key];
+    return resolved === undefined || resolved === null ? "" : String(resolved);
+  });
+}
+
+function visitTemplateValue(value: unknown, onString: (template: string) => void): void {
+  if (typeof value === "string") {
+    onString(value);
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item) => visitTemplateValue(item, onString));
+    return;
+  }
+
+  if (isPlainObject(value)) {
+    Object.values(value).forEach((item) => visitTemplateValue(item, onString));
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -1,0 +1,45 @@
+import type {
+  RuntimeActionDefinition,
+  RuntimeDatasourceDefinition,
+  RuntimeNodeSchema,
+  RuntimePageDsl,
+  RuntimeTemplateDependency
+} from "@meta-lc/contracts";
+
+export interface ParsedRuntimeDatasourceDefinition extends RuntimeDatasourceDefinition {
+  dependencies: RuntimeTemplateDependency[];
+}
+
+export interface ParsedRuntimeActionDefinition extends RuntimeActionDefinition {
+  dependencies: RuntimeTemplateDependency[];
+}
+
+export interface ParsedRuntimeNodeSchema extends RuntimeNodeSchema {
+  dependencies: RuntimeTemplateDependency[];
+  children?: ParsedRuntimeNodeSchema[];
+}
+
+export interface ParsedRuntimePageDsl extends RuntimePageDsl {
+  datasources: ParsedRuntimeDatasourceDefinition[];
+  actions: ParsedRuntimeActionDefinition[];
+  layoutTree: ParsedRuntimeNodeSchema[];
+  dependencies: {
+    datasources: Record<string, RuntimeTemplateDependency[]>;
+    actions: Record<string, RuntimeTemplateDependency[]>;
+    layoutNodes: Record<string, RuntimeTemplateDependency[]>;
+  };
+}
+
+export interface RuntimeDslValidationIssue {
+  path: string;
+  message: string;
+}
+
+export class RuntimeDslParseError extends Error {
+  constructor(public readonly issues: RuntimeDslValidationIssue[]) {
+    super(
+      `Invalid runtime DSL: ${issues.map((issue) => `${issue.path} ${issue.message}`).join("; ")}`
+    );
+    this.name = "RuntimeDslParseError";
+  }
+}

--- a/packages/runtime/test/runtime-dsl-parser.test.ts
+++ b/packages/runtime/test/runtime-dsl-parser.test.ts
@@ -1,0 +1,137 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { RuntimePageDsl } from "@meta-lc/contracts";
+import { parseRuntimePageDsl, RuntimeDslParseError } from "../src";
+
+function createRuntimeDsl(): RuntimePageDsl {
+  return {
+    schemaVersion: "runtime-page-dsl.v1",
+    pageMeta: {
+      id: "orders-crud-page",
+      title: "Orders CRUD"
+    },
+    state: {
+      tenantId: "tenant-a",
+      userId: "demo-tenant-a-user",
+      roles: ["USER"],
+      filter_status: "PAID",
+      tableData: []
+    },
+    datasources: [
+      {
+        id: "orders-query-datasource",
+        type: "rest",
+        request: {
+          method: "POST",
+          url: "/query",
+          params: {
+            table: "orders",
+            tenantId: "{{state.tenantId}}",
+            status: "{{state.filter_status}}"
+          }
+        },
+        responseMapping: {
+          stateKey: "tableData"
+        }
+      }
+    ],
+    actions: [
+      {
+        id: "search-action",
+        steps: [
+          {
+            type: "callDatasource",
+            datasourceId: "orders-query-datasource",
+            stateKey: "tableData",
+            payloadTemplate: {
+              tenantId: "{{state.tenantId}}"
+            }
+          }
+        ]
+      }
+    ],
+    layoutTree: [
+      {
+        id: "page-root",
+        componentType: "page",
+        props: {
+          title: "{{state.tenantId}} Orders"
+        },
+        children: [
+          {
+            id: "results-table",
+            componentType: "table",
+            props: {
+              dataKey: "tableData"
+            }
+          }
+        ]
+      }
+    ]
+  };
+}
+
+test("parseRuntimePageDsl parses the minimal runtime dsl and collects dependencies", () => {
+  const parsed = parseRuntimePageDsl(createRuntimeDsl());
+
+  assert.equal(parsed.datasources[0]?.id, "orders-query-datasource");
+  assert.deepEqual(parsed.dependencies.datasources["orders-query-datasource"], [
+    {
+      source: "state",
+      key: "tenantId",
+      expression: "{{state.tenantId}}"
+    },
+    {
+      source: "state",
+      key: "filter_status",
+      expression: "{{state.filter_status}}"
+    }
+  ]);
+  assert.deepEqual(parsed.dependencies.actions["search-action"], [
+    {
+      source: "state",
+      key: "tenantId",
+      expression: "{{state.tenantId}}"
+    }
+  ]);
+  assert.deepEqual(parsed.dependencies.layoutNodes["page-root"], [
+    {
+      source: "state",
+      key: "tenantId",
+      expression: "{{state.tenantId}}"
+    }
+  ]);
+});
+
+test("parseRuntimePageDsl throws a stable parse error for missing required fields", () => {
+  assert.throws(
+    () =>
+      parseRuntimePageDsl({
+        ...createRuntimeDsl(),
+        pageMeta: {
+          id: "",
+          title: ""
+        },
+        actions: [{ id: "search-action", steps: [] }]
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof RuntimeDslParseError);
+      const parseError = error as RuntimeDslParseError;
+      assert.deepEqual(parseError.issues, [
+        {
+          path: "pageMeta.id",
+          message: "is required."
+        },
+        {
+          path: "pageMeta.title",
+          message: "is required."
+        },
+        {
+          path: "actions[0].steps",
+          message: "must contain at least one step."
+        }
+      ]);
+      return true;
+    }
+  );
+});

--- a/packages/runtime/test/template-resolver.test.ts
+++ b/packages/runtime/test/template-resolver.test.ts
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { collectTemplateDependencies, resolveTemplateString, resolveTemplateValue } from "../src";
+
+test("collectTemplateDependencies extracts state references from nested values", () => {
+  const dependencies = collectTemplateDependencies({
+    body: {
+      tenantId: "{{state.tenantId}}",
+      filters: ["{{state.filter_status}}", "{{state.filter_status}}"],
+      title: "Orders for {{state.userId}}"
+    }
+  });
+
+  assert.deepEqual(dependencies, [
+    {
+      source: "state",
+      key: "tenantId",
+      expression: "{{state.tenantId}}"
+    },
+    {
+      source: "state",
+      key: "filter_status",
+      expression: "{{state.filter_status}}"
+    },
+    {
+      source: "state",
+      key: "userId",
+      expression: "{{state.userId}}"
+    }
+  ]);
+});
+
+test("resolveTemplateValue resolves nested state templates for the current demo chain", () => {
+  const resolved = resolveTemplateValue(
+    {
+      title: "Orders for {{state.tenantId}}",
+      payload: {
+        tenantId: "{{state.tenantId}}",
+        selectedId: "{{state.selectedOrderId}}"
+      }
+    },
+    {
+      tenantId: "tenant-a",
+      selectedOrderId: "SO-1001"
+    }
+  );
+
+  assert.deepEqual(resolved, {
+    title: "Orders for tenant-a",
+    payload: {
+      tenantId: "tenant-a",
+      selectedId: "SO-1001"
+    }
+  });
+  assert.equal(resolveTemplateString("{{state.missing}}", {}), "");
+});

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,19 @@ importers:
         specifier: ^5.7.2
         version: 5.9.3
 
+  packages/runtime:
+    dependencies:
+      '@meta-lc/contracts':
+        specifier: workspace:*
+        version: link:../contracts
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.17
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+
   packages/shared:
     devDependencies:
       '@types/node':

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -32,6 +32,9 @@
       "@meta-lc/contracts": [
         "packages/contracts/src"
       ],
+      "@meta-lc/runtime": [
+        "packages/runtime/src"
+      ],
       "@meta-lc/shared": [
         "packages/shared/src"
       ],


### PR DESCRIPTION
## Summary
- add minimal Phase 4 runtime DSL contracts for page/datasource/action/template dependencies
- add a new `@meta-lc/runtime` package with a parser, template resolver, and `{{state.xxx}}` dependency collection
- cover the new runtime skeleton with unit tests and wire the package into the workspace

## Validation
- `pnpm lint`
- `pnpm -r test`
- `pnpm -r build`

Closes #35