### PR TITLE
feat(kernel): add API generator baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - feat(runtime): add a manager-first runtime orchestrator baseline and shared runtime page topic helper.
 - feat(kernel): add a SQL Generator V1 baseline for tables, indexes, relations, and compiler fixture coverage.
 - test(kernel): promote SQL generator examples into a reusable compiler contract fixture baseline.
+- feat(kernel): add an API Generator V1 route manifest baseline and extend compiler fixtures across SQL and API outputs.
+- feat(contracts): add query and mutation response contracts for generated API route manifests.
 
 ## 0.1.0 (2026-04-18)
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -14,6 +14,8 @@
 - feat(runtime): 新增 manager-first runtime orchestrator 基线与共享 runtime page topic helper。
 - feat(kernel): 新增 SQL Generator V1 基线，覆盖 table、index、relation 与 compiler fixture。
 - test(kernel): 将 SQL generator 示例提升为可复用的 compiler contract fixture 基线。
+- feat(kernel): 新增 API Generator V1 route manifest 基线，并将 compiler fixture 扩展到 SQL 与 API 输出。
+- feat(contracts): 新增 query 与 mutation 响应契约，供生成的 API route manifest 引用。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/bff/CHANGELOG.md
+++ b/packages/bff/CHANGELOG.md
@@ -3,6 +3,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 ## [Unreleased]
 
 - feat(gateway): add meta API, in-memory cache, aggregation summary, and WebSocket lifecycle baseline.
+- feat(api-contracts): annotate query and mutation controller responses with shared API response contracts.
 - chore(gateway): reuse the shared runtime page topic helper for WebSocket subscription acknowledgements.
 - chore(package): adopt the `@zhongmiao/meta-lc-bff` scoped package identity for release governance.
 - fix(local-dev): move the default BFF local port to `6001` and bind an explicit host so browser-based integration can reach the service without unsafe-port blocking.

--- a/packages/bff/CHANGELOG.zh-CN.md
+++ b/packages/bff/CHANGELOG.zh-CN.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - feat(gateway): 新增 meta API、内存 cache、aggregation summary 与 WebSocket lifecycle 基线。
+- feat(api-contracts): 为 query 与 mutation controller 响应标注共享 API response contract。
 - chore(gateway): WebSocket subscription acknowledgement 复用共享 runtime page topic helper。
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-bff` 正式包名。
 - fix(local-dev): 将 BFF 本地默认端口调整为 `6001`，并显式绑定 host，避免浏览器因 unsafe port 策略阻断联调访问。

--- a/packages/bff/src/app.controller.ts
+++ b/packages/bff/src/app.controller.ts
@@ -1,6 +1,6 @@
 import { Body, Controller, Get, Post } from "@nestjs/common";
 import { QueryOrchestratorService } from "./orchestration/query-orchestrator.service";
-import type { QueryApiRequest } from "./types";
+import type { QueryApiRequest, QueryApiResponse } from "./types";
 
 @Controller()
 export class AppController {
@@ -13,7 +13,7 @@ export class AppController {
   }
 
   @Post("query")
-  async query(@Body() request: QueryApiRequest): Promise<{ rows: Record<string, unknown>[] }> {
+  async query(@Body() request: QueryApiRequest): Promise<QueryApiResponse> {
     const result = await this.queryOrchestrator.execute(request);
     return { rows: result.rows };
   }

--- a/packages/bff/src/gateway/query.controller.ts
+++ b/packages/bff/src/gateway/query.controller.ts
@@ -4,7 +4,7 @@ import { AuditLogService } from "../common/audit-log.service";
 import { resolveRequestId } from "../common/request-id";
 import { MutationOrchestratorService } from "../orchestration/mutation-orchestrator.service";
 import { QueryOrchestratorService } from "../orchestration/query-orchestrator.service";
-import type { MutationApiRequest, QueryApiRequest } from "../types";
+import type { MutationApiRequest, MutationApiResponse, QueryApiRequest, QueryApiResponse } from "../types";
 
 @Controller()
 export class QueryController {
@@ -31,7 +31,7 @@ export class QueryController {
     res: {
       setHeader(name: string, value: string): void;
     }
-  ): Promise<{ rows: Record<string, unknown>[] }> {
+  ): Promise<QueryApiResponse> {
     const requestId = resolveRequestId(req.headers["x-request-id"]);
     res.setHeader("x-request-id", requestId);
 
@@ -92,7 +92,7 @@ export class QueryController {
     res: {
       setHeader(name: string, value: string): void;
     }
-  ): Promise<{ rowCount: number; row: Record<string, unknown> | null }> {
+  ): Promise<MutationApiResponse> {
     const requestId = resolveRequestId(req.headers["x-request-id"]);
     res.setHeader("x-request-id", requestId);
 

--- a/packages/bff/src/types.ts
+++ b/packages/bff/src/types.ts
@@ -5,7 +5,9 @@ export type {
   DataScopeDecision,
   DataScopeType,
   MutationApiRequest,
+  MutationApiResponse,
   MutationOperation,
   OrgScopeContext,
-  QueryApiRequest
+  QueryApiRequest,
+  QueryApiResponse
 } from "@zhongmiao/meta-lc-contracts";

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -6,6 +6,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - feat(runtime-contracts): add refresh planning event and target contracts for dependency graph execution.
 - feat(runtime-contracts): add rule and function contracts for event-driven runtime evaluation.
 - feat(runtime-contracts): add the shared runtime page topic helper used by BFF WebSocket and runtime orchestration boundaries.
+- feat(api-contracts): add query and mutation response contracts for generated API route manifests.
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/contracts/CHANGELOG.zh-CN.md
+++ b/packages/contracts/CHANGELOG.zh-CN.md
@@ -6,6 +6,7 @@
 - feat(runtime-contracts): 补充依赖图执行所需的刷新事件与目标契约类型。
 - feat(runtime-contracts): 补充事件驱动规则求值所需的规则与函数契约类型。
 - feat(runtime-contracts): 新增共享 runtime page topic helper，用于 BFF WebSocket 与 runtime orchestration 边界对齐。
+- feat(api-contracts): 新增 query 与 mutation 响应契约，供生成的 API route manifest 引用。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -8,6 +8,10 @@ export interface QueryApiRequest {
   limit?: number;
 }
 
+export interface QueryApiResponse {
+  rows: Record<string, unknown>[];
+}
+
 export type MutationOperation = "create" | "update" | "delete";
 
 export interface MutationApiRequest {
@@ -19,6 +23,11 @@ export interface MutationApiRequest {
   orgId?: string;
   key?: Record<string, string | number | boolean>;
   data?: Record<string, string | number | boolean | null>;
+}
+
+export interface MutationApiResponse {
+  rowCount: number;
+  row: Record<string, unknown> | null;
 }
 
 export type DataScopeType =

--- a/packages/contracts/test/smoke.test.ts
+++ b/packages/contracts/test/smoke.test.ts
@@ -2,7 +2,9 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   buildRuntimePageTopic,
+  type MutationApiResponse,
   type QueryApiRequest,
+  type QueryApiResponse,
   type RuntimeFunctionCallDefinition,
   type RuntimePageDsl,
   type RuntimeRuleDefinition,
@@ -20,6 +22,19 @@ test("contracts exports query request type", () => {
     roles: ["USER"]
   };
   assert.equal(req.table, "orders");
+});
+
+test("contracts exports query and mutation response types", () => {
+  const queryResponse: QueryApiResponse = {
+    rows: [{ id: "order-1" }]
+  };
+  const mutationResponse: MutationApiResponse = {
+    rowCount: 1,
+    row: { id: "order-1" }
+  };
+
+  assert.equal(queryResponse.rows[0]?.id, "order-1");
+  assert.equal(mutationResponse.rowCount, 1);
 });
 
 test("contracts exports runtime dsl types", () => {

--- a/packages/kernel/CHANGELOG.md
+++ b/packages/kernel/CHANGELOG.md
@@ -5,6 +5,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - chore(package): adopt the `@zhongmiao/meta-lc-kernel` scoped package identity for release governance.
 - feat(sql-generator): add table, index, relation SQL generation and a compiler fixture baseline.
 - test(compiler): add a reusable compiler contract fixture for SQL generator output.
+- feat(api-generator): add a stable route manifest generator and extend compiler fixture coverage to API outputs.
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/kernel/CHANGELOG.zh-CN.md
+++ b/packages/kernel/CHANGELOG.zh-CN.md
@@ -5,6 +5,7 @@
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-kernel` 正式包名。
 - feat(sql-generator): 新增 table、index、relation SQL 生成能力与 compiler fixture 基线。
 - test(compiler): 新增可复用 compiler contract fixture，固化 SQL generator 输出。
+- feat(api-generator): 新增稳定 route manifest 生成器，并将 compiler fixture 覆盖扩展到 API 输出。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/kernel/src/api-generator.ts
+++ b/packages/kernel/src/api-generator.ts
@@ -1,0 +1,37 @@
+import type {
+  ApiRouteOperation,
+  CompiledApiRoute,
+  CompiledApiRouteManifest,
+  MetaSchema,
+  MetaTable
+} from "./types";
+import { validateSchema } from "./contracts";
+import { quoteIdentifier } from "./sql-utils";
+
+export function compileApiRoutes(schema: MetaSchema): CompiledApiRouteManifest {
+  validateSchema(schema);
+
+  return {
+    source: "meta-schema",
+    routes: schema.tables.flatMap((table) => [createRoute(table, "query"), createRoute(table, "mutation")])
+  };
+}
+
+function createRoute(table: MetaTable, operation: ApiRouteOperation): CompiledApiRoute {
+  quoteIdentifier(table.name);
+
+  const isQuery = operation === "query";
+  return {
+    id: `${table.name}.${operation}`,
+    table: table.name,
+    operation,
+    method: "POST",
+    path: `/api/${table.name}/${operation}`,
+    target: {
+      method: "POST",
+      path: isQuery ? "/query" : "/mutation"
+    },
+    requestContract: isQuery ? "QueryApiRequest" : "MutationApiRequest",
+    responseContract: isQuery ? "QueryApiResponse" : "MutationApiResponse"
+  };
+}

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -7,3 +7,4 @@ export * from "./schema-diff";
 export * from "./migration-safety";
 export * from "./snapshot-dsl";
 export * from "./sql-generator";
+export * from "./api-generator";

--- a/packages/kernel/src/types.ts
+++ b/packages/kernel/src/types.ts
@@ -90,6 +90,30 @@ export interface CompiledSchemaSql {
   statements: string[];
 }
 
+export type ApiRouteOperation = "query" | "mutation";
+export type ApiRouteMethod = "POST";
+
+export interface CompiledApiRouteTarget {
+  method: ApiRouteMethod;
+  path: "/query" | "/mutation";
+}
+
+export interface CompiledApiRoute {
+  id: string;
+  table: string;
+  operation: ApiRouteOperation;
+  method: ApiRouteMethod;
+  path: string;
+  target: CompiledApiRouteTarget;
+  requestContract: "QueryApiRequest" | "MutationApiRequest";
+  responseContract: "QueryApiResponse" | "MutationApiResponse";
+}
+
+export interface CompiledApiRouteManifest {
+  source: "meta-schema";
+  routes: CompiledApiRoute[];
+}
+
 export interface MetaVersionMetadata {
   author: string;
   message: string;

--- a/packages/kernel/test/api-generator.test.ts
+++ b/packages/kernel/test/api-generator.test.ts
@@ -1,0 +1,34 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { compileApiRoutes } from "../src";
+import { ordersCompilerFixture } from "./fixtures/compiler-fixtures";
+
+test("compileApiRoutes emits stable query and mutation route manifests", () => {
+  const compiled = compileApiRoutes(ordersCompilerFixture.schema);
+
+  assert.deepEqual(compiled, ordersCompilerFixture.expected.api);
+});
+
+test("compileApiRoutes preserves schema table order", () => {
+  const compiled = compileApiRoutes(ordersCompilerFixture.schema);
+
+  assert.deepEqual(
+    compiled.routes.map((route) => route.path),
+    ["/api/customers/query", "/api/customers/mutation", "/api/orders/query", "/api/orders/mutation"]
+  );
+});
+
+test("compileApiRoutes rejects invalid identifiers before emitting routes", () => {
+  assert.throws(
+    () =>
+      compileApiRoutes({
+        tables: [
+          {
+            name: "orders;drop",
+            fields: [{ name: "id", type: "uuid" }]
+          }
+        ]
+      }),
+    /Invalid identifier: orders;drop/
+  );
+});

--- a/packages/kernel/test/compiler-contract.test.ts
+++ b/packages/kernel/test/compiler-contract.test.ts
@@ -1,12 +1,18 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { compileSchemaSql } from "../src";
+import { compileApiRoutes, compileSchemaSql } from "../src";
 import { ordersCompilerFixture } from "./fixtures/compiler-fixtures";
 
 test("compiler fixture defines the public SQL generator contract", () => {
   const compiled = compileSchemaSql(ordersCompilerFixture.schema);
 
-  assert.deepEqual(compiled, ordersCompilerFixture.expected);
+  assert.deepEqual(compiled, ordersCompilerFixture.expected.sql);
+});
+
+test("compiler fixture defines the public API route manifest contract", () => {
+  const compiled = compileApiRoutes(ordersCompilerFixture.schema);
+
+  assert.deepEqual(compiled, ordersCompilerFixture.expected.api);
 });
 
 test("compiler statements are grouped as tables then indexes then relations", () => {
@@ -17,7 +23,17 @@ test("compiler statements are grouped as tables then indexes then relations", ()
     ...compiled.indexes,
     ...compiled.relations
   ]);
-  assert.deepEqual(compiled.statements, ordersCompilerFixture.expected.statements);
+  assert.deepEqual(compiled.statements, ordersCompilerFixture.expected.sql.statements);
+});
+
+test("compiler API routes are grouped by schema table order", () => {
+  const compiled = compileApiRoutes(ordersCompilerFixture.schema);
+
+  assert.deepEqual(
+    compiled.routes.map((route) => route.id),
+    ["customers.query", "customers.mutation", "orders.query", "orders.mutation"]
+  );
+  assert.deepEqual(compiled.routes, ordersCompilerFixture.expected.api.routes);
 });
 
 test("compiler contract accepts table-only schemas without side effects", () => {
@@ -33,13 +49,39 @@ test("compiler contract accepts table-only schemas without side effects", () => 
     ]
   };
   const before = JSON.stringify(schema);
-  const compiled = compileSchemaSql(schema);
+  const compiledSql = compileSchemaSql(schema);
+  const compiledApi = compileApiRoutes(schema);
 
-  assert.deepEqual(compiled, {
+  assert.deepEqual(compiledSql, {
     tables: ['CREATE TABLE "audit_logs" ("id" UUID NOT NULL, "status" TEXT NOT NULL);'],
     indexes: [],
     relations: [],
     statements: ['CREATE TABLE "audit_logs" ("id" UUID NOT NULL, "status" TEXT NOT NULL);']
+  });
+  assert.deepEqual(compiledApi, {
+    source: "meta-schema",
+    routes: [
+      {
+        id: "audit_logs.query",
+        table: "audit_logs",
+        operation: "query",
+        method: "POST",
+        path: "/api/audit_logs/query",
+        target: { method: "POST", path: "/query" },
+        requestContract: "QueryApiRequest",
+        responseContract: "QueryApiResponse"
+      },
+      {
+        id: "audit_logs.mutation",
+        table: "audit_logs",
+        operation: "mutation",
+        method: "POST",
+        path: "/api/audit_logs/mutation",
+        target: { method: "POST", path: "/mutation" },
+        requestContract: "MutationApiRequest",
+        responseContract: "MutationApiResponse"
+      }
+    ]
   });
   assert.equal(JSON.stringify(schema), before);
 });

--- a/packages/kernel/test/fixtures/compiler-fixtures.ts
+++ b/packages/kernel/test/fixtures/compiler-fixtures.ts
@@ -1,8 +1,11 @@
-import type { CompiledSchemaSql, MetaSchema } from "../../src";
+import type { CompiledApiRouteManifest, CompiledSchemaSql, MetaSchema } from "../../src";
 
 export interface CompilerFixture {
   schema: MetaSchema;
-  expected: CompiledSchemaSql;
+  expected: {
+    sql: CompiledSchemaSql;
+    api: CompiledApiRouteManifest;
+  };
 }
 
 export const ordersCompilerFixture: CompilerFixture = {
@@ -37,23 +40,70 @@ export const ordersCompilerFixture: CompilerFixture = {
     ]
   },
   expected: {
-    tables: [
-      'CREATE TABLE "customers" ("id" UUID NOT NULL, "email" TEXT NOT NULL);',
-      'CREATE TABLE "orders" ("id" UUID NOT NULL, "customer_id" UUID NOT NULL, "status" TEXT NOT NULL, "amount" INTEGER);'
-    ],
-    indexes: [
-      'CREATE UNIQUE INDEX "customers_email_uidx" ON "customers" ("email");',
-      'CREATE INDEX "orders_customer_idx" ON "orders" ("customer_id");'
-    ],
-    relations: [
-      'ALTER TABLE "orders" ADD CONSTRAINT "orders_customer_id_fkey" FOREIGN KEY ("customer_id") REFERENCES "customers" ("id");'
-    ],
-    statements: [
-      'CREATE TABLE "customers" ("id" UUID NOT NULL, "email" TEXT NOT NULL);',
-      'CREATE TABLE "orders" ("id" UUID NOT NULL, "customer_id" UUID NOT NULL, "status" TEXT NOT NULL, "amount" INTEGER);',
-      'CREATE UNIQUE INDEX "customers_email_uidx" ON "customers" ("email");',
-      'CREATE INDEX "orders_customer_idx" ON "orders" ("customer_id");',
-      'ALTER TABLE "orders" ADD CONSTRAINT "orders_customer_id_fkey" FOREIGN KEY ("customer_id") REFERENCES "customers" ("id");'
-    ]
+    sql: {
+      tables: [
+        'CREATE TABLE "customers" ("id" UUID NOT NULL, "email" TEXT NOT NULL);',
+        'CREATE TABLE "orders" ("id" UUID NOT NULL, "customer_id" UUID NOT NULL, "status" TEXT NOT NULL, "amount" INTEGER);'
+      ],
+      indexes: [
+        'CREATE UNIQUE INDEX "customers_email_uidx" ON "customers" ("email");',
+        'CREATE INDEX "orders_customer_idx" ON "orders" ("customer_id");'
+      ],
+      relations: [
+        'ALTER TABLE "orders" ADD CONSTRAINT "orders_customer_id_fkey" FOREIGN KEY ("customer_id") REFERENCES "customers" ("id");'
+      ],
+      statements: [
+        'CREATE TABLE "customers" ("id" UUID NOT NULL, "email" TEXT NOT NULL);',
+        'CREATE TABLE "orders" ("id" UUID NOT NULL, "customer_id" UUID NOT NULL, "status" TEXT NOT NULL, "amount" INTEGER);',
+        'CREATE UNIQUE INDEX "customers_email_uidx" ON "customers" ("email");',
+        'CREATE INDEX "orders_customer_idx" ON "orders" ("customer_id");',
+        'ALTER TABLE "orders" ADD CONSTRAINT "orders_customer_id_fkey" FOREIGN KEY ("customer_id") REFERENCES "customers" ("id");'
+      ]
+    },
+    api: {
+      source: "meta-schema",
+      routes: [
+        {
+          id: "customers.query",
+          table: "customers",
+          operation: "query",
+          method: "POST",
+          path: "/api/customers/query",
+          target: { method: "POST", path: "/query" },
+          requestContract: "QueryApiRequest",
+          responseContract: "QueryApiResponse"
+        },
+        {
+          id: "customers.mutation",
+          table: "customers",
+          operation: "mutation",
+          method: "POST",
+          path: "/api/customers/mutation",
+          target: { method: "POST", path: "/mutation" },
+          requestContract: "MutationApiRequest",
+          responseContract: "MutationApiResponse"
+        },
+        {
+          id: "orders.query",
+          table: "orders",
+          operation: "query",
+          method: "POST",
+          path: "/api/orders/query",
+          target: { method: "POST", path: "/query" },
+          requestContract: "QueryApiRequest",
+          responseContract: "QueryApiResponse"
+        },
+        {
+          id: "orders.mutation",
+          table: "orders",
+          operation: "mutation",
+          method: "POST",
+          path: "/api/orders/mutation",
+          target: { method: "POST", path: "/mutation" },
+          requestContract: "MutationApiRequest",
+          responseContract: "MutationApiResponse"
+        }
+      ]
+    }
   }
 };

--- a/packages/kernel/test/sql-generator.test.ts
+++ b/packages/kernel/test/sql-generator.test.ts
@@ -6,10 +6,10 @@ import { ordersCompilerFixture } from "./fixtures/compiler-fixtures";
 test("compileSchemaSql emits stable table, index, and relation statements", () => {
   const compiled = compileSchemaSql(ordersCompilerFixture.schema);
 
-  assert.deepEqual(compiled.tables, ordersCompilerFixture.expected.tables);
-  assert.deepEqual(compiled.indexes, ordersCompilerFixture.expected.indexes);
-  assert.deepEqual(compiled.relations, ordersCompilerFixture.expected.relations);
-  assert.deepEqual(compiled.statements, ordersCompilerFixture.expected.statements);
+  assert.deepEqual(compiled.tables, ordersCompilerFixture.expected.sql.tables);
+  assert.deepEqual(compiled.indexes, ordersCompilerFixture.expected.sql.indexes);
+  assert.deepEqual(compiled.relations, ordersCompilerFixture.expected.sql.relations);
+  assert.deepEqual(compiled.statements, ordersCompilerFixture.expected.sql.statements);
 });
 
 test("compileSchemaSql rejects invalid identifiers before emitting SQL", () => {


### PR DESCRIPTION
## Summary

- add `compileApiRoutes(schema)` as the API Generator V1 route manifest entrypoint
- extend the reusable compiler fixture from SQL-only output to SQL + API route manifest output
- add query/mutation response contracts so generated manifests can point at concrete BFF API contract names

Closes #16
Refs #30

## Test Plan

- `pnpm --filter @zhongmiao/meta-lc-kernel test`
- `pnpm --filter @zhongmiao/meta-lc-contracts test`
- `pnpm --filter @zhongmiao/meta-lc-bff test`
- `pnpm lint:boundaries`
- `pnpm lint`
- `pnpm -r test`
- `pnpm changelog:gate origin/main HEAD`
- `git diff --check`