### PR TITLE
fix(boundaries): harden db driver policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - feat(runtime): add a minimal rule engine and function registry so runtime events can compute rule-driven patches, actions, and datasource refreshes.
 - docs(runtime): sync the runtime contract, frontend integration, migration guidance, and testing playbook to the current manager-first implementation.
 - fix(boundaries): tighten direct `pg` access down to explicit BFF/datasource/kernel entry points and remove the audit package from the transitional DB-driver allowlist.
+- fix(boundaries): promote DB-driver boundary checks from a transitional allowlist to explicit package/file policy checks with self-tests.
 
 ## 0.1.0 (2026-04-18)
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -9,6 +9,7 @@
 - feat(runtime): 新增最小 RuleEngine 与 FunctionRegistry，让 runtime 事件可计算规则驱动的 state patch、action 与 datasource refresh。
 - docs(runtime): 将 runtime contract、前端接入、迁移指引与测试手册同步到当前 manager-first 实现口径。
 - fix(boundaries): 将 `pg` 直连点收紧到显式的 BFF/datasource/kernel 入口，并把 audit 包移出过渡白名单。
+- fix(boundaries): 将 DB driver 边界检查从过渡白名单升级为显式包/文件策略检查，并补充自测。
 
 ## 0.1.0 (2026-04-18)
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "infra:up": "docker compose -f infra/docker-compose.yml up -d postgres redis",
     "infra:down": "docker compose -f infra/docker-compose.yml down",
     "infra:query-gate": "bash infra/scripts/query-gate.sh",
+    "test:boundaries": "node --test scripts/check-boundaries.test.mjs",
     "lint:boundaries": "node scripts/check-boundaries.mjs",
     "changeset": "changeset",
     "release:status": "changeset status --verbose",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,16 +42,10 @@ importers:
       '@zhongmiao/meta-lc-contracts':
         specifier: workspace:*
         version: link:../contracts
-      pg:
-        specifier: ^8.13.1
-        version: 8.20.0
     devDependencies:
       '@types/node':
         specifier: ^22.10.2
         version: 22.19.17
-      '@types/pg':
-        specifier: ^8.11.10
-        version: 8.20.0
       typescript:
         specifier: ^5.7.2
         version: 5.9.3

--- a/scripts/check-boundaries.mjs
+++ b/scripts/check-boundaries.mjs
@@ -1,55 +1,67 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const ROOT = process.cwd();
-const PACKAGES = path.join(ROOT, 'packages');
-const violations = [];
+const DB_DRIVER_PACKAGES = new Set(['bff', 'datasource', 'kernel']);
+const DB_DRIVER_DEPENDENCIES = new Set(['pg', '@types/pg']);
+const ALLOWED_PG_IMPORT_FILES = new Set([
+  'packages/datasource/src/postgres-datasource-adapter.ts',
+  'packages/kernel/src/postgres-meta-kernel-repository.ts',
+  'packages/bff/src/integration/org-scope.service.ts',
+  'packages/bff/src/integration/audit-persistence.service.ts',
+  'packages/bff/src/integration/postgres-query-executor.service.ts',
+  'packages/bff/src/bootstrap/migration-runner.ts'
+]);
+const FORBIDDEN_KERNEL_DEPS = [
+  '@zhongmiao/meta-lc-bff',
+  '@zhongmiao/meta-lc-query',
+  '@zhongmiao/meta-lc-datasource'
+];
 
-function walk(dir) {
+export function checkWorkspace(root = process.cwd()) {
+  const packagesDir = path.join(root, 'packages');
+  const violations = [];
+  walk(packagesDir, root, violations);
+  return violations;
+}
+
+function walk(dir, root, violations) {
+  if (!fs.existsSync(dir)) return;
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) {
       if (entry.name === 'dist' || entry.name === 'node_modules') continue;
-      walk(full);
+      walk(full, root, violations);
       continue;
     }
-    if (entry.isFile() && full.endsWith('.ts')) checkFile(full);
+    if (entry.isFile() && entry.name === 'package.json') checkPackageManifest(full, root, violations);
+    if (entry.isFile() && full.endsWith('.ts')) checkSourceFile(full, root, violations);
   }
 }
 
-function checkFile(file) {
-  const rel = path.relative(ROOT, file);
+function checkSourceFile(file, root, violations) {
+  const rel = normalizePath(path.relative(root, file));
   const content = fs.readFileSync(file, 'utf8');
 
   // No deep cross-package imports.
-  const deepImport = content.match(/from\s+["']@meta-lc\/[a-z-]+\//g);
+  const deepImport = content.match(/from\s+["'](?:@meta-lc\/[a-z-]+|@zhongmiao\/meta-lc-[a-z-]+)\//g);
   if (deepImport) {
     violations.push(`${rel}: deep import from package internals is forbidden.`);
   }
 
-  // Transitional guard: DB driver should be centralized and explicitly allowlisted.
-  if (content.includes("from \"pg\"") || content.includes("from 'pg'")) {
-    const allowed = [
-      'packages/datasource/src/postgres-datasource-adapter.ts',
-      'packages/kernel/src/postgres-meta-kernel-repository.ts',
-      'packages/bff/src/integration/org-scope.service.ts',
-      'packages/bff/src/integration/audit-persistence.service.ts',
-      'packages/bff/src/integration/postgres-query-executor.service.ts',
-      'packages/bff/src/bootstrap/migration-runner.ts'
-    ];
-    if (!allowed.includes(rel)) {
+  // DB driver access is a hard boundary: only explicit DB edge files may import pg.
+  if (importsPg(content)) {
+    const packageName = getPackageName(rel);
+    if (!DB_DRIVER_PACKAGES.has(packageName)) {
+      violations.push(`${rel}: direct pg import is forbidden outside bff/datasource/kernel packages.`);
+    } else if (!ALLOWED_PG_IMPORT_FILES.has(rel)) {
       violations.push(`${rel}: direct pg import is not allowed here.`);
     }
   }
 
   // Kernel must not depend on bff/query/datasource implementation.
   if (rel.startsWith('packages/kernel/')) {
-    const forbidden = [
-      '@zhongmiao/meta-lc-bff',
-      '@zhongmiao/meta-lc-query',
-      '@zhongmiao/meta-lc-datasource'
-    ];
-    for (const dep of forbidden) {
+    for (const dep of FORBIDDEN_KERNEL_DEPS) {
       if (content.includes(dep)) {
         violations.push(`${rel}: kernel cannot depend on ${dep}.`);
       }
@@ -57,12 +69,50 @@ function checkFile(file) {
   }
 }
 
-walk(PACKAGES);
+function checkPackageManifest(file, root, violations) {
+  const rel = normalizePath(path.relative(root, file));
+  const packageName = getPackageName(rel);
+  const manifest = JSON.parse(fs.readFileSync(file, 'utf8'));
+  const dependencyBlocks = ['dependencies', 'devDependencies'];
 
-if (violations.length > 0) {
-  console.error('Boundary violations found:');
-  for (const v of violations) console.error(`- ${v}`);
-  process.exit(1);
+  for (const blockName of dependencyBlocks) {
+    const block = manifest[blockName] ?? {};
+    for (const dependencyName of Object.keys(block)) {
+      if (!DB_DRIVER_DEPENDENCIES.has(dependencyName)) continue;
+      if (!DB_DRIVER_PACKAGES.has(packageName)) {
+        violations.push(
+          `${rel}: ${dependencyName} is forbidden in ${blockName} outside bff/datasource/kernel packages.`
+        );
+      }
+    }
+  }
 }
 
-console.log('Boundary check passed.');
+function importsPg(content) {
+  return /from\s+["']pg["']/.test(content) || /require\(\s*["']pg["']\s*\)/.test(content);
+}
+
+function getPackageName(rel) {
+  const match = rel.match(/^packages\/([^/]+)\//);
+  return match?.[1] ?? '';
+}
+
+function normalizePath(value) {
+  return value.split(path.sep).join('/');
+}
+
+function main() {
+  const violations = checkWorkspace();
+
+  if (violations.length > 0) {
+    console.error('Boundary violations found:');
+    for (const v of violations) console.error(`- ${v}`);
+    process.exit(1);
+  }
+
+  console.log('Boundary check passed.');
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/check-boundaries.test.mjs
+++ b/scripts/check-boundaries.test.mjs
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { checkWorkspace } from './check-boundaries.mjs';
+
+test('allows current explicit pg edge files', () => {
+  const workspace = createWorkspace({
+    'packages/datasource/package.json': packageJson({
+      dependencies: { pg: '^8.13.1' },
+      devDependencies: { '@types/pg': '^8.11.10' }
+    }),
+    'packages/datasource/src/postgres-datasource-adapter.ts': 'import { Pool } from "pg";\n'
+  });
+
+  assert.deepEqual(checkWorkspace(workspace), []);
+});
+
+test('rejects pg declarations in non-db-boundary package manifests', () => {
+  const workspace = createWorkspace({
+    'packages/query/package.json': packageJson({
+      dependencies: { pg: '^8.13.1' },
+      devDependencies: { '@types/pg': '^8.11.10' }
+    })
+  });
+
+  assert.deepEqual(checkWorkspace(workspace), [
+    'packages/query/package.json: pg is forbidden in dependencies outside bff/datasource/kernel packages.',
+    'packages/query/package.json: @types/pg is forbidden in devDependencies outside bff/datasource/kernel packages.'
+  ]);
+});
+
+test('rejects pg imports outside db-boundary packages', () => {
+  const workspace = createWorkspace({
+    'packages/audit/src/index.ts': 'import { Pool } from "pg";\n'
+  });
+
+  assert.deepEqual(checkWorkspace(workspace), [
+    'packages/audit/src/index.ts: direct pg import is forbidden outside bff/datasource/kernel packages.'
+  ]);
+});
+
+test('rejects unapproved pg imports inside db-boundary packages', () => {
+  const workspace = createWorkspace({
+    'packages/bff/src/random-db-helper.ts': 'import { Pool } from "pg";\n'
+  });
+
+  assert.deepEqual(checkWorkspace(workspace), [
+    'packages/bff/src/random-db-helper.ts: direct pg import is not allowed here.'
+  ]);
+});
+
+test('keeps deep import and kernel reverse dependency checks', () => {
+  const workspace = createWorkspace({
+    'packages/kernel/src/index.ts': [
+      'import { x } from "@zhongmiao/meta-lc-query/src/index";',
+      'import { y } from "@zhongmiao/meta-lc-bff";'
+    ].join('\n')
+  });
+
+  assert.deepEqual(checkWorkspace(workspace), [
+    'packages/kernel/src/index.ts: deep import from package internals is forbidden.',
+    'packages/kernel/src/index.ts: kernel cannot depend on @zhongmiao/meta-lc-bff.',
+    'packages/kernel/src/index.ts: kernel cannot depend on @zhongmiao/meta-lc-query.'
+  ]);
+});
+
+function createWorkspace(files) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'meta-lc-boundaries-'));
+  for (const [relativePath, content] of Object.entries(files)) {
+    const file = path.join(root, relativePath);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, content);
+  }
+  return root;
+}
+
+function packageJson(content) {
+  return `${JSON.stringify({ name: 'test-package', ...content }, null, 2)}\n`;
+}


### PR DESCRIPTION
## Summary
- Harden the DB-driver boundary checker from a transitional `pg` allowlist into explicit package/file policy checks.
- Add manifest checks so non-DB-boundary packages cannot declare `pg` or `@types/pg`.
- Add Node self-tests for legal DB edge files, forbidden manifests, forbidden imports, and existing deep-import/kernel dependency guards.
- Refresh `pnpm-lock.yaml` so CI frozen install matches the current audit package boundary.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm test:boundaries`
- `pnpm lint`
- `pnpm -r test`
- `git diff --check 9c62e1d..HEAD`

## Risk / Rollback
- Risk: future legitimate DB edge files must be added intentionally to the boundary policy.
- Rollback: revert this PR to restore the previous narrower boundary script behavior.
