### PR TITLE
test(kernel): add compiler contract fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - feat(bff): add the first Gateway baseline for meta APIs, in-memory cache, aggregation summary, and WebSocket lifecycle smoke.
 - feat(runtime): add a manager-first runtime orchestrator baseline and shared runtime page topic helper.
 - feat(kernel): add a SQL Generator V1 baseline for tables, indexes, relations, and compiler fixture coverage.
+- test(kernel): promote SQL generator examples into a reusable compiler contract fixture baseline.
 
 ## 0.1.0 (2026-04-18)
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -13,6 +13,7 @@
 - feat(bff): 新增首版 Gateway 基线，覆盖 meta API、内存 cache、aggregation summary 与 WebSocket lifecycle smoke。
 - feat(runtime): 新增 manager-first runtime orchestrator 基线与共享 runtime page topic helper。
 - feat(kernel): 新增 SQL Generator V1 基线，覆盖 table、index、relation 与 compiler fixture。
+- test(kernel): 将 SQL generator 示例提升为可复用的 compiler contract fixture 基线。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/kernel/CHANGELOG.md
+++ b/packages/kernel/CHANGELOG.md
@@ -4,6 +4,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 - chore(package): adopt the `@zhongmiao/meta-lc-kernel` scoped package identity for release governance.
 - feat(sql-generator): add table, index, relation SQL generation and a compiler fixture baseline.
+- test(compiler): add a reusable compiler contract fixture for SQL generator output.
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/kernel/CHANGELOG.zh-CN.md
+++ b/packages/kernel/CHANGELOG.zh-CN.md
@@ -4,6 +4,7 @@
 
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-kernel` 正式包名。
 - feat(sql-generator): 新增 table、index、relation SQL 生成能力与 compiler fixture 基线。
+- test(compiler): 新增可复用 compiler contract fixture，固化 SQL generator 输出。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/kernel/test/compiler-contract.test.ts
+++ b/packages/kernel/test/compiler-contract.test.ts
@@ -1,0 +1,45 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { compileSchemaSql } from "../src";
+import { ordersCompilerFixture } from "./fixtures/compiler-fixtures";
+
+test("compiler fixture defines the public SQL generator contract", () => {
+  const compiled = compileSchemaSql(ordersCompilerFixture.schema);
+
+  assert.deepEqual(compiled, ordersCompilerFixture.expected);
+});
+
+test("compiler statements are grouped as tables then indexes then relations", () => {
+  const compiled = compileSchemaSql(ordersCompilerFixture.schema);
+
+  assert.deepEqual(compiled.statements, [
+    ...compiled.tables,
+    ...compiled.indexes,
+    ...compiled.relations
+  ]);
+  assert.deepEqual(compiled.statements, ordersCompilerFixture.expected.statements);
+});
+
+test("compiler contract accepts table-only schemas without side effects", () => {
+  const schema = {
+    tables: [
+      {
+        name: "audit_logs",
+        fields: [
+          { name: "id", type: "uuid" },
+          { name: "status", type: "string" }
+        ]
+      }
+    ]
+  };
+  const before = JSON.stringify(schema);
+  const compiled = compileSchemaSql(schema);
+
+  assert.deepEqual(compiled, {
+    tables: ['CREATE TABLE "audit_logs" ("id" UUID NOT NULL, "status" TEXT NOT NULL);'],
+    indexes: [],
+    relations: [],
+    statements: ['CREATE TABLE "audit_logs" ("id" UUID NOT NULL, "status" TEXT NOT NULL);']
+  });
+  assert.equal(JSON.stringify(schema), before);
+});

--- a/packages/kernel/test/fixtures/compiler-fixtures.ts
+++ b/packages/kernel/test/fixtures/compiler-fixtures.ts
@@ -1,0 +1,59 @@
+import type { CompiledSchemaSql, MetaSchema } from "../../src";
+
+export interface CompilerFixture {
+  schema: MetaSchema;
+  expected: CompiledSchemaSql;
+}
+
+export const ordersCompilerFixture: CompilerFixture = {
+  schema: {
+    tables: [
+      {
+        name: "customers",
+        fields: [
+          { name: "id", type: "uuid" },
+          { name: "email", type: "string" }
+        ],
+        indexes: [{ name: "customers_email_uidx", fields: ["email"], unique: true }]
+      },
+      {
+        name: "orders",
+        fields: [
+          { name: "id", type: "uuid" },
+          { name: "customer_id", type: "uuid" },
+          { name: "status", type: "string" },
+          { name: "amount", type: "number", nullable: true }
+        ],
+        indexes: [{ name: "orders_customer_idx", fields: ["customer_id"] }]
+      }
+    ],
+    relations: [
+      {
+        fromTable: "orders",
+        fromField: "customer_id",
+        toTable: "customers",
+        toField: "id"
+      }
+    ]
+  },
+  expected: {
+    tables: [
+      'CREATE TABLE "customers" ("id" UUID NOT NULL, "email" TEXT NOT NULL);',
+      'CREATE TABLE "orders" ("id" UUID NOT NULL, "customer_id" UUID NOT NULL, "status" TEXT NOT NULL, "amount" INTEGER);'
+    ],
+    indexes: [
+      'CREATE UNIQUE INDEX "customers_email_uidx" ON "customers" ("email");',
+      'CREATE INDEX "orders_customer_idx" ON "orders" ("customer_id");'
+    ],
+    relations: [
+      'ALTER TABLE "orders" ADD CONSTRAINT "orders_customer_id_fkey" FOREIGN KEY ("customer_id") REFERENCES "customers" ("id");'
+    ],
+    statements: [
+      'CREATE TABLE "customers" ("id" UUID NOT NULL, "email" TEXT NOT NULL);',
+      'CREATE TABLE "orders" ("id" UUID NOT NULL, "customer_id" UUID NOT NULL, "status" TEXT NOT NULL, "amount" INTEGER);',
+      'CREATE UNIQUE INDEX "customers_email_uidx" ON "customers" ("email");',
+      'CREATE INDEX "orders_customer_idx" ON "orders" ("customer_id");',
+      'ALTER TABLE "orders" ADD CONSTRAINT "orders_customer_id_fkey" FOREIGN KEY ("customer_id") REFERENCES "customers" ("id");'
+    ]
+  }
+};

--- a/packages/kernel/test/sql-generator.test.ts
+++ b/packages/kernel/test/sql-generator.test.ts
@@ -1,60 +1,15 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { compileSchemaSql } from "../src";
-import type { MetaSchema } from "../src";
-
-function createCompilerFixture(): MetaSchema {
-  return {
-    tables: [
-      {
-        name: "customers",
-        fields: [
-          { name: "id", type: "uuid" },
-          { name: "email", type: "string" }
-        ],
-        indexes: [{ name: "customers_email_uidx", fields: ["email"], unique: true }]
-      },
-      {
-        name: "orders",
-        fields: [
-          { name: "id", type: "uuid" },
-          { name: "customer_id", type: "uuid" },
-          { name: "status", type: "string" },
-          { name: "amount", type: "number", nullable: true }
-        ],
-        indexes: [{ name: "orders_customer_idx", fields: ["customer_id"] }]
-      }
-    ],
-    relations: [
-      {
-        fromTable: "orders",
-        fromField: "customer_id",
-        toTable: "customers",
-        toField: "id"
-      }
-    ]
-  };
-}
+import { ordersCompilerFixture } from "./fixtures/compiler-fixtures";
 
 test("compileSchemaSql emits stable table, index, and relation statements", () => {
-  const compiled = compileSchemaSql(createCompilerFixture());
+  const compiled = compileSchemaSql(ordersCompilerFixture.schema);
 
-  assert.deepEqual(compiled.tables, [
-    'CREATE TABLE "customers" ("id" UUID NOT NULL, "email" TEXT NOT NULL);',
-    'CREATE TABLE "orders" ("id" UUID NOT NULL, "customer_id" UUID NOT NULL, "status" TEXT NOT NULL, "amount" INTEGER);'
-  ]);
-  assert.deepEqual(compiled.indexes, [
-    'CREATE UNIQUE INDEX "customers_email_uidx" ON "customers" ("email");',
-    'CREATE INDEX "orders_customer_idx" ON "orders" ("customer_id");'
-  ]);
-  assert.deepEqual(compiled.relations, [
-    'ALTER TABLE "orders" ADD CONSTRAINT "orders_customer_id_fkey" FOREIGN KEY ("customer_id") REFERENCES "customers" ("id");'
-  ]);
-  assert.deepEqual(compiled.statements, [
-    ...compiled.tables,
-    ...compiled.indexes,
-    ...compiled.relations
-  ]);
+  assert.deepEqual(compiled.tables, ordersCompilerFixture.expected.tables);
+  assert.deepEqual(compiled.indexes, ordersCompilerFixture.expected.indexes);
+  assert.deepEqual(compiled.relations, ordersCompilerFixture.expected.relations);
+  assert.deepEqual(compiled.statements, ordersCompilerFixture.expected.statements);
 });
 
 test("compileSchemaSql rejects invalid identifiers before emitting SQL", () => {


### PR DESCRIPTION
## Summary
- promote the SQL Generator orders/customers example into a reusable compiler fixture harness
- add compiler contract tests for grouped SQL output, statements ordering, and table-only schema compatibility
- update changelogs for the compiler fixture baseline

## Validation
- pnpm --filter @zhongmiao/meta-lc-kernel test
- pnpm lint:boundaries
- pnpm lint
- pnpm -r test
- pnpm test:boundaries
- pnpm changelog:gate origin/main HEAD
- git diff --check

## Notes
- No API Generator or Permission Generator implementation in this slice.
- #30 remains open after this PR; this strengthens the SQL Generator fixture contract baseline.
- #26 can be closed after merge because #65 plus this fixture baseline covers table/field/relation/index validator evidence.

Refs #30
Refs #26