### PR TITLE
feat(runtime): tighten boundaries and expand permission gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - docs(changelog): establish bilingual root/package changelog baselines for the platform workspace.
 - feat(runtime): add dependency graph planning so runtime state and mutation events can drive deterministic auto-refresh execution.
 - feat(runtime): add a minimal rule engine and function registry so runtime events can compute rule-driven patches, actions, and datasource refreshes.
+- docs(runtime): sync the runtime contract, frontend integration, migration guidance, and testing playbook to the current manager-first implementation.
+- fix(boundaries): tighten direct `pg` access down to explicit BFF/datasource/kernel entry points and remove the audit package from the transitional DB-driver allowlist.
 
 ## 0.1.0 (2026-04-18)
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -7,6 +7,8 @@
 - docs(changelog): 为平台工作区建立根级与包级双语 changelog 基线。
 - feat(runtime): 新增依赖图规划能力，让 runtime 可由 state 与 mutation 事件驱动确定性自动刷新执行。
 - feat(runtime): 新增最小 RuleEngine 与 FunctionRegistry，让 runtime 事件可计算规则驱动的 state patch、action 与 datasource refresh。
+- docs(runtime): 将 runtime contract、前端接入、迁移指引与测试手册同步到当前 manager-first 实现口径。
+- fix(boundaries): 将 `pg` 直连点收紧到显式的 BFF/datasource/kernel 入口，并把 audit 包移出过渡白名单。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/audit/CHANGELOG.md
+++ b/packages/audit/CHANGELOG.md
@@ -3,6 +3,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 ## [Unreleased]
 
 - chore(package): adopt the `@zhongmiao/meta-lc-audit` scoped package identity for release governance.
+- refactor(boundary): narrow the package back to audit contracts and compatibility helpers so audit DB execution stays inside the BFF boundary.
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/audit/CHANGELOG.zh-CN.md
+++ b/packages/audit/CHANGELOG.zh-CN.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-audit` 正式包名。
+- refactor(boundary): 将本包收回为审计契约与兼容辅助层，避免审计数据库执行职责继续外溢到 BFF 边界之外。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -10,12 +10,10 @@
   },
   "devDependencies": {
     "@types/node": "^22.10.2",
-    "typescript": "^5.7.2",
-    "@types/pg": "^8.11.10"
+    "typescript": "^5.7.2"
   },
   "dependencies": {
-    "@zhongmiao/meta-lc-contracts": "workspace:*",
-    "pg": "^8.13.1"
+    "@zhongmiao/meta-lc-contracts": "workspace:*"
   },
   "main": "dist/audit/src/index.js",
   "types": "dist/audit/src/index.d.ts"

--- a/packages/audit/src/index.ts
+++ b/packages/audit/src/index.ts
@@ -1,4 +1,3 @@
-import { Pool } from "pg";
 import type { QueryAuditLog } from "@zhongmiao/meta-lc-contracts";
 
 export interface MutationAuditLog {
@@ -34,89 +33,51 @@ export interface AccessAuditLog {
 }
 
 export interface AuditDbConfig {
-  connectionString: string;
+  connectionString?: string;
+}
+
+export interface AuditSink {
+  logQuery(log: QueryAuditLog): Promise<void>;
+  logMutation(log: MutationAuditLog): Promise<void>;
+  logMigration(log: MigrationAuditLog): Promise<void>;
+  logAccess(log: AccessAuditLog): Promise<void>;
+  close?(): Promise<void>;
+}
+
+function createNoopAuditSink(): AuditSink {
+  return {
+    async logQuery(): Promise<void> {},
+    async logMutation(): Promise<void> {},
+    async logMigration(): Promise<void> {},
+    async logAccess(): Promise<void> {},
+    async close(): Promise<void> {}
+  };
 }
 
 export class AuditService {
-  private readonly pool: Pool;
+  private readonly sink: AuditSink;
 
-  constructor(config: AuditDbConfig) {
-    this.pool = new Pool({ connectionString: config.connectionString });
+  constructor(_config: AuditDbConfig = {}, sink?: AuditSink) {
+    this.sink = sink ?? createNoopAuditSink();
   }
 
   async logQuery(log: QueryAuditLog): Promise<void> {
-    await this.pool.query(
-      `INSERT INTO query_logs (
-        request_id, tenant_id, user_id, query_dsl, final_sql, duration_ms, result_count, status, error_message
-      ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`,
-      [
-        log.requestId,
-        log.tenantId,
-        log.userId,
-        log.queryDsl,
-        log.finalSql,
-        log.durationMs,
-        log.resultCount,
-        log.status,
-        log.errorMessage ?? null
-      ]
-    );
+    await this.sink.logQuery(log);
   }
 
   async logMutation(log: MutationAuditLog): Promise<void> {
-    await this.pool.query(
-      `INSERT INTO mutation_logs (
-        request_id, tenant_id, user_id, table_name, action, payload, status, error_message
-      ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8)`,
-      [
-        log.requestId,
-        log.tenantId,
-        log.userId,
-        log.table,
-        log.action,
-        log.payload,
-        log.status,
-        log.errorMessage ?? null
-      ]
-    );
+    await this.sink.logMutation(log);
   }
 
   async logMigration(log: MigrationAuditLog): Promise<void> {
-    await this.pool.query(
-      `INSERT INTO migration_logs (
-        request_id, app_id, from_version, to_version, statement, status, duration_ms, error_message
-      ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8)`,
-      [
-        log.requestId,
-        log.appId,
-        log.fromVersion,
-        log.toVersion,
-        log.statement,
-        log.status,
-        log.durationMs,
-        log.errorMessage ?? null
-      ]
-    );
+    await this.sink.logMigration(log);
   }
 
   async logAccess(log: AccessAuditLog): Promise<void> {
-    await this.pool.query(
-      `INSERT INTO access_logs (
-        request_id, tenant_id, user_id, resource, action, status, reason
-      ) VALUES ($1,$2,$3,$4,$5,$6,$7)`,
-      [
-        log.requestId,
-        log.tenantId,
-        log.userId,
-        log.resource,
-        log.action,
-        log.status,
-        log.reason ?? null
-      ]
-    );
+    await this.sink.logAccess(log);
   }
 
   async close(): Promise<void> {
-    await this.pool.end();
+    await this.sink.close?.();
   }
 }

--- a/packages/bff/CHANGELOG.md
+++ b/packages/bff/CHANGELOG.md
@@ -4,6 +4,8 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 - chore(package): adopt the `@zhongmiao/meta-lc-bff` scoped package identity for release governance.
 - fix(local-dev): move the default BFF local port to `6001` and bind an explicit host so browser-based integration can reach the service without unsafe-port blocking.
+- test(permission-gate): expand the query/mutation gate baseline to cover `SELF`, `DEPT_AND_CHILDREN`, and `CUSTOM_ORG_SET` permission paths in addition to the existing `DEPT` denied checks.
+- feat(permission-seed): add custom-org and self-scope demo identities so org-scope policies can be exercised in e2e and remote bootstrap flows.
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/bff/CHANGELOG.zh-CN.md
+++ b/packages/bff/CHANGELOG.zh-CN.md
@@ -4,6 +4,8 @@
 
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-bff` 正式包名。
 - fix(local-dev): 将 BFF 本地默认端口调整为 `6001`，并显式绑定 host，避免浏览器因 unsafe port 策略阻断联调访问。
+- test(permission-gate): 将 query/mutation gate 扩展到 `SELF`、`DEPT_AND_CHILDREN`、`CUSTOM_ORG_SET` 权限路径，不再只覆盖现有 `DEPT` denied 样例。
+- feat(permission-seed): 新增 custom-org 与 self-scope 演示身份，供 e2e 与远端 bootstrap 场景稳定复现组织域权限。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/bff/scripts/e2e-query-isolation.sh
+++ b/packages/bff/scripts/e2e-query-isolation.sh
@@ -77,6 +77,17 @@ run_mutation_request() {
     -d "${payload}"
 }
 
+run_query_request() {
+  local request_id="$1"
+  local payload="$2"
+  local output_file="$3"
+
+  curl -sS -o "${output_file}" -w "%{http_code}" -X POST "${BFF_URL}/query" \
+    -H "content-type: application/json" \
+    -H "x-request-id: ${request_id}" \
+    -d "${payload}"
+}
+
 run_query_and_assert() {
   local tenant_id="$1"
   local user_id="$2"
@@ -238,6 +249,69 @@ process.stdout.write("0");
   printf "%s %s\n" "${request_id}" "${row_count}"
 }
 
+query_rows_and_assert_ids() {
+  local tenant_id="$1"
+  local user_id="$2"
+  local roles_json="$3"
+  local keyword="$4"
+  local status_filter="$5"
+  local org_id_filter="$6"
+  local expected_ids_csv="$7"
+  local request_id="$8"
+  local output_file="$9"
+  local filters_block=""
+
+  filters_block="\"keyword\": \"${keyword}\""
+  if [[ -n "${status_filter}" ]]; then
+    filters_block="${filters_block},
+    \"status\": \"${status_filter}\""
+  fi
+  if [[ -n "${org_id_filter}" ]]; then
+    filters_block="${filters_block},
+    \"org_id\": \"${org_id_filter}\""
+  fi
+
+  curl -fsS -X POST "${BFF_URL}/query" \
+    -H "content-type: application/json" \
+    -H "x-request-id: ${request_id}" \
+    -d "$(cat <<JSON
+{
+  "table": "orders",
+  "fields": ["id", "owner", "status", "tenant_id", "created_by", "org_id"],
+  "filters": {
+    ${filters_block}
+  },
+  "tenantId": "${tenant_id}",
+  "userId": "${user_id}",
+  "roles": ${roles_json},
+  "limit": 100
+}
+JSON
+)" > "${output_file}"
+
+  node -e '
+const fs = require("node:fs");
+const [file, tenantId, expectedIdsCsv] = process.argv.slice(1);
+const expectedIds = expectedIdsCsv.split(",").filter(Boolean).sort();
+const data = JSON.parse(fs.readFileSync(file, "utf8"));
+if (!Array.isArray(data.rows)) {
+  console.error("rows is not an array");
+  process.exit(1);
+}
+const actualIds = data.rows.map((row) => row.id).sort();
+for (const row of data.rows) {
+  if (row.tenant_id !== tenantId) {
+    console.error("tenant leakage", row);
+    process.exit(1);
+  }
+}
+if (JSON.stringify(actualIds) !== JSON.stringify(expectedIds)) {
+  console.error("unexpected ids", { actualIds, expectedIds });
+  process.exit(1);
+}
+' "${output_file}" "${tenant_id}" "${expected_ids_csv}"
+}
+
 assert_audit_record() {
   local request_id="$1"
   local status="$2"
@@ -264,6 +338,22 @@ assert_mutation_audit_record() {
 
   if [[ "${count}" -lt 1 ]]; then
     log "mutation audit assertion failed for request_id=${request_id}, operation=${operation}, status=${status}"
+    exit 1
+  fi
+}
+
+assert_mutation_permission_details() {
+  local request_id="$1"
+  local operation="$2"
+  local status="$3"
+  local tenant_id="$4"
+  local user_id="$5"
+
+  local count
+  count="$(query_mutation_permission_details_count "${request_id}" "${operation}" "${status}" "${tenant_id}" "${user_id}" | tr -d '\r')"
+
+  if [[ "${count}" -lt 1 ]]; then
+    log "mutation permission detail assertion failed for request_id=${request_id}, operation=${operation}, status=${status}"
     exit 1
   fi
 }
@@ -340,6 +430,39 @@ assert_query_denied() {
 }
 JSON
 )")"
+
+  if [[ "${status_code}" != "403" ]]; then
+    cat "${output_file}"
+    exit 1
+  fi
+
+  assert_audit_record "${request_id}" "denied" "NULL"
+  assert_query_permission_details "${request_id}" "denied" "${tenant_id}" "${user_id}"
+}
+
+assert_query_denied_with_roles() {
+  local request_id="$1"
+  local tenant_id="$2"
+  local user_id="$3"
+  local roles_json="$4"
+  local org_id="$5"
+  local output_file="$6"
+
+  local status_code
+  status_code="$(run_query_request "${request_id}" "$(cat <<JSON
+{
+  "table": "orders",
+  "fields": ["id", "owner", "org_id", "tenant_id", "created_by"],
+  "filters": {
+    "org_id": "${org_id}"
+  },
+  "tenantId": "${tenant_id}",
+  "userId": "${user_id}",
+  "roles": ${roles_json},
+  "limit": 20
+}
+JSON
+)" "${output_file}")"
 
   if [[ "${status_code}" != "403" ]]; then
     cat "${output_file}"
@@ -429,8 +552,10 @@ const client = new Client({
     const rowCountCondition =
       expectedRowCount === "NULL"
         ? "row_count IS NULL"
+        : expectedRowCount === "ANY"
+          ? "1=1"
         : "row_count = $3::INT";
-    const params = expectedRowCount === "NULL"
+    const params = expectedRowCount === "NULL" || expectedRowCount === "ANY"
       ? [requestId, status]
       : [requestId, status, Number(expectedRowCount)];
     const result = await client.query(
@@ -597,6 +722,56 @@ NODE
   )
 }
 
+query_mutation_permission_details_count() {
+  local request_id="$1"
+  local operation="$2"
+  local status="$3"
+  local tenant_id="$4"
+  local user_id="$5"
+
+  (
+    cd "${ROOT_DIR}"
+    node - "${LC_DB_HOST}" "${LC_DB_PORT}" "${LC_DB_USER}" "${LC_DB_PASSWORD}" "${LC_DB_AUDIT_NAME}" "${LC_DB_SSL}" "${request_id}" "${operation}" "${status}" "${tenant_id}" "${user_id}" <<'NODE'
+const { Client } = require("pg");
+
+const [host, port, user, password, database, sslRaw, requestId, operation, status, tenantId, userId] = process.argv.slice(2);
+const client = new Client({
+  host,
+  port: Number(port),
+  user,
+  password,
+  database,
+  ssl: sslRaw === "true" ? { rejectUnauthorized: false } : false
+});
+
+(async () => {
+  await client.connect();
+  try {
+    const result = await client.query(
+      `SELECT COUNT(*)::INT AS count
+       FROM mutation_logs
+       WHERE request_id = $1
+         AND operation = $2
+         AND status = $3
+         AND tenant_id = $4
+         AND user_id = $5
+         AND permission_scope IS NOT NULL
+         AND permission_org_count IS NOT NULL
+         AND permission_reason IS NOT NULL;`,
+      [requestId, operation, status, tenantId, userId]
+    );
+    process.stdout.write(String(result.rows[0]?.count ?? 0));
+  } finally {
+    await client.end();
+  }
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+NODE
+  )
+}
+
 query_business_order_unchanged_count() {
   local order_id="$1"
   local expected_owner="$2"
@@ -745,6 +920,35 @@ assert_audit_record "${failure_request_id}" "failure" "NULL"
 log "validating query permission denied sample"
 query_denied_request_id="e2e-query-denied-${RUN_ID}"
 assert_query_denied "${query_denied_request_id}" "tenant-a" "demo-tenant-a-user" "dept-b" "${TMP_DIR}/query-denied.json"
+log "validating SELF query success"
+self_query_request_id="e2e-self-query-${RUN_ID}"
+query_rows_and_assert_ids "tenant-a" "self-tenant-a-user" '["SELF_ONLY"]' "SO-A" "active" "" "SO-A3001" "${self_query_request_id}" "${TMP_DIR}/self-query.json"
+assert_audit_record "${self_query_request_id}" "success" "ANY"
+assert_query_permission_details "${self_query_request_id}" "success" "tenant-a" "self-tenant-a-user"
+
+log "validating SELF query denied sample"
+self_query_denied_request_id="e2e-self-query-denied-${RUN_ID}"
+assert_query_denied_with_roles "${self_query_denied_request_id}" "tenant-a" "self-tenant-a-user" '["SELF_ONLY"]' "dept-a" "${TMP_DIR}/self-query-denied.json"
+
+log "validating manager query success"
+manager_query_request_id="e2e-manager-query-${RUN_ID}"
+query_rows_and_assert_ids "tenant-a" "manager-tenant-a" '["MANAGER"]' "SO-A" "active" "" "SO-A1001,SO-A2001,SO-A3001" "${manager_query_request_id}" "${TMP_DIR}/manager-query.json"
+assert_audit_record "${manager_query_request_id}" "success" "ANY"
+assert_query_permission_details "${manager_query_request_id}" "success" "tenant-a" "manager-tenant-a"
+
+log "validating manager query denied sample"
+manager_query_denied_request_id="e2e-manager-query-denied-${RUN_ID}"
+assert_query_denied_with_roles "${manager_query_denied_request_id}" "tenant-a" "manager-tenant-a" '["MANAGER"]' "dept-c" "${TMP_DIR}/manager-query-denied.json"
+
+log "validating custom org query success"
+custom_query_request_id="e2e-custom-query-${RUN_ID}"
+query_rows_and_assert_ids "tenant-a" "custom-tenant-a-user" '["CUSTOM_SUPPORT"]' "SO-A" "active" "" "SO-A2001" "${custom_query_request_id}" "${TMP_DIR}/custom-query.json"
+assert_audit_record "${custom_query_request_id}" "success" "ANY"
+assert_query_permission_details "${custom_query_request_id}" "success" "tenant-a" "custom-tenant-a-user"
+
+log "validating custom org query denied sample"
+custom_query_denied_request_id="e2e-custom-query-denied-${RUN_ID}"
+assert_query_denied_with_roles "${custom_query_denied_request_id}" "tenant-a" "custom-tenant-a-user" '["CUSTOM_SUPPORT"]' "dept-a" "${TMP_DIR}/custom-query-denied.json"
 
 tenant_id="tenant-a"
 user_id="demo-tenant-a-user"
@@ -783,6 +987,7 @@ if (data.rowCount !== 1 || data.row?.id !== process.argv[2]) {
 }
 ' "${TMP_DIR}/mutation-create.json" "${test_order_id}"
 assert_mutation_audit_record "${create_request_id}" "create" "success" "${tenant_id}" "${user_id}"
+assert_mutation_permission_details "${create_request_id}" "create" "success" "${tenant_id}" "${user_id}"
 read -r create_query_request_id create_query_row_count <<< "$(query_order_and_assert "${tenant_id}" "${user_id}" "${test_order_id}" "Gate Create" "web" "medium" "active")"
 assert_audit_record "${create_query_request_id}" "success" "${create_query_row_count}"
 
@@ -848,6 +1053,7 @@ if (data.rowCount !== 1 || data.row?.owner !== process.argv[2] || data.row?.stat
 }
 ' "${TMP_DIR}/mutation-update.json" "Gate Update" "paused"
 assert_mutation_audit_record "${update_request_id}" "update" "success" "${tenant_id}" "${user_id}"
+assert_mutation_permission_details "${update_request_id}" "update" "success" "${tenant_id}" "${user_id}"
 read -r update_query_request_id update_query_row_count <<< "$(query_order_and_assert "${tenant_id}" "${user_id}" "${test_order_id}" "Gate Update" "partner" "high" "paused")"
 assert_audit_record "${update_query_request_id}" "success" "${update_query_row_count}"
 
@@ -879,6 +1085,7 @@ if (data.rowCount !== 1 || data.row?.id !== process.argv[2]) {
 }
 ' "${TMP_DIR}/mutation-delete.json" "${test_order_id}"
 assert_mutation_audit_record "${delete_request_id}" "delete" "success" "${tenant_id}" "${user_id}"
+assert_mutation_permission_details "${delete_request_id}" "delete" "success" "${tenant_id}" "${user_id}"
 read -r delete_query_request_id delete_query_row_count <<< "$(query_order_and_assert_missing "${tenant_id}" "${user_id}" "${test_order_id}")"
 assert_audit_record "${delete_query_request_id}" "success" "${delete_query_row_count}"
 
@@ -910,8 +1117,211 @@ if [[ "${mutation_denied_status_code}" != "403" ]]; then
   exit 1
 fi
 assert_mutation_audit_record "${mutation_denied_request_id}" "update" "denied" "tenant-a" "demo-tenant-a-user"
+assert_mutation_permission_details "${mutation_denied_request_id}" "update" "denied" "tenant-a" "demo-tenant-a-user"
 assert_mutation_denied_integrity_record "${mutation_denied_request_id}" "update" "tenant-a" "demo-tenant-a-user"
 assert_business_order_unchanged "SO-A2001" "A-Manager-Only" "partner" "high" "active" "dept-b"
+
+log "validating SELF mutation success"
+self_test_order_id="SO-ASELF-${RUN_ID}"
+self_create_request_id="e2e-self-mutation-create-${RUN_ID}"
+self_create_status_code="$(run_mutation_request "${self_create_request_id}" "$(cat <<JSON
+{
+  "table": "orders",
+  "operation": "create",
+  "tenantId": "tenant-a",
+  "userId": "self-tenant-a-user",
+  "roles": ["SELF_ONLY"],
+  "orgId": "dept-a",
+  "data": {
+    "id": "${self_test_order_id}",
+    "owner": "Self Create",
+    "channel": "web",
+    "priority": "medium",
+    "status": "active"
+  }
+}
+JSON
+)" "${TMP_DIR}/self-mutation-create.json")"
+if [[ "${self_create_status_code}" != "201" && "${self_create_status_code}" != "200" ]]; then
+  cat "${TMP_DIR}/self-mutation-create.json"
+  exit 1
+fi
+assert_mutation_audit_record "${self_create_request_id}" "create" "success" "tenant-a" "self-tenant-a-user"
+assert_mutation_permission_details "${self_create_request_id}" "create" "success" "tenant-a" "self-tenant-a-user"
+
+log "validating SELF mutation denied sample"
+self_mutation_denied_request_id="e2e-self-mutation-denied-${RUN_ID}"
+self_mutation_denied_status_code="$(run_mutation_request "${self_mutation_denied_request_id}" "$(cat <<JSON
+{
+  "table": "orders",
+  "operation": "update",
+  "tenantId": "tenant-a",
+  "userId": "self-tenant-a-user",
+  "roles": ["SELF_ONLY"],
+  "orgId": "dept-a",
+  "key": {
+    "id": "SO-A1001"
+  },
+  "data": {
+    "id": "SO-A1001",
+    "owner": "self-should-fail",
+    "channel": "web",
+    "priority": "medium",
+    "status": "active"
+  }
+}
+JSON
+)" "${TMP_DIR}/self-mutation-denied.json")"
+if [[ "${self_mutation_denied_status_code}" != "403" ]]; then
+  cat "${TMP_DIR}/self-mutation-denied.json"
+  exit 1
+fi
+assert_mutation_audit_record "${self_mutation_denied_request_id}" "update" "denied" "tenant-a" "self-tenant-a-user"
+assert_mutation_permission_details "${self_mutation_denied_request_id}" "update" "denied" "tenant-a" "self-tenant-a-user"
+assert_mutation_denied_integrity_record "${self_mutation_denied_request_id}" "update" "tenant-a" "self-tenant-a-user"
+assert_business_order_unchanged "SO-A1001" "Alice" "web" "high" "active" "dept-a"
+
+log "validating manager mutation success"
+manager_test_order_id="SO-AMGR-${RUN_ID}"
+manager_create_request_id="e2e-manager-mutation-create-${RUN_ID}"
+manager_create_status_code="$(run_mutation_request "${manager_create_request_id}" "$(cat <<JSON
+{
+  "table": "orders",
+  "operation": "create",
+  "tenantId": "tenant-a",
+  "userId": "manager-tenant-a",
+  "roles": ["MANAGER"],
+  "orgId": "dept-b",
+  "data": {
+    "id": "${manager_test_order_id}",
+    "owner": "Manager Create",
+    "channel": "partner",
+    "priority": "high",
+    "status": "active"
+  }
+}
+JSON
+)" "${TMP_DIR}/manager-mutation-create.json")"
+if [[ "${manager_create_status_code}" != "201" && "${manager_create_status_code}" != "200" ]]; then
+  cat "${TMP_DIR}/manager-mutation-create.json"
+  exit 1
+fi
+assert_mutation_audit_record "${manager_create_request_id}" "create" "success" "tenant-a" "manager-tenant-a"
+assert_mutation_permission_details "${manager_create_request_id}" "create" "success" "tenant-a" "manager-tenant-a"
+
+log "validating manager mutation denied sample"
+manager_mutation_denied_request_id="e2e-manager-mutation-denied-${RUN_ID}"
+manager_mutation_denied_status_code="$(run_mutation_request "${manager_mutation_denied_request_id}" "$(cat <<JSON
+{
+  "table": "orders",
+  "operation": "create",
+  "tenantId": "tenant-a",
+  "userId": "manager-tenant-a",
+  "roles": ["MANAGER"],
+  "orgId": "dept-c",
+  "data": {
+    "id": "SO-AMGR-DENIED-${RUN_ID}",
+    "owner": "manager-should-fail",
+    "channel": "partner",
+    "priority": "high",
+    "status": "active"
+  }
+}
+JSON
+)" "${TMP_DIR}/manager-mutation-denied.json")"
+if [[ "${manager_mutation_denied_status_code}" != "404" && "${manager_mutation_denied_status_code}" != "403" ]]; then
+  cat "${TMP_DIR}/manager-mutation-denied.json"
+  exit 1
+fi
+assert_mutation_audit_record "${manager_mutation_denied_request_id}" "create" "denied" "tenant-a" "manager-tenant-a"
+assert_mutation_permission_details "${manager_mutation_denied_request_id}" "create" "denied" "tenant-a" "manager-tenant-a"
+
+log "validating custom org mutation success"
+custom_test_order_id="SO-ACUSTOM-${RUN_ID}"
+custom_create_request_id="e2e-custom-mutation-create-${RUN_ID}"
+custom_create_status_code="$(run_mutation_request "${custom_create_request_id}" "$(cat <<JSON
+{
+  "table": "orders",
+  "operation": "create",
+  "tenantId": "tenant-a",
+  "userId": "custom-tenant-a-user",
+  "roles": ["CUSTOM_SUPPORT"],
+  "orgId": "dept-b",
+  "data": {
+    "id": "${custom_test_order_id}",
+    "owner": "Custom Create",
+    "channel": "partner",
+    "priority": "medium",
+    "status": "active"
+  }
+}
+JSON
+)" "${TMP_DIR}/custom-mutation-create.json")"
+if [[ "${custom_create_status_code}" != "201" && "${custom_create_status_code}" != "200" ]]; then
+  cat "${TMP_DIR}/custom-mutation-create.json"
+  exit 1
+fi
+assert_mutation_audit_record "${custom_create_request_id}" "create" "success" "tenant-a" "custom-tenant-a-user"
+assert_mutation_permission_details "${custom_create_request_id}" "create" "success" "tenant-a" "custom-tenant-a-user"
+
+log "validating custom org mutation denied sample"
+custom_mutation_denied_request_id="e2e-custom-mutation-denied-${RUN_ID}"
+custom_mutation_denied_status_code="$(run_mutation_request "${custom_mutation_denied_request_id}" "$(cat <<JSON
+{
+  "table": "orders",
+  "operation": "update",
+  "tenantId": "tenant-a",
+  "userId": "custom-tenant-a-user",
+  "roles": ["CUSTOM_SUPPORT"],
+  "orgId": "dept-a",
+  "key": {
+    "id": "SO-A1001"
+  },
+  "data": {
+    "id": "SO-A1001",
+    "owner": "custom-should-fail",
+    "channel": "web",
+    "priority": "medium",
+    "status": "active"
+  }
+}
+JSON
+)" "${TMP_DIR}/custom-mutation-denied.json")"
+if [[ "${custom_mutation_denied_status_code}" != "403" ]]; then
+  cat "${TMP_DIR}/custom-mutation-denied.json"
+  exit 1
+fi
+assert_mutation_audit_record "${custom_mutation_denied_request_id}" "update" "denied" "tenant-a" "custom-tenant-a-user"
+assert_mutation_permission_details "${custom_mutation_denied_request_id}" "update" "denied" "tenant-a" "custom-tenant-a-user"
+assert_mutation_denied_integrity_record "${custom_mutation_denied_request_id}" "update" "tenant-a" "custom-tenant-a-user"
+assert_business_order_unchanged "SO-A1001" "Alice" "web" "high" "active" "dept-a"
+
+log "cleaning scoped mutation samples"
+for delete_spec in \
+  "self-tenant-a-user|SELF_ONLY|${self_test_order_id}" \
+  "manager-tenant-a|MANAGER|${manager_test_order_id}" \
+  "custom-tenant-a-user|CUSTOM_SUPPORT|${custom_test_order_id}"
+do
+  IFS="|" read -r scoped_user scoped_role scoped_order_id <<< "${delete_spec}"
+  cleanup_request_id="e2e-cleanup-${scoped_user}-${RUN_ID}"
+  cleanup_status_code="$(run_mutation_request "${cleanup_request_id}" "$(cat <<JSON
+{
+  "table": "orders",
+  "operation": "delete",
+  "tenantId": "tenant-a",
+  "userId": "${scoped_user}",
+  "roles": ["${scoped_role}"],
+  "key": {
+    "id": "${scoped_order_id}"
+  }
+}
+JSON
+)" "${TMP_DIR}/cleanup-${scoped_user}.json")"
+  if [[ "${cleanup_status_code}" != "200" && "${cleanup_status_code}" != "201" ]]; then
+    cat "${TMP_DIR}/cleanup-${scoped_user}.json"
+    exit 1
+  fi
+done
 
 log "audit snapshot"
 print_audit_snapshot

--- a/packages/bff/scripts/sql/001_orders_demo.sql
+++ b/packages/bff/scripts/sql/001_orders_demo.sql
@@ -18,6 +18,7 @@ VALUES
   ('SO-A1001', 'Alice', 'web', 'high', 'active', 'tenant-a', 'demo-tenant-a-user', 'dept-a'),
   ('SO-A1002', 'Aria', 'store', 'medium', 'paused', 'tenant-a', 'demo-tenant-a-user', 'dept-a'),
   ('SO-A2001', 'A-Manager-Only', 'partner', 'high', 'active', 'tenant-a', 'manager-tenant-a', 'dept-b'),
+  ('SO-A3001', 'Self Owned', 'web', 'medium', 'active', 'tenant-a', 'self-tenant-a-user', 'dept-a'),
   ('SO-B1001', 'Brenda', 'partner', 'high', 'active', 'tenant-b', 'demo-tenant-b-user', 'dept-c'),
   ('SO-B1002', 'Bryan', 'web', 'low', 'paused', 'tenant-b', 'demo-tenant-b-user', 'dept-c')
 ON CONFLICT (id) DO UPDATE

--- a/packages/bff/scripts/sql/bootstrap/200_business_baseline.sql
+++ b/packages/bff/scripts/sql/bootstrap/200_business_baseline.sql
@@ -82,6 +82,7 @@ INSERT INTO role_data_policies (tenant_id, role_code, data_scope, custom_org_ids
 VALUES
   ('tenant-a', 'MANAGER', 'DEPT_AND_CHILDREN', '{}'),
   ('tenant-a', 'USER', 'DEPT', '{}'),
+  ('tenant-a', 'CUSTOM_SUPPORT', 'CUSTOM_ORG_SET', '{"dept-b"}'),
   ('tenant-a', 'SUPER_ADMIN', 'TENANT_ALL', '{}'),
   ('tenant-b', 'MANAGER', 'DEPT_AND_CHILDREN', '{}'),
   ('tenant-b', 'USER', 'DEPT', '{}'),
@@ -94,6 +95,8 @@ INSERT INTO user_org_memberships (tenant_id, user_id, org_id, position, is_prima
 VALUES
   ('tenant-a', 'demo-tenant-a-user', 'dept-a', 'staff', true),
   ('tenant-a', 'manager-tenant-a', 'mgr-1', 'manager', true),
+  ('tenant-a', 'custom-tenant-a-user', 'dept-a', 'staff', true),
+  ('tenant-a', 'self-tenant-a-user', 'dept-a', 'staff', true),
   ('tenant-b', 'demo-tenant-b-user', 'dept-c', 'staff', true)
 ON CONFLICT (tenant_id, user_id, org_id) DO UPDATE
 SET position = EXCLUDED.position,
@@ -103,5 +106,6 @@ INSERT INTO user_role_bindings (tenant_id, user_id, role_code)
 VALUES
   ('tenant-a', 'demo-tenant-a-user', 'USER'),
   ('tenant-a', 'manager-tenant-a', 'MANAGER'),
+  ('tenant-a', 'custom-tenant-a-user', 'CUSTOM_SUPPORT'),
   ('tenant-b', 'demo-tenant-b-user', 'USER')
 ON CONFLICT (tenant_id, user_id, role_code) DO NOTHING;

--- a/packages/bff/test/mutation-orchestrator.test.ts
+++ b/packages/bff/test/mutation-orchestrator.test.ts
@@ -82,3 +82,86 @@ test("mutation orchestrator denies out-of-scope update with 403", async () => {
     /data scope permission denied/i
   );
 });
+
+test("mutation orchestrator allows custom org set create within configured org", async () => {
+  let receivedOrgId: string | null = null;
+  const service = new MutationOrchestratorService(
+    {
+      mutateOrder: async (command: { orgId: string | null }) => {
+        receivedOrgId = command.orgId;
+        return {
+          rowCount: 1,
+          beforeData: null,
+          afterData: { id: "SO-CUSTOM-1", org_id: command.orgId }
+        };
+      }
+    } as never,
+    {
+      resolveContext: async () => ({
+        tenantId: "tenant-a",
+        userId: "custom-user",
+        roles: ["CUSTOM_SUPPORT"],
+        userOrgIds: [],
+        rolePolicies: [{ role: "CUSTOM_SUPPORT", scope: "CUSTOM_ORG_SET", customOrgIds: ["dept-b"] }],
+        orgNodes: []
+      })
+    } as never
+  );
+
+  const result = await service.execute({
+    table: "orders",
+    operation: "create",
+    tenantId: "tenant-a",
+    userId: "custom-user",
+    roles: ["CUSTOM_SUPPORT"],
+    orgId: "dept-b",
+    data: {
+      id: "SO-CUSTOM-1",
+      owner: "Custom Access"
+    }
+  });
+
+  assert.equal(result.rowCount, 1);
+  assert.equal(receivedOrgId, "dept-b");
+  assert.equal(result.permissionDecision.scope, "CUSTOM_ORG_SET");
+});
+
+test("mutation orchestrator denies SELF scope update for another creator", async () => {
+  const service = new MutationOrchestratorService(
+    {
+      findOrderById: async () => ({
+        id: "SO-SELF-1",
+        tenant_id: "tenant-a",
+        created_by: "owner-a",
+        org_id: "dept-a"
+      })
+    } as never,
+    {
+      resolveContext: async () => ({
+        tenantId: "tenant-a",
+        userId: "self-user",
+        roles: ["SELF_ONLY"],
+        userOrgIds: ["dept-a"],
+        rolePolicies: [],
+        orgNodes: []
+      })
+    } as never
+  );
+
+  await assert.rejects(
+    async () =>
+      service.execute({
+        table: "orders",
+        operation: "update",
+        tenantId: "tenant-a",
+        userId: "self-user",
+        roles: ["SELF_ONLY"],
+        key: { id: "SO-SELF-1" },
+        data: {
+          id: "SO-SELF-1",
+          owner: "No Access"
+        }
+      }),
+    /data scope permission denied/i
+  );
+});

--- a/packages/bff/test/query-pipeline.test.ts
+++ b/packages/bff/test/query-pipeline.test.ts
@@ -1,8 +1,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { compileQueryWithPermission } from "../src/query-pipeline.service";
+import { compileQueryWithPermission } from "../src/orchestration/query-orchestrator.service";
 
-test("compileQueryWithPermission injects tenant/user filters", () => {
+test("compileQueryWithPermission injects DEPT scope filter", () => {
   const compiled = compileQueryWithPermission({
     table: "orders",
     fields: ["id", "status"],
@@ -11,16 +11,22 @@ test("compileQueryWithPermission injects tenant/user filters", () => {
     userId: "u1",
     roles: ["USER"],
     limit: 20
+  }, {
+    scope: "DEPT",
+    allowedOrgIds: ["dept-a"],
+    tenantAll: false,
+    legacyFallbackToCreatedBy: true,
+    reason: "scope:DEPT"
   });
 
   assert.equal(
     compiled.sql,
-    'SELECT "id", "status" FROM "orders" WHERE ("id" ILIKE $1 OR "owner" ILIKE $1) AND "status" = $2 AND tenant_id = $3 AND created_by = $4 LIMIT 20'
+    'SELECT "id", "status" FROM "orders" WHERE ("id" ILIKE $1 OR "owner" ILIKE $1) AND "status" = $2 AND tenant_id = $3 AND (org_id = ANY($4::text[]) OR (org_id IS NULL AND created_by = $5)) LIMIT 20'
   );
-  assert.deepEqual(compiled.params, ["%SO-1%", "PAID", "t1", "u1"]);
+  assert.deepEqual(compiled.params, ["%SO-1%", "PAID", "t1", ["dept-a"], "u1"]);
 });
 
-test("compileQueryWithPermission skips tenant/user filters for SUPER_ADMIN", () => {
+test("compileQueryWithPermission injects tenant-only filter for TENANT_ALL", () => {
   const compiled = compileQueryWithPermission({
     table: "orders",
     fields: ["id"],
@@ -28,8 +34,37 @@ test("compileQueryWithPermission skips tenant/user filters for SUPER_ADMIN", () 
     tenantId: "t1",
     userId: "u1",
     roles: ["SUPER_ADMIN"]
+  }, {
+    scope: "TENANT_ALL",
+    allowedOrgIds: [],
+    tenantAll: true,
+    legacyFallbackToCreatedBy: false,
+    reason: "scope:TENANT_ALL"
   });
 
   assert.equal(compiled.sql, 'SELECT "id" FROM "orders" WHERE "status" = $1 AND tenant_id = $2 LIMIT 100');
   assert.deepEqual(compiled.params, ["PAID", "t1"]);
+});
+
+test("compileQueryWithPermission injects custom org scope filter", () => {
+  const compiled = compileQueryWithPermission({
+    table: "orders",
+    fields: ["id"],
+    filters: {},
+    tenantId: "tenant-a",
+    userId: "custom-user",
+    roles: ["CUSTOM_SUPPORT"]
+  }, {
+    scope: "CUSTOM_ORG_SET",
+    allowedOrgIds: ["dept-b"],
+    tenantAll: false,
+    legacyFallbackToCreatedBy: true,
+    reason: "scope:CUSTOM_ORG_SET"
+  });
+
+  assert.equal(
+    compiled.sql,
+    'SELECT "id" FROM "orders" WHERE tenant_id = $1 AND (org_id = ANY($2::text[]) OR (org_id IS NULL AND created_by = $3)) LIMIT 100'
+  );
+  assert.deepEqual(compiled.params, ["tenant-a", ["dept-b"], "custom-user"]);
 });

--- a/packages/permission/test/permission-engine.test.ts
+++ b/packages/permission/test/permission-engine.test.ts
@@ -105,6 +105,37 @@ test("canAccessOrg denies sibling org and allows legacy fallback", () => {
   assert.equal(allowedByLegacy.fallbackUsed, true);
 });
 
+test("resolveDataScope keeps custom org set from role policy", () => {
+  const decision = resolveDataScope({
+    tenantId: "tenant-a",
+    userId: "custom-user",
+    roles: ["CUSTOM_SUPPORT"],
+    userOrgIds: ["dept-a"],
+    rolePolicies: [{ role: "CUSTOM_SUPPORT", scope: "CUSTOM_ORG_SET", customOrgIds: ["dept-b"] }],
+    orgNodes: []
+  });
+
+  assert.equal(decision.scope, "CUSTOM_ORG_SET");
+  assert.deepEqual(decision.allowedOrgIds, ["dept-b"]);
+});
+
+test("canAccessOrg enforces SELF scope by creator only", () => {
+  const denied = canAccessOrg(
+    {
+      scope: "SELF",
+      allowedOrgIds: [],
+      tenantAll: false,
+      legacyFallbackToCreatedBy: true,
+      reason: "scope:SELF"
+    },
+    { orgId: "dept-a", createdBy: "someone-else" },
+    { tenantId: "tenant-a", userId: "self-user", roles: ["SELF_ONLY"] }
+  );
+
+  assert.equal(denied.allowed, false);
+  assert.equal(denied.reason, "self-owner-required");
+});
+
 test("injectPermissionClause appends filter to SQL with WHERE", () => {
   const sql = injectPermissionClause("SELECT * FROM orders WHERE status = $1", {
     clause: "tenant_id = $2",

--- a/scripts/check-boundaries.mjs
+++ b/scripts/check-boundaries.mjs
@@ -30,13 +30,14 @@ function checkFile(file) {
   // Transitional guard: DB driver should be centralized and explicitly allowlisted.
   if (content.includes("from \"pg\"") || content.includes("from 'pg'")) {
     const allowed = [
-      'packages/datasource/',
-      'packages/audit/',
+      'packages/datasource/src/postgres-datasource-adapter.ts',
       'packages/kernel/src/postgres-meta-kernel-repository.ts',
-      'packages/bff/src/integration/',
-      'packages/bff/src/bootstrap/'
+      'packages/bff/src/integration/org-scope.service.ts',
+      'packages/bff/src/integration/audit-persistence.service.ts',
+      'packages/bff/src/integration/postgres-query-executor.service.ts',
+      'packages/bff/src/bootstrap/migration-runner.ts'
     ];
-    if (!allowed.some((prefix) => rel.startsWith(prefix))) {
+    if (!allowed.includes(rel)) {
       violations.push(`${rel}: direct pg import is not allowed here.`);
     }
   }


### PR DESCRIPTION
## Summary
- tighten direct pg access to explicit bff/datasource/kernel entry points and move the audit package back to a compatibility-contract role
- expand the bff permission matrix gate to cover SELF, DEPT_AND_CHILDREN, and CUSTOM_ORG_SET query/mutation paths with new bootstrap seed data
- update platform and package changelogs for the runtime boundary and permission gate work

## Validation
- pnpm run lint:boundaries
- pnpm test
- pnpm query-gate

## Risk / Rollback
- risk: query-gate now depends on the additional org-scope seed identities and permission assertions
- rollback: revert the seed, gate-script, and boundary changes together if the remote demo baseline needs to go back to the narrower matrix