### PR TITLE
feat: add runtime dependency graph and auto refresh planning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - feat(release): add aggregate package `@zhongmiao/meta-lc-platform` and reserve `@zhongmiao/meta-lc-*` naming for workspace packages.
 - feat(ci): add changelog gate, release draft sync, and manual changelog finalize workflow for platform release governance.
 - docs(changelog): establish bilingual root/package changelog baselines for the platform workspace.
+- feat(runtime): add dependency graph planning so runtime state and mutation events can drive deterministic auto-refresh execution.
 
 ## 0.1.0 (2026-04-18)
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -5,6 +5,7 @@
 - feat(release): 新增聚合总包 `@zhongmiao/meta-lc-platform`，并为工作区包统一预留 `@zhongmiao/meta-lc-*` 命名。
 - feat(ci): 新增 changelog gate、release draft 同步与手动 changelog finalize 工作流，补齐平台发版治理基础。
 - docs(changelog): 为平台工作区建立根级与包级双语 changelog 基线。
+- feat(runtime): 新增依赖图规划能力，让 runtime 可由 state 与 mutation 事件驱动确定性自动刷新执行。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -3,6 +3,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 ## [Unreleased]
 
 - chore(package): adopt the `@zhongmiao/meta-lc-contracts` scoped package identity for release governance.
+- feat(runtime-contracts): add refresh planning event and target contracts for dependency graph execution.
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/contracts/CHANGELOG.zh-CN.md
+++ b/packages/contracts/CHANGELOG.zh-CN.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-contracts` 正式包名。
+- feat(runtime-contracts): 补充依赖图执行所需的刷新事件与目标契约类型。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -127,6 +127,11 @@ export interface RuntimeDatasourceDefinition {
   };
 }
 
+export interface RuntimeActionSuccessDefinition {
+  refreshDatasources?: string[];
+  runActions?: string[];
+}
+
 export interface RuntimeActionStepDefinition {
   type: string;
   datasourceId?: string;
@@ -139,7 +144,35 @@ export interface RuntimeActionStepDefinition {
 export interface RuntimeActionDefinition {
   id: string;
   trigger?: string;
+  onSuccess?: RuntimeActionSuccessDefinition;
   steps: RuntimeActionStepDefinition[];
+}
+
+export type RuntimeDependencyTargetKind = "datasource" | "action";
+
+export interface RuntimeDependencyTargetRef {
+  kind: RuntimeDependencyTargetKind;
+  id: string;
+}
+
+export interface RuntimeStateChangedEvent {
+  type: "state.changed";
+  stateKeys: string[];
+}
+
+export interface RuntimeMutationSucceededEvent {
+  type: "mutation.succeeded";
+  actionId: string;
+  operation: MutationOperation;
+}
+
+export type RuntimeRefreshEvent = RuntimeStateChangedEvent | RuntimeMutationSucceededEvent;
+
+export interface RuntimeRefreshPlan {
+  datasourceIds: string[];
+  actionIds: string[];
+  targetOrder: RuntimeDependencyTargetRef[];
+  triggeredBy: RuntimeRefreshEvent;
 }
 
 export interface RuntimePageDsl {

--- a/packages/contracts/test/smoke.test.ts
+++ b/packages/contracts/test/smoke.test.ts
@@ -1,6 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import type { QueryApiRequest, RuntimePageDsl, RuntimeTemplateDependency } from "../src";
+import type {
+  QueryApiRequest,
+  RuntimePageDsl,
+  RuntimeRefreshEvent,
+  RuntimeRefreshPlan,
+  RuntimeTemplateDependency
+} from "../src";
 
 test("contracts exports query request type", () => {
   const req: QueryApiRequest = {
@@ -35,4 +41,21 @@ test("contracts exports runtime dsl types", () => {
 
   assert.equal(dependency.key, "tenantId");
   assert.equal(dsl.pageMeta.id, "orders-query-page");
+});
+
+test("contracts exports runtime refresh planning types", () => {
+  const event: RuntimeRefreshEvent = {
+    type: "mutation.succeeded",
+    actionId: "save-order-action",
+    operation: "update"
+  };
+  const plan: RuntimeRefreshPlan = {
+    datasourceIds: ["orders-query-datasource"],
+    actionIds: [],
+    targetOrder: [{ kind: "datasource", id: "orders-query-datasource" }],
+    triggeredBy: event
+  };
+
+  assert.equal(plan.triggeredBy.type, "mutation.succeeded");
+  assert.equal(plan.targetOrder[0]?.kind, "datasource");
 });

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -3,6 +3,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 ## [Unreleased]
 
 - chore(package): adopt the `@zhongmiao/meta-lc-runtime` scoped package identity for release governance.
+- feat(runtime): add dependency graph construction and auto-refresh planning for state and mutation events.
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/runtime/CHANGELOG.zh-CN.md
+++ b/packages/runtime/CHANGELOG.zh-CN.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-runtime` 正式包名。
+- feat(runtime): 新增依赖图构建与自动刷新规划，覆盖 state 与 mutation 成功事件。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/runtime/src/dependency-graph.ts
+++ b/packages/runtime/src/dependency-graph.ts
@@ -1,0 +1,319 @@
+import type {
+  RuntimeActionStepDefinition,
+  RuntimeDependencyTargetRef,
+  RuntimeRefreshEvent
+} from "@zhongmiao/meta-lc-contracts";
+import {
+  createRefreshPlan,
+  createRuntimeTargetRef,
+  getRuntimeTargetRefKey,
+  type ParsedRuntimeActionDefinition,
+  type ParsedRuntimeDatasourceDefinition,
+  type ParsedRuntimePageDsl,
+  type PlanRuntimeRefreshResult,
+  RuntimeDependencyGraphError,
+  type RuntimeDependencyGraph,
+  type RuntimeDependencyGraphNode,
+  toStableTargetOrder
+} from "./types";
+
+export function buildDependencyGraph(parsedDsl: ParsedRuntimePageDsl): RuntimeDependencyGraph {
+  const stateKeys = [...parsedDsl.stateKeys];
+  const knownStateKeys = new Set(stateKeys);
+  const stateToTargets = Object.fromEntries(stateKeys.map((key) => [key, [] as RuntimeDependencyTargetRef[]]));
+  const nodes: Record<string, RuntimeDependencyGraphNode> = {};
+  const mutationSuccess: Record<string, RuntimeDependencyTargetRef[]> = {};
+
+  const registerNode = (
+    ref: RuntimeDependencyTargetRef,
+    dependsOnStateKeys: string[],
+    outputStateKeys: string[],
+    trigger?: string
+  ): void => {
+    const missingStateKey = dependsOnStateKeys.find((key) => !knownStateKeys.has(key));
+    if (missingStateKey) {
+      throw new RuntimeDependencyGraphError(`Unknown state dependency "${missingStateKey}" for ${ref.kind} "${ref.id}".`);
+    }
+
+    const stableDependsOn = toStableStrings(dependsOnStateKeys);
+    const stableOutputs = toStableStrings(outputStateKeys);
+    nodes[getRuntimeTargetRefKey(ref)] = {
+      ref,
+      trigger,
+      dependsOnStateKeys: stableDependsOn,
+      outputStateKeys: stableOutputs,
+      downstream: []
+    };
+
+    stableDependsOn.forEach((stateKey) => {
+      stateToTargets[stateKey]?.push(ref);
+    });
+  };
+
+  parsedDsl.datasources.forEach((datasource) => {
+    registerNode(
+      createRuntimeTargetRef("datasource", datasource.id),
+      datasource.dependencies.map((dependency) => dependency.key),
+      getDatasourceOutputStateKeys(datasource)
+    );
+  });
+
+  parsedDsl.actions.forEach((action) => {
+    registerNode(
+      createRuntimeTargetRef("action", action.id),
+      action.dependencies.map((dependency) => dependency.key),
+      getActionOutputStateKeys(action),
+      action.trigger
+    );
+
+    mutationSuccess[action.id] = resolveMutationSuccessTargets(action, parsedDsl);
+  });
+
+  Object.values(nodes).forEach((node) => {
+    const downstream = new Map<string, RuntimeDependencyTargetRef>();
+    node.outputStateKeys.forEach((stateKey) => {
+      for (const candidate of stateToTargets[stateKey] ?? []) {
+        if (getRuntimeTargetRefKey(candidate) === getRuntimeTargetRefKey(node.ref)) {
+          continue;
+        }
+        const candidateNode = nodes[getRuntimeTargetRefKey(candidate)];
+        if (!candidateNode) {
+          continue;
+        }
+        if (candidate.kind === "action" && candidateNode.trigger !== "state.changed") {
+          continue;
+        }
+        downstream.set(getRuntimeTargetRefKey(candidate), candidate);
+      }
+    });
+    node.downstream = toStableTargetOrder([...downstream.values()]);
+  });
+
+  Object.values(stateToTargets).forEach((targets) => {
+    const stable = toStableTargetOrder(
+      targets.filter((target) => {
+        if (target.kind === "action") {
+          const node = nodes[getRuntimeTargetRefKey(target)];
+          return node?.trigger === "state.changed";
+        }
+        return true;
+      })
+    );
+    targets.splice(0, targets.length, ...stable);
+  });
+
+  Object.values(mutationSuccess).forEach((targets) => {
+    const stable = toStableTargetOrder(targets);
+    targets.splice(0, targets.length, ...stable);
+  });
+
+  assertAcyclic(nodes);
+
+  return {
+    stateKeys,
+    nodes,
+    stateToTargets,
+    mutationSuccess
+  };
+}
+
+export function planRefresh(graph: RuntimeDependencyGraph, event: RuntimeRefreshEvent): PlanRuntimeRefreshResult {
+  const scheduled = new Map<string, RuntimeDependencyTargetRef>();
+  const queue: RuntimeDependencyTargetRef[] = [];
+
+  const enqueue = (ref: RuntimeDependencyTargetRef): void => {
+    const key = getRuntimeTargetRefKey(ref);
+    if (scheduled.has(key)) {
+      return;
+    }
+    if (!graph.nodes[key]) {
+      throw new RuntimeDependencyGraphError(`Unknown refresh target "${key}".`);
+    }
+    scheduled.set(key, ref);
+    queue.push(ref);
+  };
+
+  if (event.type === "state.changed") {
+    const unknownStateKey = event.stateKeys.find((stateKey) => !graph.stateKeys.includes(stateKey));
+    if (unknownStateKey) {
+      throw new RuntimeDependencyGraphError(`Unknown state key "${unknownStateKey}" in state.changed event.`);
+    }
+    for (const stateKey of toStableStrings(event.stateKeys)) {
+      for (const ref of graph.stateToTargets[stateKey] ?? []) {
+        enqueue(ref);
+      }
+    }
+  } else {
+    const rootTargets = graph.mutationSuccess[event.actionId];
+    if (!rootTargets) {
+      throw new RuntimeDependencyGraphError(
+        `Unknown action "${event.actionId}" in mutation.succeeded event.`
+      );
+    }
+    for (const ref of rootTargets) {
+      enqueue(ref);
+    }
+  }
+
+  for (let index = 0; index < queue.length; index += 1) {
+    const current = queue[index];
+    const node = graph.nodes[getRuntimeTargetRefKey(current)];
+    if (!node) {
+      continue;
+    }
+    for (const downstream of node.downstream) {
+      enqueue(downstream);
+    }
+  }
+
+  const targetOrder = topologicallySortTargets(graph, [...scheduled.values()]);
+  return createRefreshPlan(event, targetOrder);
+}
+
+function resolveMutationSuccessTargets(
+  action: ParsedRuntimeActionDefinition,
+  parsedDsl: ParsedRuntimePageDsl
+): RuntimeDependencyTargetRef[] {
+  const refs = new Map<string, RuntimeDependencyTargetRef>();
+  const datasourceIds = new Set(parsedDsl.datasources.map((datasource) => datasource.id));
+  const actionIds = new Set(parsedDsl.actions.map((candidate) => candidate.id));
+
+  action.onSuccess?.refreshDatasources?.forEach((datasourceId) => {
+    if (!datasourceIds.has(datasourceId)) {
+      throw new RuntimeDependencyGraphError(
+        `Action "${action.id}" references unknown datasource "${datasourceId}" in onSuccess.refreshDatasources.`
+      );
+    }
+    const ref = createRuntimeTargetRef("datasource", datasourceId);
+    refs.set(getRuntimeTargetRefKey(ref), ref);
+  });
+
+  action.onSuccess?.runActions?.forEach((actionId) => {
+    if (!actionIds.has(actionId)) {
+      throw new RuntimeDependencyGraphError(
+        `Action "${action.id}" references unknown action "${actionId}" in onSuccess.runActions.`
+      );
+    }
+    const ref = createRuntimeTargetRef("action", actionId);
+    refs.set(getRuntimeTargetRefKey(ref), ref);
+  });
+
+  return [...refs.values()];
+}
+
+function getDatasourceOutputStateKeys(datasource: ParsedRuntimeDatasourceDefinition): string[] {
+  return datasource.responseMapping?.stateKey ? [datasource.responseMapping.stateKey] : [];
+}
+
+function getActionOutputStateKeys(action: ParsedRuntimeActionDefinition): string[] {
+  const outputStateKeys = new Set<string>();
+
+  action.steps.forEach((step) => {
+    if (step.stateKey?.trim()) {
+      outputStateKeys.add(step.stateKey);
+    }
+    extractPatchStateKeys(step).forEach((stateKey) => outputStateKeys.add(stateKey));
+  });
+
+  return [...outputStateKeys].sort((left, right) => left.localeCompare(right));
+}
+
+function extractPatchStateKeys(step: RuntimeActionStepDefinition): string[] {
+  if (!step.patch) {
+    return [];
+  }
+
+  return Object.keys(step.patch)
+    .map((key) => key.trim())
+    .filter((key) => key.length > 0)
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function topologicallySortTargets(
+  graph: RuntimeDependencyGraph,
+  scheduledTargets: RuntimeDependencyTargetRef[]
+): RuntimeDependencyTargetRef[] {
+  const scheduledKeys = new Set(scheduledTargets.map((target) => getRuntimeTargetRefKey(target)));
+  const indegree = new Map<string, number>();
+
+  scheduledTargets.forEach((target) => {
+    indegree.set(getRuntimeTargetRefKey(target), 0);
+  });
+
+  scheduledTargets.forEach((target) => {
+    const node = graph.nodes[getRuntimeTargetRefKey(target)];
+    node?.downstream.forEach((downstream) => {
+      const downstreamKey = getRuntimeTargetRefKey(downstream);
+      if (!scheduledKeys.has(downstreamKey)) {
+        return;
+      }
+      indegree.set(downstreamKey, (indegree.get(downstreamKey) ?? 0) + 1);
+    });
+  });
+
+  const ready = scheduledTargets.filter((target) => (indegree.get(getRuntimeTargetRefKey(target)) ?? 0) === 0);
+  const ordered: RuntimeDependencyTargetRef[] = [];
+
+  while (ready.length > 0) {
+    const [current] = toStableTargetOrder(ready);
+    const currentIndex = ready.findIndex(
+      (candidate) => getRuntimeTargetRefKey(candidate) === getRuntimeTargetRefKey(current)
+    );
+    ready.splice(currentIndex, 1);
+    if (!current) {
+      continue;
+    }
+    ordered.push(current);
+
+    const node = graph.nodes[getRuntimeTargetRefKey(current)];
+    node?.downstream.forEach((downstream) => {
+      const downstreamKey = getRuntimeTargetRefKey(downstream);
+      if (!scheduledKeys.has(downstreamKey)) {
+        return;
+      }
+      const nextDegree = (indegree.get(downstreamKey) ?? 0) - 1;
+      indegree.set(downstreamKey, nextDegree);
+      if (nextDegree === 0) {
+        ready.push(downstream);
+      }
+    });
+  }
+
+  if (ordered.length !== scheduledTargets.length) {
+    throw new RuntimeDependencyGraphError("Runtime refresh plan contains a dependency cycle.");
+  }
+
+  return ordered;
+}
+
+function assertAcyclic(nodes: Record<string, RuntimeDependencyGraphNode>): void {
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+
+  const visit = (nodeKey: string, trail: string[]): void => {
+    if (visited.has(nodeKey)) {
+      return;
+    }
+    if (visiting.has(nodeKey)) {
+      throw new RuntimeDependencyGraphError(
+        `Runtime dependency cycle detected: ${[...trail, nodeKey].join(" -> ")}.`
+      );
+    }
+
+    visiting.add(nodeKey);
+    const node = nodes[nodeKey];
+    node?.downstream.forEach((downstream) => visit(getRuntimeTargetRefKey(downstream), [...trail, nodeKey]));
+    visiting.delete(nodeKey);
+    visited.add(nodeKey);
+  };
+
+  Object.keys(nodes)
+    .sort((left, right) => left.localeCompare(right))
+    .forEach((nodeKey) => visit(nodeKey, []));
+}
+
+function toStableStrings(values: string[]): string[] {
+  return [...new Set(values.filter((value) => value.trim().length > 0))].sort((left, right) =>
+    left.localeCompare(right)
+  );
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./runtime-dsl-parser";
+export * from "./dependency-graph";
 export * from "./template-resolver";
 export * from "./types";

--- a/packages/runtime/src/runtime-dsl-parser.ts
+++ b/packages/runtime/src/runtime-dsl-parser.ts
@@ -26,7 +26,8 @@ export function parseRuntimePageDsl(input: RuntimePageDsl): ParsedRuntimePageDsl
   }));
   const actions = input.actions.map<ParsedRuntimeActionDefinition>((action) => ({
     ...action,
-    dependencies: collectTemplateDependencies(action)
+    dependencies: collectTemplateDependencies(action),
+    outputStateKeys: []
   }));
   const layoutTree = input.layoutTree.map((node) => parseLayoutNode(node));
 
@@ -35,6 +36,7 @@ export function parseRuntimePageDsl(input: RuntimePageDsl): ParsedRuntimePageDsl
     datasources,
     actions,
     layoutTree,
+    stateKeys: Object.keys(input.state).sort((left, right) => left.localeCompare(right)),
     dependencies: {
       datasources: Object.fromEntries(datasources.map((datasource) => [datasource.id, datasource.dependencies])),
       actions: Object.fromEntries(actions.map((action) => [action.id, action.dependencies])),

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -1,4 +1,8 @@
 import type {
+  RuntimeDependencyTargetKind,
+  RuntimeDependencyTargetRef,
+  RuntimeRefreshEvent,
+  RuntimeRefreshPlan,
   RuntimeActionDefinition,
   RuntimeDatasourceDefinition,
   RuntimeNodeSchema,
@@ -12,6 +16,7 @@ export interface ParsedRuntimeDatasourceDefinition extends RuntimeDatasourceDefi
 
 export interface ParsedRuntimeActionDefinition extends RuntimeActionDefinition {
   dependencies: RuntimeTemplateDependency[];
+  outputStateKeys: string[];
 }
 
 export interface ParsedRuntimeNodeSchema extends RuntimeNodeSchema {
@@ -23,11 +28,27 @@ export interface ParsedRuntimePageDsl extends RuntimePageDsl {
   datasources: ParsedRuntimeDatasourceDefinition[];
   actions: ParsedRuntimeActionDefinition[];
   layoutTree: ParsedRuntimeNodeSchema[];
+  stateKeys: string[];
   dependencies: {
     datasources: Record<string, RuntimeTemplateDependency[]>;
     actions: Record<string, RuntimeTemplateDependency[]>;
     layoutNodes: Record<string, RuntimeTemplateDependency[]>;
   };
+}
+
+export interface RuntimeDependencyGraphNode {
+  ref: RuntimeDependencyTargetRef;
+  trigger?: string;
+  dependsOnStateKeys: string[];
+  outputStateKeys: string[];
+  downstream: RuntimeDependencyTargetRef[];
+}
+
+export interface RuntimeDependencyGraph {
+  stateKeys: string[];
+  nodes: Record<string, RuntimeDependencyGraphNode>;
+  stateToTargets: Record<string, RuntimeDependencyTargetRef[]>;
+  mutationSuccess: Record<string, RuntimeDependencyTargetRef[]>;
 }
 
 export interface RuntimeDslValidationIssue {
@@ -42,4 +63,47 @@ export class RuntimeDslParseError extends Error {
     );
     this.name = "RuntimeDslParseError";
   }
+}
+
+export class RuntimeDependencyGraphError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RuntimeDependencyGraphError";
+  }
+}
+
+export interface PlanRuntimeRefreshResult extends RuntimeRefreshPlan {}
+
+export function createRuntimeTargetRef(kind: RuntimeDependencyTargetKind, id: string): RuntimeDependencyTargetRef {
+  return { kind, id };
+}
+
+export function getRuntimeTargetRefKey(ref: RuntimeDependencyTargetRef): string {
+  return `${ref.kind}:${ref.id}`;
+}
+
+export function toStableTargetOrder(refs: RuntimeDependencyTargetRef[]): RuntimeDependencyTargetRef[] {
+  const kindPriority: Record<RuntimeDependencyTargetKind, number> = {
+    datasource: 0,
+    action: 1
+  };
+
+  return [...refs].sort((left, right) => {
+    if (left.kind !== right.kind) {
+      return kindPriority[left.kind] - kindPriority[right.kind];
+    }
+    return left.id.localeCompare(right.id);
+  });
+}
+
+export function createRefreshPlan(
+  triggeredBy: RuntimeRefreshEvent,
+  targetOrder: RuntimeDependencyTargetRef[]
+): PlanRuntimeRefreshResult {
+  return {
+    triggeredBy,
+    targetOrder,
+    datasourceIds: targetOrder.filter((ref) => ref.kind === "datasource").map((ref) => ref.id),
+    actionIds: targetOrder.filter((ref) => ref.kind === "action").map((ref) => ref.id)
+  };
 }

--- a/packages/runtime/test/dependency-graph.test.ts
+++ b/packages/runtime/test/dependency-graph.test.ts
@@ -1,0 +1,242 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { RuntimePageDsl } from "@zhongmiao/meta-lc-contracts";
+import {
+  buildDependencyGraph,
+  parseRuntimePageDsl,
+  planRefresh,
+  RuntimeDependencyGraphError
+} from "../src";
+
+function createRuntimeDsl(): RuntimePageDsl {
+  return {
+    schemaVersion: "runtime-page-dsl.v1",
+    pageMeta: {
+      id: "orders-crud-page",
+      title: "Orders CRUD"
+    },
+    state: {
+      tenantId: "tenant-a",
+      filter_status: "PAID",
+      tableData: [],
+      selectedOrderId: "",
+      detailData: null
+    },
+    datasources: [
+      {
+        id: "orders-query-datasource",
+        type: "rest",
+        request: {
+          method: "POST",
+          url: "/query",
+          params: {
+            tenantId: "{{state.tenantId}}",
+            status: "{{state.filter_status}}"
+          }
+        },
+        responseMapping: {
+          stateKey: "tableData"
+        }
+      },
+      {
+        id: "order-detail-datasource",
+        type: "rest",
+        request: {
+          method: "POST",
+          url: "/query",
+          params: {
+            tenantId: "{{state.tenantId}}",
+            id: "{{state.selectedOrderId}}"
+          }
+        },
+        responseMapping: {
+          stateKey: "detailData"
+        }
+      }
+    ],
+    actions: [
+      {
+        id: "select-order-action",
+        trigger: "state.changed",
+        steps: [
+          {
+            type: "setState",
+            patch: {
+              selectedOrderId: "{{state.selectedOrderId}}"
+            }
+          }
+        ]
+      },
+      {
+        id: "save-order-action",
+        steps: [
+          {
+            type: "callMutation",
+            stateKey: "selectedOrderId"
+          }
+        ],
+        onSuccess: {
+          refreshDatasources: ["orders-query-datasource"],
+          runActions: ["select-order-action"]
+        }
+      }
+    ],
+    layoutTree: []
+  };
+}
+
+test("buildDependencyGraph creates stable state and mutation mappings", () => {
+  const graph = buildDependencyGraph(parseRuntimePageDsl(createRuntimeDsl()));
+
+  assert.deepEqual(graph.stateToTargets.filter_status, [{ kind: "datasource", id: "orders-query-datasource" }]);
+  assert.deepEqual(graph.stateToTargets.selectedOrderId, [
+    { kind: "datasource", id: "order-detail-datasource" },
+    { kind: "action", id: "select-order-action" }
+  ]);
+  assert.deepEqual(graph.mutationSuccess["save-order-action"], [
+    { kind: "datasource", id: "orders-query-datasource" },
+    { kind: "action", id: "select-order-action" }
+  ]);
+});
+
+test("buildDependencyGraph rejects unknown state dependencies and missing success targets", () => {
+  assert.throws(
+    () =>
+      buildDependencyGraph(
+        parseRuntimePageDsl({
+          ...createRuntimeDsl(),
+          datasources: [
+            {
+              id: "broken-datasource",
+              type: "rest",
+              request: {
+                params: {
+                  status: "{{state.unknown_key}}"
+                }
+              }
+            }
+          ]
+        })
+      ),
+    (error: unknown) => {
+      assert.ok(error instanceof RuntimeDependencyGraphError);
+      assert.equal(error.message, 'Unknown state dependency "unknown_key" for datasource "broken-datasource".');
+      return true;
+    }
+  );
+
+  assert.throws(
+    () =>
+      buildDependencyGraph(
+        parseRuntimePageDsl({
+          ...createRuntimeDsl(),
+          actions: [
+            {
+              id: "save-order-action",
+              steps: [{ type: "callMutation" }],
+              onSuccess: {
+                refreshDatasources: ["missing-datasource"]
+              }
+            }
+          ]
+        })
+      ),
+    (error: unknown) => {
+      assert.ok(error instanceof RuntimeDependencyGraphError);
+      assert.equal(
+        error.message,
+        'Action "save-order-action" references unknown datasource "missing-datasource" in onSuccess.refreshDatasources.'
+      );
+      return true;
+    }
+  );
+});
+
+test("buildDependencyGraph fails fast on explicit dependency cycles", () => {
+  assert.throws(
+    () =>
+      buildDependencyGraph(
+        parseRuntimePageDsl({
+          ...createRuntimeDsl(),
+          state: {
+            firstState: "",
+            secondState: ""
+          },
+          datasources: [
+            {
+              id: "first-datasource",
+              type: "rest",
+              request: {
+                params: {
+                  secondState: "{{state.secondState}}"
+                }
+              },
+              responseMapping: {
+                stateKey: "firstState"
+              }
+            },
+            {
+              id: "second-datasource",
+              type: "rest",
+              request: {
+                params: {
+                  firstState: "{{state.firstState}}"
+                }
+              },
+              responseMapping: {
+                stateKey: "secondState"
+              }
+            }
+          ],
+          actions: [],
+          layoutTree: []
+        })
+      ),
+    (error: unknown) => {
+      assert.ok(error instanceof RuntimeDependencyGraphError);
+      assert.match(error.message, /Runtime dependency cycle detected:/);
+      return true;
+    }
+  );
+});
+
+test("planRefresh schedules state-driven refreshes in stable topological order", () => {
+  const graph = buildDependencyGraph(parseRuntimePageDsl(createRuntimeDsl()));
+  const plan = planRefresh(graph, {
+    type: "state.changed",
+    stateKeys: ["selectedOrderId", "filter_status"]
+  });
+
+  assert.deepEqual(plan.targetOrder, [
+    { kind: "datasource", id: "orders-query-datasource" },
+    { kind: "action", id: "select-order-action" },
+    { kind: "datasource", id: "order-detail-datasource" }
+  ]);
+  assert.deepEqual(plan.datasourceIds, ["orders-query-datasource", "order-detail-datasource"]);
+  assert.deepEqual(plan.actionIds, ["select-order-action"]);
+});
+
+test("planRefresh schedules mutation success refreshes and ignores unrelated state", () => {
+  const graph = buildDependencyGraph(parseRuntimePageDsl(createRuntimeDsl()));
+  const mutationPlan = planRefresh(graph, {
+    type: "mutation.succeeded",
+    actionId: "save-order-action",
+    operation: "update"
+  });
+
+  assert.deepEqual(mutationPlan.targetOrder, [
+    { kind: "datasource", id: "orders-query-datasource" },
+    { kind: "action", id: "select-order-action" },
+    { kind: "datasource", id: "order-detail-datasource" }
+  ]);
+
+  const statePlan = planRefresh(graph, {
+    type: "state.changed",
+    stateKeys: ["tenantId"]
+  });
+
+  assert.deepEqual(statePlan.targetOrder, [
+    { kind: "datasource", id: "order-detail-datasource" },
+    { kind: "datasource", id: "orders-query-datasource" }
+  ]);
+});


### PR DESCRIPTION
## Summary
- add minimal dependency graph construction in `packages/runtime` from parsed runtime DSL dependencies
- add deterministic refresh planning for `state.changed` and `mutation.succeeded` events
- extend runtime/contracts tests and changelogs to cover graph validation, fail-fast cycle handling, and auto-refresh planning

## Validation
- `pnpm --filter @zhongmiao/meta-lc-contracts test`
- `pnpm --filter @zhongmiao/meta-lc-runtime test`
- `pnpm -r test`
- `pnpm -r build`
- `pnpm lint`
- `pnpm version:check`
- `pnpm query-gate`
- `query-gate` request ids:
  - `e2e-tenant-b-1776493787`
  - `e2e-mutation-create-1776493787`
  - `e2e-mutation-delete-1776493787`

## Risk / Rollback
- risk: runtime auto-refresh ordering now depends on the new dependency graph rules, so future DSL authors need to keep state dependencies and `onSuccess` targets aligned with actual runtime flow
- rollback: revert commit `1f822bf` to remove the graph/planner layer and restore the parser-only runtime baseline
