### PR TITLE
feat(runtime): add orchestrator baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - fix(boundaries): tighten direct `pg` access down to explicit BFF/datasource/kernel entry points and remove the audit package from the transitional DB-driver allowlist.
 - fix(boundaries): promote DB-driver boundary checks from a transitional allowlist to explicit package/file policy checks with self-tests.
 - feat(bff): add the first Gateway baseline for meta APIs, in-memory cache, aggregation summary, and WebSocket lifecycle smoke.
+- feat(runtime): add a manager-first runtime orchestrator baseline and shared runtime page topic helper.
 
 ## 0.1.0 (2026-04-18)
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -11,6 +11,7 @@
 - fix(boundaries): 将 `pg` 直连点收紧到显式的 BFF/datasource/kernel 入口，并把 audit 包移出过渡白名单。
 - fix(boundaries): 将 DB driver 边界检查从过渡白名单升级为显式包/文件策略检查，并补充自测。
 - feat(bff): 新增首版 Gateway 基线，覆盖 meta API、内存 cache、aggregation summary 与 WebSocket lifecycle smoke。
+- feat(runtime): 新增 manager-first runtime orchestrator 基线与共享 runtime page topic helper。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/bff/CHANGELOG.md
+++ b/packages/bff/CHANGELOG.md
@@ -3,6 +3,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 ## [Unreleased]
 
 - feat(gateway): add meta API, in-memory cache, aggregation summary, and WebSocket lifecycle baseline.
+- chore(gateway): reuse the shared runtime page topic helper for WebSocket subscription acknowledgements.
 - chore(package): adopt the `@zhongmiao/meta-lc-bff` scoped package identity for release governance.
 - fix(local-dev): move the default BFF local port to `6001` and bind an explicit host so browser-based integration can reach the service without unsafe-port blocking.
 - test(permission-gate): expand the query/mutation gate baseline to cover `SELF`, `DEPT_AND_CHILDREN`, and `CUSTOM_ORG_SET` permission paths in addition to the existing `DEPT` denied checks.

--- a/packages/bff/CHANGELOG.zh-CN.md
+++ b/packages/bff/CHANGELOG.zh-CN.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - feat(gateway): 新增 meta API、内存 cache、aggregation summary 与 WebSocket lifecycle 基线。
+- chore(gateway): WebSocket subscription acknowledgement 复用共享 runtime page topic helper。
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-bff` 正式包名。
 - fix(local-dev): 将 BFF 本地默认端口调整为 `6001`，并显式绑定 host，避免浏览器因 unsafe port 策略阻断联调访问。
 - test(permission-gate): 将 query/mutation gate 扩展到 `SELF`、`DEPT_AND_CHILDREN`、`CUSTOM_ORG_SET` 权限路径，不再只覆盖现有 `DEPT` denied 样例。

--- a/packages/bff/src/gateway/ws.gateway.ts
+++ b/packages/bff/src/gateway/ws.gateway.ts
@@ -7,17 +7,17 @@ import {
   SubscribeMessage,
   WebSocketGateway
 } from "@nestjs/websockets";
+import {
+  buildRuntimePageTopic,
+  type RuntimePageTopicRef
+} from "@zhongmiao/meta-lc-contracts";
 
 export interface WsClientLike {
   id: string;
   emit(event: string, payload: unknown): void;
 }
 
-export interface SubscribePageMessage {
-  tenantId: string;
-  pageId: string;
-  pageInstanceId: string;
-}
+export interface SubscribePageMessage extends RuntimePageTopicRef {}
 
 export interface PageSubscribedEvent extends SubscribePageMessage {
   topic: string;
@@ -52,5 +52,5 @@ export class RuntimeWsGateway implements OnGatewayConnection<WsClientLike>, OnGa
 }
 
 export function buildPageTopic(message: SubscribePageMessage): string {
-  return `tenant.${message.tenantId}.page.${message.pageId}.instance.${message.pageInstanceId}`;
+  return buildRuntimePageTopic(message);
 }

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -5,6 +5,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - chore(package): adopt the `@zhongmiao/meta-lc-contracts` scoped package identity for release governance.
 - feat(runtime-contracts): add refresh planning event and target contracts for dependency graph execution.
 - feat(runtime-contracts): add rule and function contracts for event-driven runtime evaluation.
+- feat(runtime-contracts): add the shared runtime page topic helper used by BFF WebSocket and runtime orchestration boundaries.
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/contracts/CHANGELOG.zh-CN.md
+++ b/packages/contracts/CHANGELOG.zh-CN.md
@@ -5,6 +5,7 @@
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-contracts` 正式包名。
 - feat(runtime-contracts): 补充依赖图执行所需的刷新事件与目标契约类型。
 - feat(runtime-contracts): 补充事件驱动规则求值所需的规则与函数契约类型。
+- feat(runtime-contracts): 新增共享 runtime page topic helper，用于 BFF WebSocket 与 runtime orchestration 边界对齐。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -106,6 +106,16 @@ export interface RuntimePageMeta {
   description?: string;
 }
 
+export interface RuntimePageTopicRef {
+  tenantId: string;
+  pageId: string;
+  pageInstanceId: string;
+}
+
+export function buildRuntimePageTopic(ref: RuntimePageTopicRef): string {
+  return `tenant.${ref.tenantId}.page.${ref.pageId}.instance.${ref.pageInstanceId}`;
+}
+
 export interface RuntimeNodeSchema {
   id: string;
   componentType: string;

--- a/packages/contracts/test/smoke.test.ts
+++ b/packages/contracts/test/smoke.test.ts
@@ -1,13 +1,14 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import type {
-  QueryApiRequest,
-  RuntimeFunctionCallDefinition,
-  RuntimePageDsl,
-  RuntimeRuleDefinition,
-  RuntimeRefreshEvent,
-  RuntimeRefreshPlan,
-  RuntimeTemplateDependency
+import {
+  buildRuntimePageTopic,
+  type QueryApiRequest,
+  type RuntimeFunctionCallDefinition,
+  type RuntimePageDsl,
+  type RuntimeRuleDefinition,
+  type RuntimeRefreshEvent,
+  type RuntimeRefreshPlan,
+  type RuntimeTemplateDependency
 } from "../src";
 
 test("contracts exports query request type", () => {
@@ -87,4 +88,15 @@ test("contracts exports runtime refresh planning types", () => {
 
   assert.equal(plan.triggeredBy.type, "mutation.succeeded");
   assert.equal(plan.targetOrder[0]?.kind, "datasource");
+});
+
+test("contracts exports runtime page topic helper", () => {
+  assert.equal(
+    buildRuntimePageTopic({
+      tenantId: "tenant-a",
+      pageId: "orders-page",
+      pageInstanceId: "instance-1"
+    }),
+    "tenant.tenant-a.page.orders-page.instance.instance-1"
+  );
 });

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -5,6 +5,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - chore(package): adopt the `@zhongmiao/meta-lc-runtime` scoped package identity for release governance.
 - feat(runtime): add dependency graph construction and auto-refresh planning for state and mutation events.
 - feat(runtime): add a minimal function registry and rule engine for event-driven runtime effects.
+- feat(runtime): add a manager-first orchestration plan that combines refresh planning, rule effects, next state, manager commands, and WebSocket topics.
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/runtime/CHANGELOG.zh-CN.md
+++ b/packages/runtime/CHANGELOG.zh-CN.md
@@ -5,6 +5,7 @@
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-runtime` 正式包名。
 - feat(runtime): 新增依赖图构建与自动刷新规划，覆盖 state 与 mutation 成功事件。
 - feat(runtime): 新增最小 FunctionRegistry 与 RuleEngine，支持事件驱动的规则 effect 计算。
+- feat(runtime): 新增 manager-first orchestration plan，统一 refresh planning、rule effects、next state、manager commands 与 WebSocket topics。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./runtime-dsl-parser";
 export * from "./dependency-graph";
 export * from "./function-registry";
+export * from "./orchestrator";
 export * from "./rule-engine";
 export * from "./template-resolver";
 export * from "./types";

--- a/packages/runtime/src/orchestrator.ts
+++ b/packages/runtime/src/orchestrator.ts
@@ -1,0 +1,124 @@
+import {
+  buildRuntimePageTopic,
+  type RuntimePageDsl,
+  type RuntimePageTopicRef,
+  type RuntimeRefreshEvent,
+  type RuntimeRefreshPlan
+} from "@zhongmiao/meta-lc-contracts";
+import { buildDependencyGraph, planRefresh } from "./dependency-graph";
+import { createFunctionRegistry } from "./function-registry";
+import { evaluateRules } from "./rule-engine";
+import { parseRuntimePageDsl } from "./runtime-dsl-parser";
+import type {
+  ParsedRuntimePageDsl,
+  RuntimeFunctionRegistry,
+  RuntimeRuleEffectsPlan
+} from "./types";
+
+export type RuntimeManagerCommand =
+  | {
+      type: "patchState";
+      patch: Record<string, unknown>;
+    }
+  | {
+      type: "refreshDatasource";
+      datasourceId: string;
+    }
+  | {
+      type: "runAction";
+      actionId: string;
+    };
+
+export interface RuntimeOrchestrationRequest {
+  dsl: RuntimePageDsl | ParsedRuntimePageDsl;
+  state: Record<string, unknown>;
+  event: RuntimeRefreshEvent;
+  functionRegistry?: RuntimeFunctionRegistry;
+  pageInstance?: RuntimePageTopicRef;
+}
+
+export interface RuntimeOrchestrationPlan {
+  refreshPlan: RuntimeRefreshPlan;
+  ruleEffects: RuntimeRuleEffectsPlan;
+  nextState: Record<string, unknown>;
+  managerCommands: RuntimeManagerCommand[];
+  wsTopics: string[];
+}
+
+export async function orchestrateRuntimeEvent(
+  request: RuntimeOrchestrationRequest
+): Promise<RuntimeOrchestrationPlan> {
+  const parsedDsl = isParsedRuntimePageDsl(request.dsl) ? request.dsl : parseRuntimePageDsl(request.dsl);
+  const graph = buildDependencyGraph(parsedDsl);
+  const refreshPlan = planRefresh(graph, request.event);
+  const functionRegistry = request.functionRegistry ?? createFunctionRegistry();
+  const ruleEffects = await evaluateRules({
+    event: request.event,
+    state: request.state,
+    parsedDsl,
+    graph,
+    functionRegistry
+  });
+  const nextState = {
+    ...request.state,
+    ...ruleEffects.patchState
+  };
+
+  return {
+    refreshPlan,
+    ruleEffects,
+    nextState,
+    managerCommands: buildManagerCommands(refreshPlan, ruleEffects),
+    wsTopics: request.pageInstance ? [buildRuntimePageTopic(request.pageInstance)] : []
+  };
+}
+
+function buildManagerCommands(
+  refreshPlan: RuntimeRefreshPlan,
+  ruleEffects: RuntimeRuleEffectsPlan
+): RuntimeManagerCommand[] {
+  const commands: RuntimeManagerCommand[] = [];
+  if (Object.keys(ruleEffects.patchState).length > 0) {
+    commands.push({
+      type: "patchState",
+      patch: ruleEffects.patchState
+    });
+  }
+
+  for (const datasourceId of mergeStableIds(refreshPlan.datasourceIds, ruleEffects.refreshDatasourceIds)) {
+    commands.push({
+      type: "refreshDatasource",
+      datasourceId
+    });
+  }
+
+  for (const actionId of mergeStableIds(refreshPlan.actionIds, ruleEffects.runActionIds)) {
+    commands.push({
+      type: "runAction",
+      actionId
+    });
+  }
+
+  return commands;
+}
+
+function mergeStableIds(primary: string[], secondary: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  const append = (id: string): void => {
+    if (seen.has(id)) {
+      return;
+    }
+    seen.add(id);
+    result.push(id);
+  };
+
+  primary.forEach(append);
+  [...secondary].sort((left, right) => left.localeCompare(right)).forEach(append);
+  return result;
+}
+
+function isParsedRuntimePageDsl(value: RuntimePageDsl | ParsedRuntimePageDsl): value is ParsedRuntimePageDsl {
+  return "stateKeys" in value && "dependencies" in value;
+}

--- a/packages/runtime/test/orchestrator.test.ts
+++ b/packages/runtime/test/orchestrator.test.ts
@@ -1,0 +1,266 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildRuntimePageTopic,
+  type RuntimePageDsl
+} from "@zhongmiao/meta-lc-contracts";
+import {
+  orchestrateRuntimeEvent,
+  parseRuntimePageDsl,
+  RuntimeDependencyGraphError,
+  RuntimeRuleEngineError
+} from "../src";
+
+function createRuntimeDsl(): RuntimePageDsl {
+  return {
+    schemaVersion: "runtime-page-dsl.v1",
+    pageMeta: {
+      id: "orders-page",
+      title: "Orders Page"
+    },
+    state: {
+      tenantId: "tenant-a",
+      filter_status: "PAID",
+      selectedOrderId: "",
+      tableData: [],
+      detailData: null,
+      shouldReload: false
+    },
+    datasources: [
+      {
+        id: "orders-query-datasource",
+        type: "rest",
+        request: {
+          params: {
+            status: "{{state.filter_status}}"
+          }
+        },
+        responseMapping: {
+          stateKey: "tableData"
+        }
+      },
+      {
+        id: "order-detail-datasource",
+        type: "rest",
+        request: {
+          params: {
+            id: "{{state.selectedOrderId}}"
+          }
+        },
+        responseMapping: {
+          stateKey: "detailData"
+        }
+      }
+    ],
+    actions: [
+      {
+        id: "select-order-action",
+        trigger: "state.changed",
+        steps: [
+          {
+            type: "setState",
+            patch: {
+              selectedOrderId: "{{state.selectedOrderId}}"
+            }
+          }
+        ]
+      },
+      {
+        id: "save-order-action",
+        steps: [{ type: "callMutation" }],
+        onSuccess: {
+          refreshDatasources: ["orders-query-datasource"],
+          runActions: ["select-order-action"]
+        }
+      },
+      {
+        id: "notify-action",
+        steps: [{ type: "toast", message: "saved" }]
+      }
+    ],
+    rules: [
+      {
+        id: "reload-paid-orders-rule",
+        trigger: "state.changed",
+        condition: {
+          call: {
+            name: "eq",
+            args: [
+              { source: "state", key: "filter_status" },
+              { source: "literal", value: "PAID" }
+            ]
+          }
+        },
+        effects: [
+          {
+            type: "setState",
+            stateKey: "shouldReload",
+            value: { source: "literal", value: true }
+          },
+          {
+            type: "refreshDatasource",
+            datasourceId: "orders-query-datasource"
+          },
+          {
+            type: "runAction",
+            actionId: "notify-action"
+          }
+        ]
+      }
+    ],
+    layoutTree: []
+  };
+}
+
+test("orchestrateRuntimeEvent parses raw DSL and creates a stable manager plan", async () => {
+  const dsl = createRuntimeDsl();
+  const plan = await orchestrateRuntimeEvent({
+    dsl,
+    state: dsl.state,
+    event: {
+      type: "state.changed",
+      stateKeys: ["selectedOrderId", "filter_status"]
+    },
+    pageInstance: {
+      tenantId: "tenant-a",
+      pageId: "orders-page",
+      pageInstanceId: "instance-1"
+    }
+  });
+
+  assert.deepEqual(plan.refreshPlan.targetOrder, [
+    { kind: "datasource", id: "orders-query-datasource" },
+    { kind: "action", id: "select-order-action" },
+    { kind: "datasource", id: "order-detail-datasource" }
+  ]);
+  assert.deepEqual(plan.ruleEffects.matchedRuleIds, ["reload-paid-orders-rule"]);
+  assert.deepEqual(plan.nextState, {
+    ...dsl.state,
+    shouldReload: true
+  });
+  assert.deepEqual(plan.managerCommands, [
+    {
+      type: "patchState",
+      patch: {
+        shouldReload: true
+      }
+    },
+    {
+      type: "refreshDatasource",
+      datasourceId: "orders-query-datasource"
+    },
+    {
+      type: "refreshDatasource",
+      datasourceId: "order-detail-datasource"
+    },
+    {
+      type: "runAction",
+      actionId: "select-order-action"
+    },
+    {
+      type: "runAction",
+      actionId: "notify-action"
+    }
+  ]);
+  assert.deepEqual(plan.wsTopics, ["tenant.tenant-a.page.orders-page.instance.instance-1"]);
+});
+
+test("orchestrateRuntimeEvent accepts parsed DSL and preserves mutation refresh order", async () => {
+  const dsl = createRuntimeDsl();
+  const parsedDsl = parseRuntimePageDsl(dsl);
+  const plan = await orchestrateRuntimeEvent({
+    dsl: parsedDsl,
+    state: dsl.state,
+    event: {
+      type: "mutation.succeeded",
+      actionId: "save-order-action",
+      operation: "update"
+    }
+  });
+
+  assert.deepEqual(plan.ruleEffects.matchedRuleIds, []);
+  assert.deepEqual(plan.nextState, dsl.state);
+  assert.deepEqual(plan.managerCommands, [
+    {
+      type: "refreshDatasource",
+      datasourceId: "orders-query-datasource"
+    },
+    {
+      type: "refreshDatasource",
+      datasourceId: "order-detail-datasource"
+    },
+    {
+      type: "runAction",
+      actionId: "select-order-action"
+    }
+  ]);
+  assert.deepEqual(plan.wsTopics, []);
+});
+
+test("orchestrator keeps graph and rule errors observable", async () => {
+  const dsl = createRuntimeDsl();
+  await assert.rejects(
+    () =>
+      orchestrateRuntimeEvent({
+        dsl,
+        state: dsl.state,
+        event: {
+          type: "state.changed",
+          stateKeys: ["missingState"]
+        }
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof RuntimeDependencyGraphError);
+      assert.equal(error.message, 'Unknown state key "missingState" in state.changed event.');
+      return true;
+    }
+  );
+
+  await assert.rejects(
+    () =>
+      orchestrateRuntimeEvent({
+        dsl: {
+          ...dsl,
+          rules: [
+            {
+              id: "broken-rule",
+              trigger: "state.changed",
+              condition: {
+                call: {
+                  name: "notEmpty",
+                  args: [{ source: "literal", value: "ok" }]
+                }
+              },
+              effects: [
+                {
+                  type: "refreshDatasource",
+                  datasourceId: "missing-datasource"
+                }
+              ]
+            }
+          ]
+        },
+        state: dsl.state,
+        event: {
+          type: "state.changed",
+          stateKeys: ["filter_status"]
+        }
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof RuntimeRuleEngineError);
+      assert.equal(error.message, 'Rule effect references unknown datasource "missing-datasource".');
+      return true;
+    }
+  );
+});
+
+test("runtime page topic helper matches the BFF websocket baseline", () => {
+  assert.equal(
+    buildRuntimePageTopic({
+      tenantId: "tenant-a",
+      pageId: "orders-page",
+      pageInstanceId: "instance-1"
+    }),
+    "tenant.tenant-a.page.orders-page.instance.instance-1"
+  );
+});


### PR DESCRIPTION
## Summary
- add #21 Runtime Orchestrator V1 baseline that combines parsing, dependency graph refresh planning, rule effects, next state, manager commands, and WebSocket topic placeholders
- add shared runtime page topic helper in contracts and make BFF WebSocket subscription acknowledgements reuse it
- add runtime/contracts tests and changelog entries

## Validation
- pnpm --filter @zhongmiao/meta-lc-runtime test
- pnpm --filter @zhongmiao/meta-lc-contracts test
- pnpm --filter @zhongmiao/meta-lc-bff test
- pnpm lint:boundaries
- pnpm lint
- pnpm -r test
- pnpm test:boundaries
- pnpm changelog:gate origin/main HEAD
- git diff --check

## Notes
- No DSL expansion, no real WebSocket push, no Redis/queue, no Angular manager consumer changes.
- #28/#30 compiler work remains open for a later Phase 2 pass.

Refs #21