### PR TITLE
feat(kernel): add permission generator baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - test(kernel): promote SQL generator examples into a reusable compiler contract fixture baseline.
 - feat(kernel): add an API Generator V1 route manifest baseline and extend compiler fixtures across SQL and API outputs.
 - feat(contracts): add query and mutation response contracts for generated API route manifests.
+- feat(kernel): add a Permission Generator V1 manifest baseline and complete compiler fixture coverage across SQL, API, and permission outputs.
 
 ## 0.1.0 (2026-04-18)
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -16,6 +16,7 @@
 - test(kernel): 将 SQL generator 示例提升为可复用的 compiler contract fixture 基线。
 - feat(kernel): 新增 API Generator V1 route manifest 基线，并将 compiler fixture 扩展到 SQL 与 API 输出。
 - feat(contracts): 新增 query 与 mutation 响应契约，供生成的 API route manifest 引用。
+- feat(kernel): 新增 Permission Generator V1 manifest 基线，完成 SQL、API 与 permission 输出的 compiler fixture 覆盖。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/kernel/CHANGELOG.md
+++ b/packages/kernel/CHANGELOG.md
@@ -6,6 +6,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - feat(sql-generator): add table, index, relation SQL generation and a compiler fixture baseline.
 - test(compiler): add a reusable compiler contract fixture for SQL generator output.
 - feat(api-generator): add a stable route manifest generator and extend compiler fixture coverage to API outputs.
+- feat(permission-generator): add a stable permission manifest generator and complete compiler fixture coverage.
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/kernel/CHANGELOG.zh-CN.md
+++ b/packages/kernel/CHANGELOG.zh-CN.md
@@ -6,6 +6,7 @@
 - feat(sql-generator): 新增 table、index、relation SQL 生成能力与 compiler fixture 基线。
 - test(compiler): 新增可复用 compiler contract fixture，固化 SQL generator 输出。
 - feat(api-generator): 新增稳定 route manifest 生成器，并将 compiler fixture 覆盖扩展到 API 输出。
+- feat(permission-generator): 新增稳定 permission manifest 生成器，完成 compiler fixture 覆盖。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -8,3 +8,4 @@ export * from "./migration-safety";
 export * from "./snapshot-dsl";
 export * from "./sql-generator";
 export * from "./api-generator";
+export * from "./permission-generator";

--- a/packages/kernel/src/permission-generator.ts
+++ b/packages/kernel/src/permission-generator.ts
@@ -1,0 +1,44 @@
+import type { CompiledPermissionManifest, CompiledPermissionRule, SnapshotPermission } from "./types";
+
+export function compilePermissionManifest(permissions: SnapshotPermission[]): CompiledPermissionManifest {
+  if (!Array.isArray(permissions)) {
+    throw new Error("Permissions must be an array.");
+  }
+
+  return {
+    source: "snapshot-permissions",
+    rules: permissions.map((permission) => createPermissionRule(permission))
+  };
+}
+
+function createPermissionRule(permission: SnapshotPermission): CompiledPermissionRule {
+  if (!permission?.resource) {
+    throw new Error("Permission requires a resource.");
+  }
+  if (!permission.action) {
+    throw new Error(`Permission ${permission.resource} requires an action.`);
+  }
+  if (!Array.isArray(permission.roles) || permission.roles.length === 0) {
+    throw new Error(`Permission ${permission.resource}:${permission.action} requires at least one role.`);
+  }
+
+  const roles = new Set<string>();
+  for (const role of permission.roles) {
+    if (!role) {
+      throw new Error(`Permission ${permission.resource}:${permission.action} has an empty role.`);
+    }
+    if (roles.has(role)) {
+      throw new Error(`Permission ${permission.resource}:${permission.action} has duplicate role "${role}".`);
+    }
+    roles.add(role);
+  }
+
+  return {
+    id: `${permission.resource}.${permission.action}`,
+    resource: permission.resource,
+    action: permission.action,
+    roles: [...permission.roles],
+    effect: "allow",
+    enforcement: "rbac"
+  };
+}

--- a/packages/kernel/src/types.ts
+++ b/packages/kernel/src/types.ts
@@ -114,6 +114,23 @@ export interface CompiledApiRouteManifest {
   routes: CompiledApiRoute[];
 }
 
+export type PermissionRuleEffect = "allow";
+export type PermissionRuleEnforcement = "rbac";
+
+export interface CompiledPermissionRule {
+  id: string;
+  resource: string;
+  action: string;
+  roles: string[];
+  effect: PermissionRuleEffect;
+  enforcement: PermissionRuleEnforcement;
+}
+
+export interface CompiledPermissionManifest {
+  source: "snapshot-permissions";
+  rules: CompiledPermissionRule[];
+}
+
 export interface MetaVersionMetadata {
   author: string;
   message: string;

--- a/packages/kernel/test/compiler-contract.test.ts
+++ b/packages/kernel/test/compiler-contract.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { compileApiRoutes, compileSchemaSql } from "../src";
+import { compileApiRoutes, compilePermissionManifest, compileSchemaSql } from "../src";
 import { ordersCompilerFixture } from "./fixtures/compiler-fixtures";
 
 test("compiler fixture defines the public SQL generator contract", () => {
@@ -13,6 +13,12 @@ test("compiler fixture defines the public API route manifest contract", () => {
   const compiled = compileApiRoutes(ordersCompilerFixture.schema);
 
   assert.deepEqual(compiled, ordersCompilerFixture.expected.api);
+});
+
+test("compiler fixture defines the public permission manifest contract", () => {
+  const compiled = compilePermissionManifest(ordersCompilerFixture.permissions);
+
+  assert.deepEqual(compiled, ordersCompilerFixture.expected.permission);
 });
 
 test("compiler statements are grouped as tables then indexes then relations", () => {
@@ -36,6 +42,16 @@ test("compiler API routes are grouped by schema table order", () => {
   assert.deepEqual(compiled.routes, ordersCompilerFixture.expected.api.routes);
 });
 
+test("compiler permission rules preserve fixture order", () => {
+  const compiled = compilePermissionManifest(ordersCompilerFixture.permissions);
+
+  assert.deepEqual(
+    compiled.rules.map((rule) => rule.id),
+    ["customers.query", "orders.query", "orders.mutation"]
+  );
+  assert.deepEqual(compiled.rules, ordersCompilerFixture.expected.permission.rules);
+});
+
 test("compiler contract accepts table-only schemas without side effects", () => {
   const schema = {
     tables: [
@@ -51,6 +67,7 @@ test("compiler contract accepts table-only schemas without side effects", () => 
   const before = JSON.stringify(schema);
   const compiledSql = compileSchemaSql(schema);
   const compiledApi = compileApiRoutes(schema);
+  const compiledPermission = compilePermissionManifest([]);
 
   assert.deepEqual(compiledSql, {
     tables: ['CREATE TABLE "audit_logs" ("id" UUID NOT NULL, "status" TEXT NOT NULL);'],
@@ -82,6 +99,10 @@ test("compiler contract accepts table-only schemas without side effects", () => 
         responseContract: "MutationApiResponse"
       }
     ]
+  });
+  assert.deepEqual(compiledPermission, {
+    source: "snapshot-permissions",
+    rules: []
   });
   assert.equal(JSON.stringify(schema), before);
 });

--- a/packages/kernel/test/fixtures/compiler-fixtures.ts
+++ b/packages/kernel/test/fixtures/compiler-fixtures.ts
@@ -1,10 +1,18 @@
-import type { CompiledApiRouteManifest, CompiledSchemaSql, MetaSchema } from "../../src";
+import type {
+  CompiledApiRouteManifest,
+  CompiledPermissionManifest,
+  CompiledSchemaSql,
+  MetaSchema,
+  SnapshotPermission
+} from "../../src";
 
 export interface CompilerFixture {
   schema: MetaSchema;
+  permissions: SnapshotPermission[];
   expected: {
     sql: CompiledSchemaSql;
     api: CompiledApiRouteManifest;
+    permission: CompiledPermissionManifest;
   };
 }
 
@@ -39,6 +47,11 @@ export const ordersCompilerFixture: CompilerFixture = {
       }
     ]
   },
+  permissions: [
+    { resource: "customers", action: "query", roles: ["SALES", "ADMIN"] },
+    { resource: "orders", action: "query", roles: ["SALES", "FINANCE", "ADMIN"] },
+    { resource: "orders", action: "mutation", roles: ["ADMIN"] }
+  ],
   expected: {
     sql: {
       tables: [
@@ -102,6 +115,35 @@ export const ordersCompilerFixture: CompilerFixture = {
           target: { method: "POST", path: "/mutation" },
           requestContract: "MutationApiRequest",
           responseContract: "MutationApiResponse"
+        }
+      ]
+    },
+    permission: {
+      source: "snapshot-permissions",
+      rules: [
+        {
+          id: "customers.query",
+          resource: "customers",
+          action: "query",
+          roles: ["SALES", "ADMIN"],
+          effect: "allow",
+          enforcement: "rbac"
+        },
+        {
+          id: "orders.query",
+          resource: "orders",
+          action: "query",
+          roles: ["SALES", "FINANCE", "ADMIN"],
+          effect: "allow",
+          enforcement: "rbac"
+        },
+        {
+          id: "orders.mutation",
+          resource: "orders",
+          action: "mutation",
+          roles: ["ADMIN"],
+          effect: "allow",
+          enforcement: "rbac"
         }
       ]
     }

--- a/packages/kernel/test/permission-generator.test.ts
+++ b/packages/kernel/test/permission-generator.test.ts
@@ -1,0 +1,45 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { compilePermissionManifest } from "../src";
+import { ordersCompilerFixture } from "./fixtures/compiler-fixtures";
+
+test("compilePermissionManifest emits stable permission rules", () => {
+  const compiled = compilePermissionManifest(ordersCompilerFixture.permissions);
+
+  assert.deepEqual(compiled, ordersCompilerFixture.expected.permission);
+});
+
+test("compilePermissionManifest preserves permission input order", () => {
+  const compiled = compilePermissionManifest(ordersCompilerFixture.permissions);
+
+  assert.deepEqual(
+    compiled.rules.map((rule) => rule.id),
+    ["customers.query", "orders.query", "orders.mutation"]
+  );
+});
+
+test("compilePermissionManifest accepts empty permissions", () => {
+  assert.deepEqual(compilePermissionManifest([]), {
+    source: "snapshot-permissions",
+    rules: []
+  });
+});
+
+test("compilePermissionManifest rejects invalid permissions", () => {
+  assert.throws(
+    () => compilePermissionManifest([{ resource: "", action: "query", roles: ["ADMIN"] }]),
+    /Permission requires a resource/
+  );
+  assert.throws(
+    () => compilePermissionManifest([{ resource: "orders", action: "", roles: ["ADMIN"] }]),
+    /Permission orders requires an action/
+  );
+  assert.throws(
+    () => compilePermissionManifest([{ resource: "orders", action: "query", roles: [] }]),
+    /Permission orders:query requires at least one role/
+  );
+  assert.throws(
+    () => compilePermissionManifest([{ resource: "orders", action: "query", roles: ["ADMIN", "ADMIN"] }]),
+    /Permission orders:query has duplicate role "ADMIN"/
+  );
+});


### PR DESCRIPTION
## Summary

- add `compilePermissionManifest(permissions)` as the Permission Generator V1 manifest entrypoint
- extend `ordersCompilerFixture` with permission inputs and expected permission manifest output
- complete compiler contract fixture coverage across SQL, API, and permission generator outputs

Closes #30
Refs #19

## Test Plan

- `pnpm --filter @zhongmiao/meta-lc-kernel test`
- `pnpm lint:boundaries`
- `pnpm lint`
- `pnpm -r test`
- `pnpm changelog:gate origin/main HEAD`
- `git diff --check`