### PR TITLE
feat: add runtime rule engine and function registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - feat(ci): add changelog gate, release draft sync, and manual changelog finalize workflow for platform release governance.
 - docs(changelog): establish bilingual root/package changelog baselines for the platform workspace.
 - feat(runtime): add dependency graph planning so runtime state and mutation events can drive deterministic auto-refresh execution.
+- feat(runtime): add a minimal rule engine and function registry so runtime events can compute rule-driven patches, actions, and datasource refreshes.
 
 ## 0.1.0 (2026-04-18)
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -6,6 +6,7 @@
 - feat(ci): 新增 changelog gate、release draft 同步与手动 changelog finalize 工作流，补齐平台发版治理基础。
 - docs(changelog): 为平台工作区建立根级与包级双语 changelog 基线。
 - feat(runtime): 新增依赖图规划能力，让 runtime 可由 state 与 mutation 事件驱动确定性自动刷新执行。
+- feat(runtime): 新增最小 RuleEngine 与 FunctionRegistry，让 runtime 事件可计算规则驱动的 state patch、action 与 datasource refresh。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -4,6 +4,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 - chore(package): adopt the `@zhongmiao/meta-lc-contracts` scoped package identity for release governance.
 - feat(runtime-contracts): add refresh planning event and target contracts for dependency graph execution.
+- feat(runtime-contracts): add rule and function contracts for event-driven runtime evaluation.
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/contracts/CHANGELOG.zh-CN.md
+++ b/packages/contracts/CHANGELOG.zh-CN.md
@@ -4,6 +4,7 @@
 
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-contracts` 正式包名。
 - feat(runtime-contracts): 补充依赖图执行所需的刷新事件与目标契约类型。
+- feat(runtime-contracts): 补充事件驱动规则求值所需的规则与函数契约类型。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -148,6 +148,73 @@ export interface RuntimeActionDefinition {
   steps: RuntimeActionStepDefinition[];
 }
 
+export type RuntimeRuleTrigger = "state.changed" | "mutation.succeeded";
+
+export type RuntimeRuleValueSource = "literal" | "state" | "event" | "function";
+
+export interface RuntimeRuleLiteralValueDefinition {
+  source: "literal";
+  value: unknown;
+}
+
+export interface RuntimeRuleStateValueDefinition {
+  source: "state";
+  key: string;
+}
+
+export interface RuntimeRuleEventValueDefinition {
+  source: "event";
+  key: string;
+}
+
+export interface RuntimeFunctionCallDefinition {
+  name: string;
+  args: RuntimeRuleValueDefinition[];
+}
+
+export interface RuntimeRuleFunctionValueDefinition {
+  source: "function";
+  call: RuntimeFunctionCallDefinition;
+}
+
+export type RuntimeRuleValueDefinition =
+  | RuntimeRuleLiteralValueDefinition
+  | RuntimeRuleStateValueDefinition
+  | RuntimeRuleEventValueDefinition
+  | RuntimeRuleFunctionValueDefinition;
+
+export interface RuntimeRuleConditionDefinition {
+  call: RuntimeFunctionCallDefinition;
+}
+
+export interface RuntimeSetStateEffectDefinition {
+  type: "setState";
+  stateKey: string;
+  value: RuntimeRuleValueDefinition;
+}
+
+export interface RuntimeRunActionEffectDefinition {
+  type: "runAction";
+  actionId: string;
+}
+
+export interface RuntimeRefreshDatasourceEffectDefinition {
+  type: "refreshDatasource";
+  datasourceId: string;
+}
+
+export type RuntimeRuleEffectDefinition =
+  | RuntimeSetStateEffectDefinition
+  | RuntimeRunActionEffectDefinition
+  | RuntimeRefreshDatasourceEffectDefinition;
+
+export interface RuntimeRuleDefinition {
+  id: string;
+  trigger: RuntimeRuleTrigger;
+  condition: RuntimeRuleConditionDefinition;
+  effects: RuntimeRuleEffectDefinition[];
+}
+
 export type RuntimeDependencyTargetKind = "datasource" | "action";
 
 export interface RuntimeDependencyTargetRef {
@@ -181,5 +248,6 @@ export interface RuntimePageDsl {
   state: Record<string, unknown>;
   datasources: RuntimeDatasourceDefinition[];
   actions: RuntimeActionDefinition[];
+  rules?: RuntimeRuleDefinition[];
   layoutTree: RuntimeNodeSchema[];
 }

--- a/packages/contracts/test/smoke.test.ts
+++ b/packages/contracts/test/smoke.test.ts
@@ -2,7 +2,9 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import type {
   QueryApiRequest,
+  RuntimeFunctionCallDefinition,
   RuntimePageDsl,
+  RuntimeRuleDefinition,
   RuntimeRefreshEvent,
   RuntimeRefreshPlan,
   RuntimeTemplateDependency
@@ -36,11 +38,38 @@ test("contracts exports runtime dsl types", () => {
     },
     datasources: [],
     actions: [],
+    rules: [],
     layoutTree: []
   };
 
   assert.equal(dependency.key, "tenantId");
   assert.equal(dsl.pageMeta.id, "orders-query-page");
+});
+
+test("contracts exports runtime rule and function types", () => {
+  const conditionCall: RuntimeFunctionCallDefinition = {
+    name: "eq",
+    args: [
+      { source: "state", key: "filter_status" },
+      { source: "literal", value: "PAID" }
+    ]
+  };
+  const rule: RuntimeRuleDefinition = {
+    id: "refresh-paid-orders-rule",
+    trigger: "state.changed",
+    condition: {
+      call: conditionCall
+    },
+    effects: [
+      {
+        type: "refreshDatasource",
+        datasourceId: "orders-query-datasource"
+      }
+    ]
+  };
+
+  assert.equal(rule.trigger, "state.changed");
+  assert.equal(rule.condition.call.name, "eq");
 });
 
 test("contracts exports runtime refresh planning types", () => {

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -4,6 +4,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 - chore(package): adopt the `@zhongmiao/meta-lc-runtime` scoped package identity for release governance.
 - feat(runtime): add dependency graph construction and auto-refresh planning for state and mutation events.
+- feat(runtime): add a minimal function registry and rule engine for event-driven runtime effects.
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/runtime/CHANGELOG.zh-CN.md
+++ b/packages/runtime/CHANGELOG.zh-CN.md
@@ -4,6 +4,7 @@
 
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-runtime` 正式包名。
 - feat(runtime): 新增依赖图构建与自动刷新规划，覆盖 state 与 mutation 成功事件。
+- feat(runtime): 新增最小 FunctionRegistry 与 RuleEngine，支持事件驱动的规则 effect 计算。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/runtime/src/function-registry.ts
+++ b/packages/runtime/src/function-registry.ts
@@ -1,0 +1,52 @@
+import {
+  RuntimeFunctionRegistryError,
+  type RuntimeFunctionExecutionContext,
+  type RuntimeFunctionHandler,
+  type RuntimeFunctionRegistry
+} from "./types";
+
+class DefaultRuntimeFunctionRegistry implements RuntimeFunctionRegistry {
+  private readonly handlers = new Map<string, RuntimeFunctionHandler>();
+
+  register(name: string, handler: RuntimeFunctionHandler): void {
+    const normalizedName = name.trim();
+    if (!normalizedName) {
+      throw new RuntimeFunctionRegistryError("Function name is required.");
+    }
+    this.handlers.set(normalizedName, handler);
+  }
+
+  async exec(name: string, args: unknown[], context: RuntimeFunctionExecutionContext): Promise<unknown> {
+    const handler = this.handlers.get(name);
+    if (!handler) {
+      throw new RuntimeFunctionRegistryError(`Runtime function "${name}" is not registered.`);
+    }
+    return handler(args, context);
+  }
+}
+
+export function createFunctionRegistry(): RuntimeFunctionRegistry {
+  const registry = new DefaultRuntimeFunctionRegistry();
+
+  registry.register("eq", ([left, right]) => left === right);
+  registry.register("notEmpty", ([value]) => {
+    if (value === null || value === undefined) {
+      return false;
+    }
+    if (typeof value === "string" || Array.isArray(value)) {
+      return value.length > 0;
+    }
+    return true;
+  });
+  registry.register("includes", ([collection, value]) => {
+    if (typeof collection === "string") {
+      return collection.includes(String(value ?? ""));
+    }
+    if (Array.isArray(collection)) {
+      return collection.includes(value);
+    }
+    return false;
+  });
+
+  return registry;
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,4 +1,6 @@
 export * from "./runtime-dsl-parser";
 export * from "./dependency-graph";
+export * from "./function-registry";
+export * from "./rule-engine";
 export * from "./template-resolver";
 export * from "./types";

--- a/packages/runtime/src/rule-engine.ts
+++ b/packages/runtime/src/rule-engine.ts
@@ -1,0 +1,132 @@
+import type {
+  RuntimeRuleEffectDefinition,
+  RuntimeRuleValueDefinition
+} from "@zhongmiao/meta-lc-contracts";
+import {
+  createEmptyRuleEffectsPlan,
+  isSupportedRuleTrigger,
+  RuntimeRuleEngineError,
+  type RuntimeRuleEffectsPlan,
+  type RuntimeRuleEvaluationContext,
+  type RuntimeRuleEvaluationRequest
+} from "./types";
+
+export async function evaluateRules(request: RuntimeRuleEvaluationRequest): Promise<RuntimeRuleEffectsPlan> {
+  const evaluationContext: RuntimeRuleEvaluationContext = {
+    state: request.state,
+    event: request.event,
+    parsedDsl: request.parsedDsl,
+    graph: request.graph,
+    functionRegistry: request.functionRegistry
+  };
+
+  const plan = createEmptyRuleEffectsPlan(request.event);
+  const actionIds = new Set(request.parsedDsl.actions.map((action) => action.id));
+  const datasourceIds = new Set(request.parsedDsl.datasources.map((datasource) => datasource.id));
+  const stateKeys = new Set(request.parsedDsl.stateKeys);
+
+  for (const rule of request.parsedDsl.rules) {
+    if (!isSupportedRuleTrigger(rule.trigger)) {
+      throw new RuntimeRuleEngineError(`Unsupported rule trigger "${rule.trigger}" for rule "${rule.id}".`);
+    }
+    if (rule.trigger !== request.event.type) {
+      continue;
+    }
+    if (request.event.type === "state.changed" && rule.stateDependencies.length > 0) {
+      const stateChangedEvent = request.event;
+      const intersects = rule.stateDependencies.some((stateKey) => stateChangedEvent.stateKeys.includes(stateKey));
+      if (!intersects) {
+        continue;
+      }
+    }
+
+    const conditionResult = await resolveFunctionCall(rule.condition.call, evaluationContext);
+    if (!conditionResult) {
+      continue;
+    }
+
+    plan.matchedRuleIds.push(rule.id);
+    for (const effect of rule.effects) {
+      await applyRuleEffect(effect, {
+        plan,
+        actionIds,
+        datasourceIds,
+        stateKeys,
+        evaluationContext
+      });
+    }
+  }
+
+  plan.runActionIds.sort((left, right) => left.localeCompare(right));
+  plan.refreshDatasourceIds.sort((left, right) => left.localeCompare(right));
+  return plan;
+}
+
+async function applyRuleEffect(
+  effect: RuntimeRuleEffectDefinition,
+  context: {
+    plan: RuntimeRuleEffectsPlan;
+    actionIds: Set<string>;
+    datasourceIds: Set<string>;
+    stateKeys: Set<string>;
+    evaluationContext: RuntimeRuleEvaluationContext;
+  }
+): Promise<void> {
+  switch (effect.type) {
+    case "setState": {
+      if (!context.stateKeys.has(effect.stateKey)) {
+        throw new RuntimeRuleEngineError(`Rule effect references unknown state key "${effect.stateKey}".`);
+      }
+      context.plan.patchState[effect.stateKey] = await resolveRuleValue(effect.value, context.evaluationContext);
+      return;
+    }
+    case "runAction": {
+      if (!context.actionIds.has(effect.actionId)) {
+        throw new RuntimeRuleEngineError(`Rule effect references unknown action "${effect.actionId}".`);
+      }
+      if (!context.plan.runActionIds.includes(effect.actionId)) {
+        context.plan.runActionIds.push(effect.actionId);
+      }
+      return;
+    }
+    case "refreshDatasource": {
+      if (!context.datasourceIds.has(effect.datasourceId)) {
+        throw new RuntimeRuleEngineError(`Rule effect references unknown datasource "${effect.datasourceId}".`);
+      }
+      if (!context.plan.refreshDatasourceIds.includes(effect.datasourceId)) {
+        context.plan.refreshDatasourceIds.push(effect.datasourceId);
+      }
+      return;
+    }
+  }
+}
+
+async function resolveRuleValue(
+  value: RuntimeRuleValueDefinition,
+  context: RuntimeRuleEvaluationContext
+): Promise<unknown> {
+  switch (value.source) {
+    case "literal":
+      return value.value;
+    case "state":
+      if (!(value.key in context.state)) {
+        throw new RuntimeRuleEngineError(`Rule value references unknown state key "${value.key}".`);
+      }
+      return context.state[value.key];
+    case "event":
+      if (!(value.key in context.event)) {
+        throw new RuntimeRuleEngineError(`Rule value references unknown event key "${value.key}".`);
+      }
+      return context.event[value.key as keyof typeof context.event];
+    case "function":
+      return resolveFunctionCall(value.call, context);
+  }
+}
+
+async function resolveFunctionCall(
+  call: { name: string; args: RuntimeRuleValueDefinition[] },
+  context: RuntimeRuleEvaluationContext
+): Promise<unknown> {
+  const resolvedArgs = await Promise.all(call.args.map((argument) => resolveRuleValue(argument, context)));
+  return context.functionRegistry.exec(call.name, resolvedArgs, context);
+}

--- a/packages/runtime/src/runtime-dsl-parser.ts
+++ b/packages/runtime/src/runtime-dsl-parser.ts
@@ -2,14 +2,17 @@ import type {
   RuntimeActionDefinition,
   RuntimeDatasourceDefinition,
   RuntimeNodeSchema,
+  RuntimeRuleDefinition,
   RuntimePageDsl
 } from "@zhongmiao/meta-lc-contracts";
 import { collectTemplateDependencies } from "./template-resolver";
 import {
+  collectRuleStateDependencies,
   type ParsedRuntimeActionDefinition,
   type ParsedRuntimeDatasourceDefinition,
   type ParsedRuntimeNodeSchema,
   type ParsedRuntimePageDsl,
+  type ParsedRuntimeRuleDefinition,
   RuntimeDslParseError,
   type RuntimeDslValidationIssue
 } from "./types";
@@ -29,17 +32,23 @@ export function parseRuntimePageDsl(input: RuntimePageDsl): ParsedRuntimePageDsl
     dependencies: collectTemplateDependencies(action),
     outputStateKeys: []
   }));
+  const rules = (input.rules ?? []).map<ParsedRuntimeRuleDefinition>((rule) => ({
+    ...rule,
+    stateDependencies: collectRuleStateDependencies(rule.condition.call)
+  }));
   const layoutTree = input.layoutTree.map((node) => parseLayoutNode(node));
 
   return {
     ...input,
     datasources,
     actions,
+    rules,
     layoutTree,
     stateKeys: Object.keys(input.state).sort((left, right) => left.localeCompare(right)),
     dependencies: {
       datasources: Object.fromEntries(datasources.map((datasource) => [datasource.id, datasource.dependencies])),
       actions: Object.fromEntries(actions.map((action) => [action.id, action.dependencies])),
+      rules: Object.fromEntries(rules.map((rule) => [rule.id, rule.stateDependencies])),
       layoutNodes: Object.fromEntries(flattenLayoutNodes(layoutTree).map((node) => [node.id, node.dependencies]))
     }
   };
@@ -68,9 +77,13 @@ function validateRuntimePageDsl(input: RuntimePageDsl): RuntimeDslValidationIssu
   if (!Array.isArray(input.layoutTree)) {
     issues.push({ path: "layoutTree", message: "must be an array." });
   }
+  if (input.rules !== undefined && !Array.isArray(input.rules)) {
+    issues.push({ path: "rules", message: "must be an array when provided." });
+  }
 
   collectDuplicateIdIssues(input.datasources, "datasources", issues);
   collectDuplicateIdIssues(input.actions, "actions", issues);
+  collectDuplicateRuleIdIssues(input.rules ?? [], issues);
   collectLayoutIssues(input.layoutTree, "layoutTree", issues);
 
   input.datasources.forEach((datasource, index) => {
@@ -88,6 +101,24 @@ function validateRuntimePageDsl(input: RuntimePageDsl): RuntimeDslValidationIssu
     }
     if (!Array.isArray(action.steps) || action.steps.length === 0) {
       issues.push({ path: `actions[${index}].steps`, message: "must contain at least one step." });
+    }
+  });
+
+  (input.rules ?? []).forEach((rule, index) => {
+    if (!rule.id?.trim()) {
+      issues.push({ path: `rules[${index}].id`, message: "is required." });
+    }
+    if (!rule.trigger?.trim()) {
+      issues.push({ path: `rules[${index}].trigger`, message: "is required." });
+    }
+    if (!rule.condition?.call?.name?.trim()) {
+      issues.push({ path: `rules[${index}].condition.call.name`, message: "is required." });
+    }
+    if (!Array.isArray(rule.condition?.call?.args)) {
+      issues.push({ path: `rules[${index}].condition.call.args`, message: "must be an array." });
+    }
+    if (!Array.isArray(rule.effects) || rule.effects.length === 0) {
+      issues.push({ path: `rules[${index}].effects`, message: "must contain at least one effect." });
     }
   });
 
@@ -145,6 +176,23 @@ function collectLayoutIssues(
   };
 
   nodes.forEach((node, index) => visit(node, `${path}[${index}]`));
+}
+
+function collectDuplicateRuleIdIssues(
+  rules: RuntimeRuleDefinition[],
+  issues: RuntimeDslValidationIssue[]
+): void {
+  const seen = new Set<string>();
+  rules.forEach((rule, index) => {
+    if (!rule.id?.trim()) {
+      return;
+    }
+    if (seen.has(rule.id)) {
+      issues.push({ path: `rules[${index}].id`, message: `duplicates "${rule.id}".` });
+      return;
+    }
+    seen.add(rule.id);
+  });
 }
 
 function parseLayoutNode(node: RuntimeNodeSchema): ParsedRuntimeNodeSchema {

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -1,6 +1,10 @@
 import type {
   RuntimeDependencyTargetKind,
   RuntimeDependencyTargetRef,
+  RuntimeFunctionCallDefinition,
+  RuntimeRuleDefinition,
+  RuntimeRuleTrigger,
+  RuntimeRuleValueDefinition,
   RuntimeRefreshEvent,
   RuntimeRefreshPlan,
   RuntimeActionDefinition,
@@ -24,14 +28,20 @@ export interface ParsedRuntimeNodeSchema extends RuntimeNodeSchema {
   children?: ParsedRuntimeNodeSchema[];
 }
 
+export interface ParsedRuntimeRuleDefinition extends RuntimeRuleDefinition {
+  stateDependencies: string[];
+}
+
 export interface ParsedRuntimePageDsl extends RuntimePageDsl {
   datasources: ParsedRuntimeDatasourceDefinition[];
   actions: ParsedRuntimeActionDefinition[];
+  rules: ParsedRuntimeRuleDefinition[];
   layoutTree: ParsedRuntimeNodeSchema[];
   stateKeys: string[];
   dependencies: {
     datasources: Record<string, RuntimeTemplateDependency[]>;
     actions: Record<string, RuntimeTemplateDependency[]>;
+    rules: Record<string, string[]>;
     layoutNodes: Record<string, RuntimeTemplateDependency[]>;
   };
 }
@@ -72,6 +82,20 @@ export class RuntimeDependencyGraphError extends Error {
   }
 }
 
+export class RuntimeFunctionRegistryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RuntimeFunctionRegistryError";
+  }
+}
+
+export class RuntimeRuleEngineError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RuntimeRuleEngineError";
+  }
+}
+
 export interface PlanRuntimeRefreshResult extends RuntimeRefreshPlan {}
 
 export function createRuntimeTargetRef(kind: RuntimeDependencyTargetKind, id: string): RuntimeDependencyTargetRef {
@@ -106,4 +130,79 @@ export function createRefreshPlan(
     datasourceIds: targetOrder.filter((ref) => ref.kind === "datasource").map((ref) => ref.id),
     actionIds: targetOrder.filter((ref) => ref.kind === "action").map((ref) => ref.id)
   };
+}
+
+export interface RuntimeFunctionExecutionContext {
+  state: Record<string, unknown>;
+  event: RuntimeRefreshEvent;
+  parsedDsl: ParsedRuntimePageDsl;
+  graph: RuntimeDependencyGraph;
+}
+
+export type RuntimeFunctionHandler = (
+  args: unknown[],
+  context: RuntimeFunctionExecutionContext
+) => unknown | Promise<unknown>;
+
+export interface RuntimeFunctionRegistry {
+  register(name: string, handler: RuntimeFunctionHandler): void;
+  exec(name: string, args: unknown[], context: RuntimeFunctionExecutionContext): Promise<unknown>;
+}
+
+export interface RuntimeRuleEffectsPlan {
+  triggeredBy: RuntimeRefreshEvent;
+  matchedRuleIds: string[];
+  patchState: Record<string, unknown>;
+  runActionIds: string[];
+  refreshDatasourceIds: string[];
+}
+
+export interface RuntimeRuleEvaluationContext extends RuntimeFunctionExecutionContext {
+  functionRegistry: RuntimeFunctionRegistry;
+}
+
+export interface RuntimeRuleEvaluationRequest {
+  event: RuntimeRefreshEvent;
+  state: Record<string, unknown>;
+  parsedDsl: ParsedRuntimePageDsl;
+  graph: RuntimeDependencyGraph;
+  functionRegistry: RuntimeFunctionRegistry;
+}
+
+export function createEmptyRuleEffectsPlan(triggeredBy: RuntimeRefreshEvent): RuntimeRuleEffectsPlan {
+  return {
+    triggeredBy,
+    matchedRuleIds: [],
+    patchState: {},
+    runActionIds: [],
+    refreshDatasourceIds: []
+  };
+}
+
+export function isSupportedRuleTrigger(value: string): value is RuntimeRuleTrigger {
+  return value === "state.changed" || value === "mutation.succeeded";
+}
+
+export function collectRuleStateDependencies(value: RuntimeRuleValueDefinition | RuntimeFunctionCallDefinition): string[] {
+  const keys = new Set<string>();
+  const visitValue = (current: RuntimeRuleValueDefinition): void => {
+    if (current.source === "state") {
+      keys.add(current.key);
+      return;
+    }
+    if (current.source === "function") {
+      current.call.args.forEach((argument) => visitValue(argument));
+    }
+  };
+  const visitCall = (call: RuntimeFunctionCallDefinition): void => {
+    call.args.forEach((argument) => visitValue(argument));
+  };
+
+  if ("name" in value) {
+    visitCall(value);
+  } else {
+    visitValue(value);
+  }
+
+  return [...keys].sort((left, right) => left.localeCompare(right));
 }

--- a/packages/runtime/test/dependency-graph.test.ts
+++ b/packages/runtime/test/dependency-graph.test.ts
@@ -81,6 +81,7 @@ function createRuntimeDsl(): RuntimePageDsl {
         }
       }
     ],
+    rules: [],
     layoutTree: []
   };
 }

--- a/packages/runtime/test/function-registry.test.ts
+++ b/packages/runtime/test/function-registry.test.ts
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createFunctionRegistry, RuntimeFunctionRegistryError } from "../src";
+
+test("createFunctionRegistry registers and executes built-in functions", async () => {
+  const registry = createFunctionRegistry();
+
+  assert.equal(
+    await registry.exec("eq", ["PAID", "PAID"], {} as never),
+    true
+  );
+  assert.equal(
+    await registry.exec("notEmpty", [["USER"]], {} as never),
+    true
+  );
+  assert.equal(
+    await registry.exec("includes", [["USER", "ADMIN"], "ADMIN"], {} as never),
+    true
+  );
+});
+
+test("createFunctionRegistry supports custom handlers and fails on unknown functions", async () => {
+  const registry = createFunctionRegistry();
+  registry.register("concat", ([left, right]) => `${left}${right}`);
+
+  assert.equal(await registry.exec("concat", ["meta", "-lc"], {} as never), "meta-lc");
+
+  await assert.rejects(
+    () => registry.exec("missing", [], {} as never),
+    (error: unknown) => {
+      assert.ok(error instanceof RuntimeFunctionRegistryError);
+      assert.equal(error.message, 'Runtime function "missing" is not registered.');
+      return true;
+    }
+  );
+});

--- a/packages/runtime/test/rule-engine.test.ts
+++ b/packages/runtime/test/rule-engine.test.ts
@@ -1,0 +1,260 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { RuntimePageDsl } from "@zhongmiao/meta-lc-contracts";
+import {
+  buildDependencyGraph,
+  createFunctionRegistry,
+  evaluateRules,
+  parseRuntimePageDsl,
+  RuntimeRuleEngineError
+} from "../src";
+
+function createRuntimeDsl(): RuntimePageDsl {
+  return {
+    schemaVersion: "runtime-page-dsl.v1",
+    pageMeta: {
+      id: "orders-rule-page",
+      title: "Orders Rule Page"
+    },
+    state: {
+      filter_status: "PAID",
+      selectedOrderId: "",
+      shouldReload: false,
+      roles: ["USER"]
+    },
+    datasources: [
+      {
+        id: "orders-query-datasource",
+        type: "rest",
+        request: {
+          params: {
+            status: "{{state.filter_status}}"
+          }
+        }
+      }
+    ],
+    actions: [
+      {
+        id: "load-order-detail-action",
+        trigger: "state.changed",
+        steps: [{ type: "callDatasource", datasourceId: "orders-query-datasource" }]
+      },
+      {
+        id: "save-order-action",
+        steps: [{ type: "callMutation" }]
+      }
+    ],
+    rules: [
+      {
+        id: "reload-paid-orders-rule",
+        trigger: "state.changed",
+        condition: {
+          call: {
+            name: "eq",
+            args: [
+              { source: "state", key: "filter_status" },
+              { source: "literal", value: "PAID" }
+            ]
+          }
+        },
+        effects: [
+          {
+            type: "refreshDatasource",
+            datasourceId: "orders-query-datasource"
+          },
+          {
+            type: "setState",
+            stateKey: "shouldReload",
+            value: {
+              source: "literal",
+              value: true
+            }
+          }
+        ]
+      },
+      {
+        id: "reload-on-save-rule",
+        trigger: "mutation.succeeded",
+        condition: {
+          call: {
+            name: "eq",
+            args: [
+              { source: "event", key: "actionId" },
+              { source: "literal", value: "save-order-action" }
+            ]
+          }
+        },
+        effects: [
+          {
+            type: "runAction",
+            actionId: "load-order-detail-action"
+          }
+        ]
+      }
+    ],
+    layoutTree: []
+  };
+}
+
+test("evaluateRules only runs matching state.changed rules and returns stable effects", async () => {
+  const parsedDsl = parseRuntimePageDsl(createRuntimeDsl());
+  const graph = buildDependencyGraph(parsedDsl);
+  const plan = await evaluateRules({
+    event: {
+      type: "state.changed",
+      stateKeys: ["filter_status"]
+    },
+    state: parsedDsl.state,
+    parsedDsl,
+    graph,
+    functionRegistry: createFunctionRegistry()
+  });
+
+  assert.deepEqual(plan.matchedRuleIds, ["reload-paid-orders-rule"]);
+  assert.deepEqual(plan.refreshDatasourceIds, ["orders-query-datasource"]);
+  assert.deepEqual(plan.runActionIds, []);
+  assert.deepEqual(plan.patchState, {
+    shouldReload: true
+  });
+});
+
+test("evaluateRules only runs matching mutation.succeeded rules", async () => {
+  const parsedDsl = parseRuntimePageDsl(createRuntimeDsl());
+  const graph = buildDependencyGraph(parsedDsl);
+  const plan = await evaluateRules({
+    event: {
+      type: "mutation.succeeded",
+      actionId: "save-order-action",
+      operation: "update"
+    },
+    state: parsedDsl.state,
+    parsedDsl,
+    graph,
+    functionRegistry: createFunctionRegistry()
+  });
+
+  assert.deepEqual(plan.matchedRuleIds, ["reload-on-save-rule"]);
+  assert.deepEqual(plan.runActionIds, ["load-order-detail-action"]);
+  assert.deepEqual(plan.refreshDatasourceIds, []);
+  assert.deepEqual(plan.patchState, {});
+});
+
+test("evaluateRules ignores unrelated triggers and unchanged state dependencies", async () => {
+  const parsedDsl = parseRuntimePageDsl(createRuntimeDsl());
+  const graph = buildDependencyGraph(parsedDsl);
+
+  const statePlan = await evaluateRules({
+    event: {
+      type: "state.changed",
+      stateKeys: ["selectedOrderId"]
+    },
+    state: parsedDsl.state,
+    parsedDsl,
+    graph,
+    functionRegistry: createFunctionRegistry()
+  });
+
+  assert.deepEqual(statePlan.matchedRuleIds, []);
+
+  const mutationPlan = await evaluateRules({
+    event: {
+      type: "mutation.succeeded",
+      actionId: "load-order-detail-action",
+      operation: "update"
+    },
+    state: parsedDsl.state,
+    parsedDsl,
+    graph,
+    functionRegistry: createFunctionRegistry()
+  });
+
+  assert.deepEqual(mutationPlan.matchedRuleIds, []);
+});
+
+test("evaluateRules fails with stable errors for unknown effect targets and state keys", async () => {
+  const invalidDsl = parseRuntimePageDsl({
+    ...createRuntimeDsl(),
+    rules: [
+      {
+        id: "broken-rule",
+        trigger: "state.changed",
+        condition: {
+          call: {
+            name: "notEmpty",
+            args: [{ source: "state", key: "filter_status" }]
+          }
+        },
+        effects: [
+          {
+            type: "refreshDatasource",
+            datasourceId: "missing-datasource"
+          }
+        ]
+      }
+    ]
+  });
+
+  await assert.rejects(
+    () =>
+      evaluateRules({
+        event: {
+          type: "state.changed",
+          stateKeys: ["filter_status"]
+        },
+        state: invalidDsl.state,
+        parsedDsl: invalidDsl,
+        graph: buildDependencyGraph(invalidDsl),
+        functionRegistry: createFunctionRegistry()
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof RuntimeRuleEngineError);
+      assert.equal(error.message, 'Rule effect references unknown datasource "missing-datasource".');
+      return true;
+    }
+  );
+
+  const invalidStateDsl = parseRuntimePageDsl({
+    ...createRuntimeDsl(),
+    rules: [
+      {
+        id: "broken-state-rule",
+        trigger: "state.changed",
+        condition: {
+          call: {
+            name: "notEmpty",
+            args: [{ source: "literal", value: "ok" }]
+          }
+        },
+        effects: [
+          {
+            type: "setState",
+            stateKey: "missingState",
+            value: {
+              source: "literal",
+              value: true
+            }
+          }
+        ]
+      }
+    ]
+  });
+
+  await assert.rejects(
+    () =>
+      evaluateRules({
+        event: {
+          type: "state.changed",
+          stateKeys: ["filter_status"]
+        },
+        state: invalidStateDsl.state,
+        parsedDsl: invalidStateDsl,
+        graph: buildDependencyGraph(invalidStateDsl),
+        functionRegistry: createFunctionRegistry()
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof RuntimeRuleEngineError);
+      assert.equal(error.message, 'Rule effect references unknown state key "missingState".');
+      return true;
+    }
+  );
+});

--- a/packages/runtime/test/runtime-dsl-parser.test.ts
+++ b/packages/runtime/test/runtime-dsl-parser.test.ts
@@ -50,6 +50,27 @@ function createRuntimeDsl(): RuntimePageDsl {
         ]
       }
     ],
+    rules: [
+      {
+        id: "reload-rule",
+        trigger: "state.changed",
+        condition: {
+          call: {
+            name: "eq",
+            args: [
+              { source: "state", key: "filter_status" },
+              { source: "literal", value: "PAID" }
+            ]
+          }
+        },
+        effects: [
+          {
+            type: "refreshDatasource",
+            datasourceId: "orders-query-datasource"
+          }
+        ]
+      }
+    ],
     layoutTree: [
       {
         id: "page-root",
@@ -94,6 +115,7 @@ test("parseRuntimePageDsl parses the minimal runtime dsl and collects dependenci
       expression: "{{state.tenantId}}"
     }
   ]);
+  assert.deepEqual(parsed.dependencies.rules["reload-rule"], ["filter_status"]);
   assert.deepEqual(parsed.dependencies.layoutNodes["page-root"], [
     {
       source: "state",
@@ -112,7 +134,20 @@ test("parseRuntimePageDsl throws a stable parse error for missing required field
           id: "",
           title: ""
         },
-        actions: [{ id: "search-action", steps: [] }]
+        actions: [{ id: "search-action", steps: [] }],
+        rules: [
+          {
+            id: "reload-rule",
+            trigger: "" as never,
+            condition: {
+              call: {
+                name: "",
+                args: []
+              }
+            },
+            effects: []
+          }
+        ]
       }),
     (error: unknown) => {
       assert.ok(error instanceof RuntimeDslParseError);
@@ -129,6 +164,18 @@ test("parseRuntimePageDsl throws a stable parse error for missing required field
         {
           path: "actions[0].steps",
           message: "must contain at least one step."
+        },
+        {
+          path: "rules[0].trigger",
+          message: "is required."
+        },
+        {
+          path: "rules[0].condition.call.name",
+          message: "is required."
+        },
+        {
+          path: "rules[0].effects",
+          message: "must contain at least one effect."
         }
       ]);
       return true;


### PR DESCRIPTION
## Summary
- add minimal runtime rule and function contracts to `RuntimePageDsl`
- add `FunctionRegistry` and `RuleEngine` so `state.changed` and `mutation.succeeded` events can produce rule-driven state patches, action runs, and datasource refreshes
- extend runtime/contracts tests and changelogs to cover structured rule evaluation and stable error semantics

## Validation
- `pnpm --filter @zhongmiao/meta-lc-contracts test`
- `pnpm --filter @zhongmiao/meta-lc-runtime test`
- `pnpm -r test`
- `pnpm -r build`
- `pnpm lint`
- `pnpm version:check`
- `pnpm query-gate`
- `query-gate` request ids:
  - `e2e-tenant-b-1776496157`
  - `e2e-mutation-create-1776496157`
  - `e2e-mutation-delete-1776496157`

## Risk / Rollback
- risk: runtime rule evaluation now introduces a second event-driven planning layer on top of dependency graph refresh planning, so malformed rules or missing registry functions will fail the runtime plan explicitly
- rollback: revert commit `99fcbba` to remove rule/function evaluation and restore the dependency-graph-only runtime baseline
