### PR TITLE
fix: move local BFF default port to 6001

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # BFF runtime
-PORT=6000
+PORT=6001
 NODE_ENV=development
 
 # Bootstrap mode: auto | manual

--- a/infra/README.md
+++ b/infra/README.md
@@ -31,6 +31,6 @@ The gate validates:
 
 ## Defaults
 
-- `PORT=6000`
+- `PORT=6001`
 - `LC_DB_BOOTSTRAP_MODE=auto` (dev/test)
 - databases: `meta_db`, `business_db`, `audit_db`

--- a/packages/bff/scripts/e2e-query-isolation.sh
+++ b/packages/bff/scripts/e2e-query-isolation.sh
@@ -15,8 +15,8 @@ if [[ -f "${ENV_FILE}" ]]; then
   set +a
 fi
 
-BFF_URL="${BFF_URL:-http://127.0.0.1:6000}"
-PORT="${PORT:-6000}"
+BFF_URL="${BFF_URL:-http://127.0.0.1:6001}"
+PORT="${PORT:-6001}"
 RUN_ID="${RUN_ID:-$(date +%s)}"
 NODE_ENV="${NODE_ENV:-development}"
 LC_DB_BOOTSTRAP_MODE="${LC_DB_BOOTSTRAP_MODE:-auto}"

--- a/packages/bff/src/main.ts
+++ b/packages/bff/src/main.ts
@@ -13,7 +13,9 @@ export async function startBffServer(): Promise<void> {
     origin: true,
     credentials: true
   });
-  await app.listen(process.env.PORT ? Number(process.env.PORT) : 6000);
+  const port = process.env.PORT ? Number(process.env.PORT) : 6001;
+  const host = process.env.HOST?.trim() || "0.0.0.0";
+  await app.listen(port, host);
 }
 
 if (require.main === module) {


### PR DESCRIPTION
## Summary
- change the local BFF default port from 6000 to 6001 because browsers block 6000 as an unsafe port
- keep the BFF listening on an explicit host for local integration
- align example config, infra docs, and the query isolation script with the new safe default port

## Verification
- pnpm --filter @zhongmiao/meta-lc-bff-server test
- manual health and query checks against local BFF on port 6001