### PR TITLE
feat(bff): add gateway baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - docs(runtime): sync the runtime contract, frontend integration, migration guidance, and testing playbook to the current manager-first implementation.
 - fix(boundaries): tighten direct `pg` access down to explicit BFF/datasource/kernel entry points and remove the audit package from the transitional DB-driver allowlist.
 - fix(boundaries): promote DB-driver boundary checks from a transitional allowlist to explicit package/file policy checks with self-tests.
+- feat(bff): add the first Gateway baseline for meta APIs, in-memory cache, aggregation summary, and WebSocket lifecycle smoke.
 
 ## 0.1.0 (2026-04-18)
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -10,6 +10,7 @@
 - docs(runtime): 将 runtime contract、前端接入、迁移指引与测试手册同步到当前 manager-first 实现口径。
 - fix(boundaries): 将 `pg` 直连点收紧到显式的 BFF/datasource/kernel 入口，并把 audit 包移出过渡白名单。
 - fix(boundaries): 将 DB driver 边界检查从过渡白名单升级为显式包/文件策略检查，并补充自测。
+- feat(bff): 新增首版 Gateway 基线，覆盖 meta API、内存 cache、aggregation summary 与 WebSocket lifecycle smoke。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/bff/CHANGELOG.md
+++ b/packages/bff/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- feat(gateway): add meta API, in-memory cache, aggregation summary, and WebSocket lifecycle baseline.
 - chore(package): adopt the `@zhongmiao/meta-lc-bff` scoped package identity for release governance.
 - fix(local-dev): move the default BFF local port to `6001` and bind an explicit host so browser-based integration can reach the service without unsafe-port blocking.
 - test(permission-gate): expand the query/mutation gate baseline to cover `SELF`, `DEPT_AND_CHILDREN`, and `CUSTOM_ORG_SET` permission paths in addition to the existing `DEPT` denied checks.

--- a/packages/bff/CHANGELOG.zh-CN.md
+++ b/packages/bff/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- feat(gateway): 新增 meta API、内存 cache、aggregation summary 与 WebSocket lifecycle 基线。
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-bff` 正式包名。
 - fix(local-dev): 将 BFF 本地默认端口调整为 `6001`，并显式绑定 host，避免浏览器因 unsafe port 策略阻断联调访问。
 - test(permission-gate): 将 query/mutation gate 扩展到 `SELF`、`DEPT_AND_CHILDREN`、`CUSTOM_ORG_SET` 权限路径，不再只覆盖现有 `DEPT` denied 样例。

--- a/packages/bff/package.json
+++ b/packages/bff/package.json
@@ -13,6 +13,8 @@
     "@nestjs/common": "^10.4.12",
     "@nestjs/core": "^10.4.12",
     "@nestjs/platform-express": "^10.4.22",
+    "@nestjs/platform-socket.io": "^10.4.22",
+    "@nestjs/websockets": "^10.4.22",
     "pg": "^8.13.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",

--- a/packages/bff/src/aggregation/aggregation.service.ts
+++ b/packages/bff/src/aggregation/aggregation.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from "@nestjs/common";
+import { MetaRegistryService, type MetaResourceKind } from "../gateway/meta-registry.service";
+
+export interface MetaSummaryEntry {
+  count: number;
+  updatedAt: string | null;
+}
+
+export type MetaSummary = Record<MetaResourceKind, MetaSummaryEntry>;
+
+@Injectable()
+export class AggregationService {
+  constructor(private readonly registry: MetaRegistryService) {}
+
+  summarizeMeta(): MetaSummary {
+    return this.registry.listKinds().reduce((summary, kind) => {
+      const items = this.registry.list(kind);
+      summary[kind] = {
+        count: items.length,
+        updatedAt: newestUpdatedAt(items.map((item) => item.updatedAt))
+      };
+      return summary;
+    }, {} as MetaSummary);
+  }
+}
+
+function newestUpdatedAt(values: string[]): string | null {
+  if (!values.length) {
+    return null;
+  }
+  return values.sort().at(-1) ?? null;
+}

--- a/packages/bff/src/app.module.ts
+++ b/packages/bff/src/app.module.ts
@@ -1,8 +1,13 @@
 import { Module } from "@nestjs/common";
 import { APP_FILTER } from "@nestjs/core";
+import { AggregationService } from "./aggregation/aggregation.service";
+import { CacheService } from "./cache/cache.service";
 import { AuditLogService } from "./common/audit-log.service";
 import { HttpExceptionFilter } from "./common/http-exception.filter";
+import { MetaController } from "./gateway/meta.controller";
+import { MetaRegistryService } from "./gateway/meta-registry.service";
 import { QueryController } from "./gateway/query.controller";
+import { RuntimeWsGateway } from "./gateway/ws.gateway";
 import { AuditPersistenceService } from "./integration/audit-persistence.service";
 import { OrgScopeService } from "./integration/org-scope.service";
 import { PostgresQueryExecutorService } from "./integration/postgres-query-executor.service";
@@ -11,14 +16,18 @@ import { QueryOrchestratorService } from "./orchestration/query-orchestrator.ser
 
 @Module({
   imports: [],
-  controllers: [QueryController],
+  controllers: [QueryController, MetaController],
   providers: [
+    AggregationService,
+    CacheService,
+    MetaRegistryService,
     PostgresQueryExecutorService,
     OrgScopeService,
     AuditPersistenceService,
     QueryOrchestratorService,
     MutationOrchestratorService,
     AuditLogService,
+    RuntimeWsGateway,
     {
       provide: APP_FILTER,
       useClass: HttpExceptionFilter

--- a/packages/bff/src/cache/cache.service.ts
+++ b/packages/bff/src/cache/cache.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from "@nestjs/common";
+
+export interface CacheHit<T> {
+  value: T;
+  cached: boolean;
+}
+
+@Injectable()
+export class CacheService {
+  private readonly store = new Map<string, unknown>();
+
+  get<T>(key: string): T | undefined {
+    return this.store.get(key) as T | undefined;
+  }
+
+  set<T>(key: string, value: T): T {
+    this.store.set(key, value);
+    return value;
+  }
+
+  async remember<T>(key: string, loader: () => Promise<T> | T): Promise<CacheHit<T>> {
+    const existing = this.get<T>(key);
+    if (existing !== undefined) {
+      return { value: existing, cached: true };
+    }
+    const value = await loader();
+    this.set(key, value);
+    return { value, cached: false };
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+}

--- a/packages/bff/src/gateway/meta-registry.service.ts
+++ b/packages/bff/src/gateway/meta-registry.service.ts
@@ -1,0 +1,66 @@
+import { Injectable } from "@nestjs/common";
+
+export type MetaResourceKind = "tables" | "pages" | "datasources" | "rules" | "permissions";
+
+export interface MetaRegistryItem {
+  id: string;
+  name: string;
+  updatedAt: string;
+  [key: string]: unknown;
+}
+
+const UPDATED_AT = "2026-04-20T00:00:00.000Z";
+
+const FIXTURES: Record<MetaResourceKind, MetaRegistryItem[]> = {
+  tables: [
+    {
+      id: "orders",
+      name: "Orders",
+      updatedAt: UPDATED_AT,
+      fields: ["id", "owner", "channel", "priority", "status", "tenant_id", "org_id"]
+    }
+  ],
+  pages: [
+    {
+      id: "orders-workbench",
+      name: "Orders Workbench",
+      updatedAt: UPDATED_AT,
+      route: "/studio/page/orders"
+    }
+  ],
+  datasources: [
+    {
+      id: "orders-query",
+      name: "Orders Query",
+      updatedAt: UPDATED_AT,
+      type: "bff-query"
+    }
+  ],
+  rules: [
+    {
+      id: "orders-refresh-after-mutation",
+      name: "Refresh Orders After Mutation",
+      updatedAt: UPDATED_AT,
+      trigger: "mutation.succeeded"
+    }
+  ],
+  permissions: [
+    {
+      id: "orders-data-scope",
+      name: "Orders Data Scope",
+      updatedAt: UPDATED_AT,
+      scopes: ["SELF", "DEPT", "DEPT_AND_CHILDREN", "CUSTOM_ORG_SET", "TENANT_ALL"]
+    }
+  ]
+};
+
+@Injectable()
+export class MetaRegistryService {
+  list(kind: MetaResourceKind): MetaRegistryItem[] {
+    return FIXTURES[kind].map((item) => ({ ...item }));
+  }
+
+  listKinds(): MetaResourceKind[] {
+    return ["tables", "pages", "datasources", "rules", "permissions"];
+  }
+}

--- a/packages/bff/src/gateway/meta.controller.ts
+++ b/packages/bff/src/gateway/meta.controller.ts
@@ -1,0 +1,103 @@
+import { Controller, Get, Req, Res } from "@nestjs/common";
+import { AggregationService, type MetaSummary } from "../aggregation/aggregation.service";
+import { CacheService } from "../cache/cache.service";
+import { resolveRequestId } from "../common/request-id";
+import {
+  MetaRegistryService,
+  type MetaRegistryItem,
+  type MetaResourceKind
+} from "./meta-registry.service";
+
+interface RequestLike {
+  headers: Record<string, string | string[] | undefined>;
+}
+
+interface ResponseLike {
+  setHeader(name: string, value: string): void;
+}
+
+export interface MetaListEnvelope {
+  items: MetaRegistryItem[];
+  source: "memory";
+  cached: boolean;
+  requestId: string;
+}
+
+export interface MetaSummaryEnvelope {
+  summary: MetaSummary;
+  source: "memory";
+  cached: boolean;
+  requestId: string;
+}
+
+@Controller("meta")
+export class MetaController {
+  constructor(
+    private readonly registry: MetaRegistryService,
+    private readonly cache: CacheService,
+    private readonly aggregation: AggregationService
+  ) {}
+
+  @Get("tables")
+  tables(@Req() req: RequestLike, @Res({ passthrough: true }) res: ResponseLike): Promise<MetaListEnvelope> {
+    return this.list("tables", req, res);
+  }
+
+  @Get("pages")
+  pages(@Req() req: RequestLike, @Res({ passthrough: true }) res: ResponseLike): Promise<MetaListEnvelope> {
+    return this.list("pages", req, res);
+  }
+
+  @Get("datasources")
+  datasources(
+    @Req() req: RequestLike,
+    @Res({ passthrough: true }) res: ResponseLike
+  ): Promise<MetaListEnvelope> {
+    return this.list("datasources", req, res);
+  }
+
+  @Get("rules")
+  rules(@Req() req: RequestLike, @Res({ passthrough: true }) res: ResponseLike): Promise<MetaListEnvelope> {
+    return this.list("rules", req, res);
+  }
+
+  @Get("permissions")
+  permissions(
+    @Req() req: RequestLike,
+    @Res({ passthrough: true }) res: ResponseLike
+  ): Promise<MetaListEnvelope> {
+    return this.list("permissions", req, res);
+  }
+
+  @Get("summary")
+  async summary(
+    @Req() req: RequestLike,
+    @Res({ passthrough: true }) res: ResponseLike
+  ): Promise<MetaSummaryEnvelope> {
+    const requestId = this.bindRequestId(req, res);
+    const result = await this.cache.remember("meta:summary", () => this.aggregation.summarizeMeta());
+    return {
+      summary: result.value,
+      source: "memory",
+      cached: result.cached,
+      requestId
+    };
+  }
+
+  private async list(kind: MetaResourceKind, req: RequestLike, res: ResponseLike): Promise<MetaListEnvelope> {
+    const requestId = this.bindRequestId(req, res);
+    const result = await this.cache.remember(`meta:${kind}`, () => this.registry.list(kind));
+    return {
+      items: result.value,
+      source: "memory",
+      cached: result.cached,
+      requestId
+    };
+  }
+
+  private bindRequestId(req: RequestLike, res: ResponseLike): string {
+    const requestId = resolveRequestId(req.headers["x-request-id"]);
+    res.setHeader("x-request-id", requestId);
+    return requestId;
+  }
+}

--- a/packages/bff/src/gateway/ws.gateway.ts
+++ b/packages/bff/src/gateway/ws.gateway.ts
@@ -1,0 +1,56 @@
+import { Logger } from "@nestjs/common";
+import {
+  ConnectedSocket,
+  MessageBody,
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+  SubscribeMessage,
+  WebSocketGateway
+} from "@nestjs/websockets";
+
+export interface WsClientLike {
+  id: string;
+  emit(event: string, payload: unknown): void;
+}
+
+export interface SubscribePageMessage {
+  tenantId: string;
+  pageId: string;
+  pageInstanceId: string;
+}
+
+export interface PageSubscribedEvent extends SubscribePageMessage {
+  topic: string;
+  status: "subscribed";
+}
+
+@WebSocketGateway({ namespace: "runtime" })
+export class RuntimeWsGateway implements OnGatewayConnection<WsClientLike>, OnGatewayDisconnect<WsClientLike> {
+  private readonly logger = new Logger("RuntimeWsGateway");
+
+  handleConnection(client: WsClientLike): void {
+    this.logger.log(`client connected: ${client.id}`);
+  }
+
+  handleDisconnect(client: WsClientLike): void {
+    this.logger.log(`client disconnected: ${client.id}`);
+  }
+
+  @SubscribeMessage("subscribePage")
+  subscribePage(
+    @MessageBody() message: SubscribePageMessage,
+    @ConnectedSocket() client: WsClientLike
+  ): PageSubscribedEvent {
+    const event: PageSubscribedEvent = {
+      ...message,
+      topic: buildPageTopic(message),
+      status: "subscribed"
+    };
+    client.emit("pageSubscribed", event);
+    return event;
+  }
+}
+
+export function buildPageTopic(message: SubscribePageMessage): string {
+  return `tenant.${message.tenantId}.page.${message.pageId}.instance.${message.pageInstanceId}`;
+}

--- a/packages/bff/test/cache.service.test.ts
+++ b/packages/bff/test/cache.service.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { CacheService } from "../src/cache/cache.service";
+
+test("cache remember returns cached value without reloading", async () => {
+  const cache = new CacheService();
+  let calls = 0;
+
+  const first = await cache.remember("meta:tables", () => {
+    calls += 1;
+    return [{ id: "orders" }];
+  });
+  const second = await cache.remember("meta:tables", () => {
+    calls += 1;
+    return [{ id: "customers" }];
+  });
+
+  assert.equal(calls, 1);
+  assert.equal(first.cached, false);
+  assert.equal(second.cached, true);
+  assert.deepEqual(second.value, [{ id: "orders" }]);
+});
+
+test("cache clear removes remembered values", async () => {
+  const cache = new CacheService();
+  await cache.remember("meta:tables", () => [{ id: "orders" }]);
+  cache.clear();
+
+  assert.equal(cache.get("meta:tables"), undefined);
+});

--- a/packages/bff/test/meta-gateway.test.ts
+++ b/packages/bff/test/meta-gateway.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { AggregationService } from "../src/aggregation/aggregation.service";
+import { CacheService } from "../src/cache/cache.service";
+import { MetaController } from "../src/gateway/meta.controller";
+import { MetaRegistryService } from "../src/gateway/meta-registry.service";
+
+test("meta controller returns stable envelope and request id", async () => {
+  const controller = createController();
+  const headers: Record<string, string> = {};
+
+  const first = await controller.tables(request("req-meta-1"), response(headers));
+  const second = await controller.tables(request("req-meta-2"), response(headers));
+
+  assert.equal(first.requestId, "req-meta-1");
+  assert.equal(second.requestId, "req-meta-2");
+  assert.equal(headers["x-request-id"], "req-meta-2");
+  assert.equal(first.source, "memory");
+  assert.equal(first.cached, false);
+  assert.equal(second.cached, true);
+  assert.equal(first.items[0]?.id, "orders");
+});
+
+test("aggregation summary returns resource counts and updated timestamps", async () => {
+  const registry = new MetaRegistryService();
+  const aggregation = new AggregationService(registry);
+
+  const summary = aggregation.summarizeMeta();
+
+  assert.equal(summary.tables.count, 1);
+  assert.equal(summary.pages.count, 1);
+  assert.equal(summary.datasources.count, 1);
+  assert.equal(summary.rules.count, 1);
+  assert.equal(summary.permissions.count, 1);
+  assert.equal(summary.tables.updatedAt, "2026-04-20T00:00:00.000Z");
+});
+
+test("meta summary endpoint uses cached aggregation envelope", async () => {
+  const controller = createController();
+  const headers: Record<string, string> = {};
+
+  const first = await controller.summary(request("req-summary-1"), response(headers));
+  const second = await controller.summary(request("req-summary-2"), response(headers));
+
+  assert.equal(first.cached, false);
+  assert.equal(second.cached, true);
+  assert.equal(second.summary.permissions.count, 1);
+});
+
+function createController(): MetaController {
+  const registry = new MetaRegistryService();
+  return new MetaController(registry, new CacheService(), new AggregationService(registry));
+}
+
+function request(requestId: string): { headers: Record<string, string> } {
+  return { headers: { "x-request-id": requestId } };
+}
+
+function response(headers: Record<string, string>): { setHeader(name: string, value: string): void } {
+  return {
+    setHeader(name: string, value: string): void {
+      headers[name] = value;
+    }
+  };
+}

--- a/packages/bff/test/ws-gateway.test.ts
+++ b/packages/bff/test/ws-gateway.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildPageTopic,
+  RuntimeWsGateway,
+  type PageSubscribedEvent,
+  type WsClientLike
+} from "../src/gateway/ws.gateway";
+
+test("buildPageTopic creates tenant/page/instance scoped topic", () => {
+  assert.equal(
+    buildPageTopic({
+      tenantId: "tenant-a",
+      pageId: "orders",
+      pageInstanceId: "instance-1"
+    }),
+    "tenant.tenant-a.page.orders.instance.instance-1"
+  );
+});
+
+test("runtime websocket gateway confirms page subscription", () => {
+  const gateway = new RuntimeWsGateway();
+  const emitted: Array<{ event: string; payload: unknown }> = [];
+  const client: WsClientLike = {
+    id: "client-1",
+    emit(event: string, payload: unknown): void {
+      emitted.push({ event, payload });
+    }
+  };
+
+  gateway.handleConnection(client);
+  const result = gateway.subscribePage(
+    {
+      tenantId: "tenant-a",
+      pageId: "orders",
+      pageInstanceId: "instance-1"
+    },
+    client
+  );
+  gateway.handleDisconnect(client);
+
+  const expected: PageSubscribedEvent = {
+    tenantId: "tenant-a",
+    pageId: "orders",
+    pageInstanceId: "instance-1",
+    topic: "tenant.tenant-a.page.orders.instance.instance-1",
+    status: "subscribed"
+  };
+  assert.deepEqual(result, expected);
+  assert.deepEqual(emitted, [{ event: "pageSubscribed", payload: expected }]);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,10 +57,16 @@ importers:
         version: 10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core':
         specifier: ^10.4.12
-        version: 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(@nestjs/websockets@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/platform-express':
         specifier: ^10.4.22
         version: 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)
+      '@nestjs/platform-socket.io':
+        specifier: ^10.4.22
+        version: 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/websockets@10.4.22)(rxjs@7.8.2)
+      '@nestjs/websockets':
+        specifier: ^10.4.22
+        version: 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@nestjs/platform-socket.io@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@zhongmiao/meta-lc-contracts':
         specifier: workspace:*
         version: link:../contracts
@@ -340,6 +346,25 @@ packages:
       '@nestjs/common': ^10.0.0
       '@nestjs/core': ^10.0.0
 
+  '@nestjs/platform-socket.io@10.4.22':
+    resolution: {integrity: sha512-xxGw3R0Ihr51/Omq23z3//bKmCXyVKaikxbH0/pkwqMsQrxkUv9NabNUZ22b4Jnlwwi02X+zlwo8GRa9u8oV9g==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0
+      '@nestjs/websockets': ^10.0.0
+      rxjs: ^7.1.0
+
+  '@nestjs/websockets@10.4.22':
+    resolution: {integrity: sha512-OLd4i0Faq7vgdtB5vVUrJ54hWEtcXy9poJ6n7kbbh/5ms+KffUl+wwGsbe7uSXLrkoyI8xXU6fZPkFArI+XiRg==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0
+      '@nestjs/core': ^10.0.0
+      '@nestjs/platform-socket.io': ^10.0.0
+      reflect-metadata: ^0.1.12 || ^0.2.0
+      rxjs: ^7.1.0
+    peerDependenciesMeta:
+      '@nestjs/platform-socket.io':
+        optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -420,6 +445,9 @@ packages:
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
 
+  '@socket.io/component-emitter@3.1.2':
+    resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
+
   '@tokenizer/inflate@0.2.7':
     resolution: {integrity: sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==}
     engines: {node: '>=18'}
@@ -430,6 +458,9 @@ packages:
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
 
+  '@types/cors@2.8.19':
+    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
+
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
@@ -438,6 +469,9 @@ packages:
 
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@yarnpkg/lockfile@1.1.0':
     resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
@@ -497,6 +531,10 @@ packages:
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  base64id@2.0.0:
+    resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
+    engines: {node: ^4.5.0 || >= 5.9}
 
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
@@ -610,6 +648,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.3.7:
+    resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -674,6 +721,14 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  engine.io-parser@5.2.3:
+    resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
+    engines: {node: '>=10.0.0'}
+
+  engine.io@6.6.6:
+    resolution: {integrity: sha512-U2SN0w3OpjFRVlrc17E6TMDmH58Xl9rai1MblNjAdwWp07Kk+llmzX0hjDpQdrDGzwmvOtgM5yI+meYX6iZ2xA==}
+    engines: {node: '>=10.2.0'}
 
   enquirer@2.3.6:
     resolution: {integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==}
@@ -1065,6 +1120,10 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -1329,6 +1388,17 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  socket.io-adapter@2.5.6:
+    resolution: {integrity: sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==}
+
+  socket.io-parser@4.2.6:
+    resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
+    engines: {node: '>=10.0.0'}
+
+  socket.io@4.8.1:
+    resolution: {integrity: sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==}
+    engines: {node: '>=10.2.0'}
+
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
@@ -1466,6 +1536,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -1696,7 +1778,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@nestjs/core@10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+  '@nestjs/core@10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(@nestjs/websockets@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:
       '@nestjs/common': 10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nuxtjs/opencollective': 0.3.2
@@ -1709,13 +1791,14 @@ snapshots:
       uid: 2.0.2
     optionalDependencies:
       '@nestjs/platform-express': 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)
+      '@nestjs/websockets': 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@nestjs/platform-socket.io@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
     transitivePeerDependencies:
       - encoding
 
   '@nestjs/platform-express@10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)':
     dependencies:
       '@nestjs/common': 10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(@nestjs/websockets@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       body-parser: 1.20.4
       cors: 2.8.5
       express: 4.22.1
@@ -1723,6 +1806,30 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
+
+  '@nestjs/platform-socket.io@10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/websockets@10.4.22)(rxjs@7.8.2)':
+    dependencies:
+      '@nestjs/common': 10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/websockets': 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@nestjs/platform-socket.io@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      rxjs: 7.8.2
+      socket.io: 4.8.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@nestjs/websockets@10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@nestjs/platform-socket.io@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+    dependencies:
+      '@nestjs/common': 10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(@nestjs/websockets@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      iterare: 1.2.1
+      object-hash: 3.0.0
+      reflect-metadata: 0.2.2
+      rxjs: 7.8.2
+      tslib: 2.8.1
+    optionalDependencies:
+      '@nestjs/platform-socket.io': 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/websockets@10.4.22)(rxjs@7.8.2)
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -1776,6 +1883,8 @@ snapshots:
 
   '@sinclair/typebox@0.27.10': {}
 
+  '@socket.io/component-emitter@3.1.2': {}
+
   '@tokenizer/inflate@0.2.7':
     dependencies:
       debug: 4.4.3
@@ -1790,6 +1899,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@types/cors@2.8.19':
+    dependencies:
+      '@types/node': 22.19.17
+
   '@types/node@12.20.55': {}
 
   '@types/node@22.19.17':
@@ -1801,6 +1914,10 @@ snapshots:
       '@types/node': 22.19.17
       pg-protocol: 1.13.0
       pg-types: 2.2.0
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.19.17
 
   '@yarnpkg/lockfile@1.1.0': {}
 
@@ -1853,6 +1970,8 @@ snapshots:
   balanced-match@1.0.2: {}
 
   base64-js@1.5.1: {}
+
+  base64id@2.0.0: {}
 
   better-path-resolve@1.0.0:
     dependencies:
@@ -1977,6 +2096,10 @@ snapshots:
     dependencies:
       ms: 2.0.0
 
+  debug@4.3.7:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -2022,6 +2145,25 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+
+  engine.io-parser@5.2.3: {}
+
+  engine.io@6.6.6:
+    dependencies:
+      '@types/cors': 2.8.19
+      '@types/node': 22.19.17
+      '@types/ws': 8.18.1
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cookie: 0.7.2
+      cors: 2.8.5
+      debug: 4.4.3
+      engine.io-parser: 5.2.3
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   enquirer@2.3.6:
     dependencies:
@@ -2440,6 +2582,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-hash@3.0.0: {}
+
   object-inspect@1.13.4: {}
 
   on-finished@2.4.1:
@@ -2701,6 +2845,36 @@ snapshots:
 
   slash@3.0.0: {}
 
+  socket.io-adapter@2.5.6:
+    dependencies:
+      debug: 4.4.3
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  socket.io-parser@4.2.6:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  socket.io@4.8.1:
+    dependencies:
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cors: 2.8.5
+      debug: 4.3.7
+      engine.io: 6.6.6
+      socket.io-adapter: 2.5.6
+      socket.io-parser: 4.2.6
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   spawndamnit@3.0.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -2821,6 +2995,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   wrappy@1.0.2: {}
+
+  ws@8.18.3: {}
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
## Summary
- add #34 Gateway baseline: read-only meta API envelopes, in-memory cache, aggregation summary, and WebSocket lifecycle smoke
- wire gateway/cache/aggregation services into the BFF module
- add BFF unit tests, WebSocket runtime adapter deps, and changelog entries

## Validation
- pnpm install --frozen-lockfile
- pnpm lint:boundaries
- pnpm --filter @zhongmiao/meta-lc-bff test
- pnpm lint
- pnpm -r test
- BFF_URL=http://127.0.0.1:6000 PORT=6000 pnpm query-gate
- pnpm test:boundaries
- pnpm changelog:gate origin/main HEAD
- git diff --check

## Notes
- Real meta DB querying, Redis cache, and WebSocket diff/replay remain follow-up work.

Closes #34