### PR TITLE
feat(kernel): add sql generator baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - fix(boundaries): promote DB-driver boundary checks from a transitional allowlist to explicit package/file policy checks with self-tests.
 - feat(bff): add the first Gateway baseline for meta APIs, in-memory cache, aggregation summary, and WebSocket lifecycle smoke.
 - feat(runtime): add a manager-first runtime orchestrator baseline and shared runtime page topic helper.
+- feat(kernel): add a SQL Generator V1 baseline for tables, indexes, relations, and compiler fixture coverage.
 
 ## 0.1.0 (2026-04-18)
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -12,6 +12,7 @@
 - fix(boundaries): 将 DB driver 边界检查从过渡白名单升级为显式包/文件策略检查，并补充自测。
 - feat(bff): 新增首版 Gateway 基线，覆盖 meta API、内存 cache、aggregation summary 与 WebSocket lifecycle smoke。
 - feat(runtime): 新增 manager-first runtime orchestrator 基线与共享 runtime page topic helper。
+- feat(kernel): 新增 SQL Generator V1 基线，覆盖 table、index、relation 与 compiler fixture。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/kernel/CHANGELOG.md
+++ b/packages/kernel/CHANGELOG.md
@@ -3,6 +3,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 ## [Unreleased]
 
 - chore(package): adopt the `@zhongmiao/meta-lc-kernel` scoped package identity for release governance.
+- feat(sql-generator): add table, index, relation SQL generation and a compiler fixture baseline.
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/kernel/CHANGELOG.zh-CN.md
+++ b/packages/kernel/CHANGELOG.zh-CN.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-kernel` 正式包名。
+- feat(sql-generator): 新增 table、index、relation SQL 生成能力与 compiler fixture 基线。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/kernel/src/contracts.ts
+++ b/packages/kernel/src/contracts.ts
@@ -1,4 +1,4 @@
-import type { MetaSchema } from "./types";
+import type { MetaField, MetaSchema, MetaTable, SnapshotRelation } from "./types";
 
 export const REQUIRED_ROOT_KEYS = ["tables"];
 
@@ -16,13 +16,91 @@ export function validateSchema(schema: MetaSchema): void {
   if (!Array.isArray(schema.tables)) {
     throw new Error("Schema.tables must be an array.");
   }
+  if (schema.relations !== undefined && !Array.isArray(schema.relations)) {
+    throw new Error("Schema.relations must be an array when provided.");
+  }
 
+  const tableNames = new Set<string>();
   for (const table of schema.tables) {
     if (!table?.name) {
       throw new Error("Every table requires a name.");
     }
+    if (tableNames.has(table.name)) {
+      throw new Error(`Duplicate table name: ${table.name}.`);
+    }
+    tableNames.add(table.name);
     if (!Array.isArray(table.fields)) {
       throw new Error(`Table ${table.name} must define fields array.`);
+    }
+    validateFields(table);
+    validateIndexes(table);
+  }
+
+  validateRelations(schema.tables, schema.relations ?? []);
+}
+
+function validateFields(table: MetaTable): void {
+  const fieldNames = new Set<string>();
+  for (const field of table.fields) {
+    if (!field?.name) {
+      throw new Error(`Table ${table.name} has a field without a name.`);
+    }
+    if (fieldNames.has(field.name)) {
+      throw new Error(`Duplicate field name "${field.name}" in table ${table.name}.`);
+    }
+    fieldNames.add(field.name);
+  }
+}
+
+function validateIndexes(table: MetaTable): void {
+  if (table.indexes === undefined) {
+    return;
+  }
+  if (!Array.isArray(table.indexes)) {
+    throw new Error(`Table ${table.name} indexes must be an array when provided.`);
+  }
+
+  const fieldNames = new Set(table.fields.map((field: MetaField) => field.name));
+  const indexNames = new Set<string>();
+  for (const index of table.indexes) {
+    if (!index?.name) {
+      throw new Error(`Table ${table.name} has an index without a name.`);
+    }
+    if (indexNames.has(index.name)) {
+      throw new Error(`Duplicate index name "${index.name}" in table ${table.name}.`);
+    }
+    indexNames.add(index.name);
+    if (!Array.isArray(index.fields) || index.fields.length === 0) {
+      throw new Error(`Index ${index.name} in table ${table.name} must define at least one field.`);
+    }
+    for (const field of index.fields) {
+      if (!fieldNames.has(field)) {
+        throw new Error(`Index ${index.name} in table ${table.name} references unknown field "${field}".`);
+      }
+    }
+  }
+}
+
+function validateRelations(tables: MetaTable[], relations: SnapshotRelation[]): void {
+  const tableMap = new Map(tables.map((table) => [table.name, new Set(table.fields.map((field) => field.name))]));
+
+  for (const relation of relations) {
+    if (!relation.fromTable || !relation.fromField || !relation.toTable || !relation.toField) {
+      throw new Error("Relation must define fromTable, fromField, toTable, and toField.");
+    }
+    const fromFields = tableMap.get(relation.fromTable);
+    if (!fromFields) {
+      throw new Error(`Relation references unknown fromTable "${relation.fromTable}".`);
+    }
+    if (!fromFields.has(relation.fromField)) {
+      throw new Error(`Relation references unknown fromField "${relation.fromField}" on table ${relation.fromTable}.`);
+    }
+    const toFields = tableMap.get(relation.toTable);
+    if (!toFields) {
+      throw new Error(`Relation references unknown toTable "${relation.toTable}".`);
+    }
+    if (!toFields.has(relation.toField)) {
+      throw new Error(`Relation references unknown toField "${relation.toField}" on table ${relation.toTable}.`);
     }
   }
 }

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -6,3 +6,4 @@ export * from "./meta-kernel-service";
 export * from "./schema-diff";
 export * from "./migration-safety";
 export * from "./snapshot-dsl";
+export * from "./sql-generator";

--- a/packages/kernel/src/schema-diff.ts
+++ b/packages/kernel/src/schema-diff.ts
@@ -1,4 +1,5 @@
 import type { MetaField, MetaSchema, MetaTable } from "./types";
+import { createTableSql, quoteIdentifier, toSqlType } from "./sql-utils";
 
 export interface FieldChange {
   field: string;
@@ -62,10 +63,7 @@ export function generateMigrationSql(diff: SchemaDiff): string[] {
   const statements: string[] = [];
 
   for (const table of diff.addedTables) {
-    const columns = table.fields
-      .map((field) => `${quoteIdentifier(field.name)} ${toSqlType(field.type)}${field.nullable ? "" : " NOT NULL"}`)
-      .join(", ");
-    statements.push(`CREATE TABLE ${quoteIdentifier(table.name)} (${columns});`);
+    statements.push(createTableSql(table.name, table.fields));
   }
 
   for (const table of diff.changedTables) {
@@ -122,21 +120,4 @@ function diffTableFields(table: string, fromFields: MetaField[], toFields: MetaF
   }
 
   return { table, addedFields, removedFields, changedFields };
-}
-
-function quoteIdentifier(value: string): string {
-  if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(value)) {
-    throw new Error(`Invalid identifier: ${value}`);
-  }
-  return `"${value}"`;
-}
-
-function toSqlType(type: string): string {
-  const normalized = type.toLowerCase();
-  if (normalized === "string") return "TEXT";
-  if (normalized === "number") return "INTEGER";
-  if (normalized === "boolean") return "BOOLEAN";
-  if (normalized === "date") return "TIMESTAMPTZ";
-  if (normalized === "uuid") return "UUID";
-  return type.toUpperCase();
 }

--- a/packages/kernel/src/snapshot-dsl.ts
+++ b/packages/kernel/src/snapshot-dsl.ts
@@ -1,12 +1,12 @@
 import { createHash } from "node:crypto";
 import type {
   CompiledMigrationSql,
-  MetaField,
   MigrationAction,
   MigrationDslV1,
   SnapshotV1
 } from "./types";
 import { diffSchemas } from "./schema-diff";
+import { createTableSql, quoteIdentifier, toColumnDefinition, toSqlType } from "./sql-utils";
 
 export function computeSnapshotChecksum(snapshot: Omit<SnapshotV1, "checksum">): string {
   return sha256(stableStringify(snapshot));
@@ -185,30 +185,4 @@ function stableStringify(value: unknown): string {
   const object = value as Record<string, unknown>;
   const sortedKeys = Object.keys(object).sort();
   return `{${sortedKeys.map((key) => `${JSON.stringify(key)}:${stableStringify(object[key])}`).join(",")}}`;
-}
-
-function createTableSql(tableName: string, fields: MetaField[]): string {
-  const columns = fields.map((field) => toColumnDefinition(field)).join(", ");
-  return `CREATE TABLE ${quoteIdentifier(tableName)} (${columns});`;
-}
-
-function toColumnDefinition(field: MetaField): string {
-  return `${quoteIdentifier(field.name)} ${toSqlType(field.type)}${field.nullable ? "" : " NOT NULL"}`;
-}
-
-function quoteIdentifier(value: string): string {
-  if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(value)) {
-    throw new Error(`Invalid identifier: ${value}`);
-  }
-  return `"${value}"`;
-}
-
-function toSqlType(type: string): string {
-  const normalized = type.toLowerCase();
-  if (normalized === "string") return "TEXT";
-  if (normalized === "number") return "INTEGER";
-  if (normalized === "boolean") return "BOOLEAN";
-  if (normalized === "date") return "TIMESTAMPTZ";
-  if (normalized === "uuid") return "UUID";
-  return type.toUpperCase();
 }

--- a/packages/kernel/src/sql-generator.ts
+++ b/packages/kernel/src/sql-generator.ts
@@ -1,0 +1,34 @@
+import type { CompiledSchemaSql, MetaIndex, MetaSchema, MetaTable, SnapshotRelation } from "./types";
+import { validateSchema } from "./contracts";
+import { createTableSql, quoteIdentifier } from "./sql-utils";
+
+export function compileSchemaSql(schema: MetaSchema): CompiledSchemaSql {
+  validateSchema(schema);
+
+  const tables = schema.tables.map((table) => createTableSql(table.name, table.fields));
+  const indexes = schema.tables.flatMap((table) => (table.indexes ?? []).map((index) => createIndexSql(table, index)));
+  const relations = (schema.relations ?? []).map((relation) => createRelationSql(relation));
+
+  return {
+    tables,
+    indexes,
+    relations,
+    statements: [...tables, ...indexes, ...relations]
+  };
+}
+
+function createIndexSql(table: MetaTable, index: MetaIndex): string {
+  const unique = index.unique ? "UNIQUE " : "";
+  const fields = index.fields.map((field) => quoteIdentifier(field)).join(", ");
+  return `CREATE ${unique}INDEX ${quoteIdentifier(index.name)} ON ${quoteIdentifier(table.name)} (${fields});`;
+}
+
+function createRelationSql(relation: SnapshotRelation): string {
+  const constraintName = `${relation.fromTable}_${relation.fromField}_fkey`;
+  return [
+    `ALTER TABLE ${quoteIdentifier(relation.fromTable)}`,
+    `ADD CONSTRAINT ${quoteIdentifier(constraintName)}`,
+    `FOREIGN KEY (${quoteIdentifier(relation.fromField)})`,
+    `REFERENCES ${quoteIdentifier(relation.toTable)} (${quoteIdentifier(relation.toField)});`
+  ].join(" ");
+}

--- a/packages/kernel/src/sql-utils.ts
+++ b/packages/kernel/src/sql-utils.ts
@@ -1,0 +1,27 @@
+import type { MetaField } from "./types";
+
+export function quoteIdentifier(value: string): string {
+  if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(value)) {
+    throw new Error(`Invalid identifier: ${value}`);
+  }
+  return `"${value}"`;
+}
+
+export function toSqlType(type: string): string {
+  const normalized = type.toLowerCase();
+  if (normalized === "string") return "TEXT";
+  if (normalized === "number") return "INTEGER";
+  if (normalized === "boolean") return "BOOLEAN";
+  if (normalized === "date") return "TIMESTAMPTZ";
+  if (normalized === "uuid") return "UUID";
+  return type.toUpperCase();
+}
+
+export function toColumnDefinition(field: MetaField): string {
+  return `${quoteIdentifier(field.name)} ${toSqlType(field.type)}${field.nullable ? "" : " NOT NULL"}`;
+}
+
+export function createTableSql(tableName: string, fields: MetaField[]): string {
+  const columns = fields.map((field) => toColumnDefinition(field)).join(", ");
+  return `CREATE TABLE ${quoteIdentifier(tableName)} (${columns});`;
+}

--- a/packages/kernel/src/types.ts
+++ b/packages/kernel/src/types.ts
@@ -7,13 +7,21 @@ export interface MetaField {
   defaultValue?: Primitive;
 }
 
+export interface MetaIndex {
+  name: string;
+  fields: string[];
+  unique?: boolean;
+}
+
 export interface MetaTable {
   name: string;
   fields: MetaField[];
+  indexes?: MetaIndex[];
 }
 
 export interface MetaSchema {
   tables: MetaTable[];
+  relations?: SnapshotRelation[];
 }
 
 export interface SnapshotRelation {
@@ -73,6 +81,13 @@ export interface MigrationDslV1 {
 export interface CompiledMigrationSql {
   up: string[];
   down: string[];
+}
+
+export interface CompiledSchemaSql {
+  tables: string[];
+  indexes: string[];
+  relations: string[];
+  statements: string[];
 }
 
 export interface MetaVersionMetadata {

--- a/packages/kernel/test/contracts.test.ts
+++ b/packages/kernel/test/contracts.test.ts
@@ -16,3 +16,108 @@ test("validateSchema throws for missing tables", () => {
     /required key: tables/
   );
 });
+
+test("validateSchema accepts indexes and relations", () => {
+  assert.doesNotThrow(() =>
+    validateSchema({
+      tables: [
+        {
+          name: "customers",
+          fields: [{ name: "id", type: "uuid" }],
+          indexes: [{ name: "customers_id_uidx", fields: ["id"], unique: true }]
+        },
+        {
+          name: "orders",
+          fields: [
+            { name: "id", type: "uuid" },
+            { name: "customer_id", type: "uuid" }
+          ],
+          indexes: [{ name: "orders_customer_idx", fields: ["customer_id"] }]
+        }
+      ],
+      relations: [
+        {
+          fromTable: "orders",
+          fromField: "customer_id",
+          toTable: "customers",
+          toField: "id"
+        }
+      ]
+    })
+  );
+});
+
+test("validateSchema rejects duplicate index names and empty index fields", () => {
+  assert.throws(
+    () =>
+      validateSchema({
+        tables: [
+          {
+            name: "orders",
+            fields: [{ name: "id", type: "uuid" }],
+            indexes: [
+              { name: "orders_id_idx", fields: ["id"] },
+              { name: "orders_id_idx", fields: ["id"] }
+            ]
+          }
+        ]
+      }),
+    /Duplicate index name "orders_id_idx" in table orders/
+  );
+
+  assert.throws(
+    () =>
+      validateSchema({
+        tables: [
+          {
+            name: "orders",
+            fields: [{ name: "id", type: "uuid" }],
+            indexes: [{ name: "orders_empty_idx", fields: [] }]
+          }
+        ]
+      }),
+    /must define at least one field/
+  );
+});
+
+test("validateSchema rejects relations to missing tables or fields", () => {
+  assert.throws(
+    () =>
+      validateSchema({
+        tables: [{ name: "orders", fields: [{ name: "id", type: "uuid" }] }],
+        relations: [
+          {
+            fromTable: "orders",
+            fromField: "customer_id",
+            toTable: "customers",
+            toField: "id"
+          }
+        ]
+      }),
+    /unknown fromField "customer_id"/
+  );
+
+  assert.throws(
+    () =>
+      validateSchema({
+        tables: [
+          {
+            name: "orders",
+            fields: [
+              { name: "id", type: "uuid" },
+              { name: "customer_id", type: "uuid" }
+            ]
+          }
+        ],
+        relations: [
+          {
+            fromTable: "orders",
+            fromField: "customer_id",
+            toTable: "customers",
+            toField: "id"
+          }
+        ]
+      }),
+    /unknown toTable "customers"/
+  );
+});

--- a/packages/kernel/test/sql-generator.test.ts
+++ b/packages/kernel/test/sql-generator.test.ts
@@ -1,0 +1,73 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { compileSchemaSql } from "../src";
+import type { MetaSchema } from "../src";
+
+function createCompilerFixture(): MetaSchema {
+  return {
+    tables: [
+      {
+        name: "customers",
+        fields: [
+          { name: "id", type: "uuid" },
+          { name: "email", type: "string" }
+        ],
+        indexes: [{ name: "customers_email_uidx", fields: ["email"], unique: true }]
+      },
+      {
+        name: "orders",
+        fields: [
+          { name: "id", type: "uuid" },
+          { name: "customer_id", type: "uuid" },
+          { name: "status", type: "string" },
+          { name: "amount", type: "number", nullable: true }
+        ],
+        indexes: [{ name: "orders_customer_idx", fields: ["customer_id"] }]
+      }
+    ],
+    relations: [
+      {
+        fromTable: "orders",
+        fromField: "customer_id",
+        toTable: "customers",
+        toField: "id"
+      }
+    ]
+  };
+}
+
+test("compileSchemaSql emits stable table, index, and relation statements", () => {
+  const compiled = compileSchemaSql(createCompilerFixture());
+
+  assert.deepEqual(compiled.tables, [
+    'CREATE TABLE "customers" ("id" UUID NOT NULL, "email" TEXT NOT NULL);',
+    'CREATE TABLE "orders" ("id" UUID NOT NULL, "customer_id" UUID NOT NULL, "status" TEXT NOT NULL, "amount" INTEGER);'
+  ]);
+  assert.deepEqual(compiled.indexes, [
+    'CREATE UNIQUE INDEX "customers_email_uidx" ON "customers" ("email");',
+    'CREATE INDEX "orders_customer_idx" ON "orders" ("customer_id");'
+  ]);
+  assert.deepEqual(compiled.relations, [
+    'ALTER TABLE "orders" ADD CONSTRAINT "orders_customer_id_fkey" FOREIGN KEY ("customer_id") REFERENCES "customers" ("id");'
+  ]);
+  assert.deepEqual(compiled.statements, [
+    ...compiled.tables,
+    ...compiled.indexes,
+    ...compiled.relations
+  ]);
+});
+
+test("compileSchemaSql rejects invalid identifiers before emitting SQL", () => {
+  assert.throws(
+    () =>
+      compileSchemaSql({
+        tables: [
+          {
+            name: "orders;drop",
+            fields: [{ name: "id", type: "uuid" }]
+          }
+        ]
+      }),
+    /Invalid identifier: orders;drop/
+  );
+});


### PR DESCRIPTION
## Summary
- add #28 SQL Generator V1 baseline for tables, indexes, and relations
- extend kernel schema types with optional indexes and relations while keeping existing table-only schemas compatible
- add compiler fixture coverage for #30 with customers/orders tables, unique/regular indexes, and an orders -> customers relation

## Validation
- pnpm --filter @zhongmiao/meta-lc-kernel test
- pnpm lint:boundaries
- pnpm lint
- pnpm -r test
- pnpm test:boundaries
- pnpm changelog:gate origin/main HEAD
- git diff --check

## Notes
- No API Generator, Permission Generator, DB execution, or migration audit behavior changes.
- #30 remains open after this PR; this adds the first compiler fixture baseline evidence.

Closes #28
Refs #30