### PR TITLE
feat(kernel): add meta domain schema baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - feat(kernel): add an API Generator V1 route manifest baseline and extend compiler fixtures across SQL and API outputs.
 - feat(contracts): add query and mutation response contracts for generated API route manifests.
 - feat(kernel): add a Permission Generator V1 manifest baseline and complete compiler fixture coverage across SQL, API, and permission outputs.
+- feat(kernel): add tenant, app, rule, and permission metadata to the versioned MetaSchema contract.
 
 ## 0.1.0 (2026-04-18)
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -17,6 +17,7 @@
 - feat(kernel): 新增 API Generator V1 route manifest 基线，并将 compiler fixture 扩展到 SQL 与 API 输出。
 - feat(contracts): 新增 query 与 mutation 响应契约，供生成的 API route manifest 引用。
 - feat(kernel): 新增 Permission Generator V1 manifest 基线，完成 SQL、API 与 permission 输出的 compiler fixture 覆盖。
+- feat(kernel): 将 tenant、app、rule 与 permission 元数据纳入可版本化 MetaSchema 契约。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/kernel/CHANGELOG.md
+++ b/packages/kernel/CHANGELOG.md
@@ -7,6 +7,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - test(compiler): add a reusable compiler contract fixture for SQL generator output.
 - feat(api-generator): add a stable route manifest generator and extend compiler fixture coverage to API outputs.
 - feat(permission-generator): add a stable permission manifest generator and complete compiler fixture coverage.
+- feat(schema): add tenant, app, rule, and permission metadata to the versioned MetaSchema contract.
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/kernel/CHANGELOG.zh-CN.md
+++ b/packages/kernel/CHANGELOG.zh-CN.md
@@ -7,6 +7,7 @@
 - test(compiler): 新增可复用 compiler contract fixture，固化 SQL generator 输出。
 - feat(api-generator): 新增稳定 route manifest 生成器，并将 compiler fixture 覆盖扩展到 API 输出。
 - feat(permission-generator): 新增稳定 permission manifest 生成器，完成 compiler fixture 覆盖。
+- feat(schema): 将 tenant、app、rule 与 permission 元数据纳入可版本化 MetaSchema 契约。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/kernel/src/contracts.ts
+++ b/packages/kernel/src/contracts.ts
@@ -1,4 +1,13 @@
-import type { MetaField, MetaSchema, MetaTable, SnapshotRelation } from "./types";
+import type {
+  MetaApp,
+  MetaField,
+  MetaRule,
+  MetaSchema,
+  MetaTable,
+  MetaTenant,
+  SnapshotPermission,
+  SnapshotRelation
+} from "./types";
 
 export const REQUIRED_ROOT_KEYS = ["tables"];
 
@@ -19,6 +28,18 @@ export function validateSchema(schema: MetaSchema): void {
   if (schema.relations !== undefined && !Array.isArray(schema.relations)) {
     throw new Error("Schema.relations must be an array when provided.");
   }
+  if (schema.tenants !== undefined && !Array.isArray(schema.tenants)) {
+    throw new Error("Schema.tenants must be an array when provided.");
+  }
+  if (schema.apps !== undefined && !Array.isArray(schema.apps)) {
+    throw new Error("Schema.apps must be an array when provided.");
+  }
+  if (schema.rules !== undefined && !Array.isArray(schema.rules)) {
+    throw new Error("Schema.rules must be an array when provided.");
+  }
+  if (schema.permissions !== undefined && !Array.isArray(schema.permissions)) {
+    throw new Error("Schema.permissions must be an array when provided.");
+  }
 
   const tableNames = new Set<string>();
   for (const table of schema.tables) {
@@ -37,6 +58,10 @@ export function validateSchema(schema: MetaSchema): void {
   }
 
   validateRelations(schema.tables, schema.relations ?? []);
+  const tenantIds = validateTenants(schema.tenants ?? []);
+  const appIds = validateApps(schema.apps ?? [], tenantIds);
+  validateRules(schema.rules ?? [], appIds);
+  validatePermissions(schema.permissions ?? []);
 }
 
 function validateFields(table: MetaTable): void {
@@ -49,6 +74,92 @@ function validateFields(table: MetaTable): void {
       throw new Error(`Duplicate field name "${field.name}" in table ${table.name}.`);
     }
     fieldNames.add(field.name);
+  }
+}
+
+function validateTenants(tenants: MetaTenant[]): Set<string> {
+  const tenantIds = new Set<string>();
+  for (const tenant of tenants) {
+    if (!tenant?.id) {
+      throw new Error("Tenant requires an id.");
+    }
+    if (tenantIds.has(tenant.id)) {
+      throw new Error(`Duplicate tenant id: ${tenant.id}.`);
+    }
+    tenantIds.add(tenant.id);
+    if (!tenant.name) {
+      throw new Error(`Tenant ${tenant.id} requires a name.`);
+    }
+  }
+  return tenantIds;
+}
+
+function validateApps(apps: MetaApp[], tenantIds: Set<string>): Set<string> {
+  const appIds = new Set<string>();
+  for (const app of apps) {
+    if (!app?.id) {
+      throw new Error("App requires an id.");
+    }
+    if (appIds.has(app.id)) {
+      throw new Error(`Duplicate app id: ${app.id}.`);
+    }
+    appIds.add(app.id);
+    if (!app.tenantId) {
+      throw new Error(`App ${app.id} requires a tenantId.`);
+    }
+    if (!tenantIds.has(app.tenantId)) {
+      throw new Error(`App ${app.id} references unknown tenant "${app.tenantId}".`);
+    }
+    if (!app.name) {
+      throw new Error(`App ${app.id} requires a name.`);
+    }
+  }
+  return appIds;
+}
+
+function validateRules(rules: MetaRule[], appIds: Set<string>): void {
+  const ruleIds = new Set<string>();
+  for (const rule of rules) {
+    if (!rule?.id) {
+      throw new Error("Rule requires an id.");
+    }
+    if (ruleIds.has(rule.id)) {
+      throw new Error(`Duplicate rule id: ${rule.id}.`);
+    }
+    ruleIds.add(rule.id);
+    if (!rule.appId) {
+      throw new Error(`Rule ${rule.id} requires an appId.`);
+    }
+    if (!appIds.has(rule.appId)) {
+      throw new Error(`Rule ${rule.id} references unknown app "${rule.appId}".`);
+    }
+    if (!rule.trigger) {
+      throw new Error(`Rule ${rule.id} requires a trigger.`);
+    }
+  }
+}
+
+function validatePermissions(permissions: SnapshotPermission[]): void {
+  for (const permission of permissions) {
+    if (!permission?.resource) {
+      throw new Error("Permission requires a resource.");
+    }
+    if (!permission.action) {
+      throw new Error(`Permission ${permission.resource} requires an action.`);
+    }
+    if (!Array.isArray(permission.roles) || permission.roles.length === 0) {
+      throw new Error(`Permission ${permission.resource}:${permission.action} requires at least one role.`);
+    }
+    const roles = new Set<string>();
+    for (const role of permission.roles) {
+      if (!role) {
+        throw new Error(`Permission ${permission.resource}:${permission.action} has an empty role.`);
+      }
+      if (roles.has(role)) {
+        throw new Error(`Permission ${permission.resource}:${permission.action} has duplicate role "${role}".`);
+      }
+      roles.add(role);
+    }
   }
 }
 

--- a/packages/kernel/src/types.ts
+++ b/packages/kernel/src/types.ts
@@ -22,6 +22,30 @@ export interface MetaTable {
 export interface MetaSchema {
   tables: MetaTable[];
   relations?: SnapshotRelation[];
+  tenants?: MetaTenant[];
+  apps?: MetaApp[];
+  rules?: MetaRule[];
+  permissions?: SnapshotPermission[];
+}
+
+export interface MetaTenant {
+  id: string;
+  name: string;
+  status?: "active" | "disabled";
+}
+
+export interface MetaApp {
+  id: string;
+  tenantId: string;
+  name: string;
+  status?: "active" | "disabled";
+}
+
+export interface MetaRule {
+  id: string;
+  appId: string;
+  name?: string;
+  trigger: string;
 }
 
 export interface SnapshotRelation {

--- a/packages/kernel/test/contracts.test.ts
+++ b/packages/kernel/test/contracts.test.ts
@@ -47,6 +47,18 @@ test("validateSchema accepts indexes and relations", () => {
   );
 });
 
+test("validateSchema accepts tenant, app, rule, and permission metadata", () => {
+  assert.doesNotThrow(() =>
+    validateSchema({
+      tables: [{ name: "orders", fields: [{ name: "id", type: "uuid" }] }],
+      tenants: [{ id: "tenant-a", name: "Tenant A", status: "active" }],
+      apps: [{ id: "sales-app", tenantId: "tenant-a", name: "Sales App", status: "active" }],
+      rules: [{ id: "refresh-orders", appId: "sales-app", trigger: "mutation.succeeded" }],
+      permissions: [{ resource: "orders", action: "query", roles: ["SALES", "ADMIN"] }]
+    })
+  );
+});
+
 test("validateSchema rejects duplicate index names and empty index fields", () => {
   assert.throws(
     () =>
@@ -119,5 +131,117 @@ test("validateSchema rejects relations to missing tables or fields", () => {
         ]
       }),
     /unknown toTable "customers"/
+  );
+});
+
+test("validateSchema rejects duplicate tenant, app, and rule ids", () => {
+  assert.throws(
+    () =>
+      validateSchema({
+        tables: [],
+        tenants: [
+          { id: "tenant-a", name: "Tenant A" },
+          { id: "tenant-a", name: "Tenant A Duplicate" }
+        ]
+      }),
+    /Duplicate tenant id: tenant-a/
+  );
+
+  assert.throws(
+    () =>
+      validateSchema({
+        tables: [],
+        tenants: [{ id: "tenant-a", name: "Tenant A" }],
+        apps: [
+          { id: "sales-app", tenantId: "tenant-a", name: "Sales App" },
+          { id: "sales-app", tenantId: "tenant-a", name: "Sales App Duplicate" }
+        ]
+      }),
+    /Duplicate app id: sales-app/
+  );
+
+  assert.throws(
+    () =>
+      validateSchema({
+        tables: [],
+        tenants: [{ id: "tenant-a", name: "Tenant A" }],
+        apps: [{ id: "sales-app", tenantId: "tenant-a", name: "Sales App" }],
+        rules: [
+          { id: "refresh-orders", appId: "sales-app", trigger: "mutation.succeeded" },
+          { id: "refresh-orders", appId: "sales-app", trigger: "state.changed" }
+        ]
+      }),
+    /Duplicate rule id: refresh-orders/
+  );
+});
+
+test("validateSchema rejects invalid app and rule references", () => {
+  assert.throws(
+    () =>
+      validateSchema({
+        tables: [],
+        apps: [{ id: "sales-app", tenantId: "tenant-a", name: "Sales App" }]
+      }),
+    /App sales-app references unknown tenant "tenant-a"/
+  );
+
+  assert.throws(
+    () =>
+      validateSchema({
+        tables: [],
+        tenants: [{ id: "tenant-a", name: "Tenant A" }],
+        apps: [{ id: "sales-app", tenantId: "tenant-a", name: "Sales App" }],
+        rules: [{ id: "refresh-orders", appId: "missing-app", trigger: "mutation.succeeded" }]
+      }),
+    /Rule refresh-orders references unknown app "missing-app"/
+  );
+
+  assert.throws(
+    () =>
+      validateSchema({
+        tables: [],
+        tenants: [{ id: "tenant-a", name: "Tenant A" }],
+        apps: [{ id: "sales-app", tenantId: "tenant-a", name: "Sales App" }],
+        rules: [{ id: "refresh-orders", appId: "sales-app", trigger: "" }]
+      }),
+    /Rule refresh-orders requires a trigger/
+  );
+});
+
+test("validateSchema rejects invalid permissions", () => {
+  assert.throws(
+    () =>
+      validateSchema({
+        tables: [],
+        permissions: [{ resource: "", action: "query", roles: ["ADMIN"] }]
+      }),
+    /Permission requires a resource/
+  );
+
+  assert.throws(
+    () =>
+      validateSchema({
+        tables: [],
+        permissions: [{ resource: "orders", action: "", roles: ["ADMIN"] }]
+      }),
+    /Permission orders requires an action/
+  );
+
+  assert.throws(
+    () =>
+      validateSchema({
+        tables: [],
+        permissions: [{ resource: "orders", action: "query", roles: [] }]
+      }),
+    /Permission orders:query requires at least one role/
+  );
+
+  assert.throws(
+    () =>
+      validateSchema({
+        tables: [],
+        permissions: [{ resource: "orders", action: "query", roles: ["ADMIN", "ADMIN"] }]
+      }),
+    /Permission orders:query has duplicate role "ADMIN"/
   );
 });

--- a/packages/kernel/test/permission-generator.test.ts
+++ b/packages/kernel/test/permission-generator.test.ts
@@ -25,6 +25,15 @@ test("compilePermissionManifest accepts empty permissions", () => {
   });
 });
 
+test("compilePermissionManifest accepts permissions from MetaSchema", () => {
+  const schema = {
+    tables: [],
+    permissions: ordersCompilerFixture.permissions
+  };
+
+  assert.deepEqual(compilePermissionManifest(schema.permissions ?? []), ordersCompilerFixture.expected.permission);
+});
+
 test("compilePermissionManifest rejects invalid permissions", () => {
   assert.throws(
     () => compilePermissionManifest([{ resource: "", action: "query", roles: ["ADMIN"] }]),


### PR DESCRIPTION
## Summary

- extend `MetaSchema` with versioned tenant, app, rule, and permission metadata
- add domain schema validation for duplicate ids, app tenant references, rule app references, rule triggers, and permission role shape
- keep repository storage unchanged by relying on existing `meta_kernel_versions.schema_json` JSONB persistence

Closes #27
Refs #18

## Test Plan

- `pnpm --filter @zhongmiao/meta-lc-kernel test`
- `pnpm lint:boundaries`
- `pnpm lint`
- `pnpm -r test`
- `pnpm changelog:gate origin/main HEAD`
- `git diff --check`