### PR TITLE
feat(runtime): add manager adapter baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - feat(contracts): add query and mutation response contracts for generated API route manifests.
 - feat(kernel): add a Permission Generator V1 manifest baseline and complete compiler fixture coverage across SQL, API, and permission outputs.
 - feat(kernel): add tenant, app, rule, and permission metadata to the versioned MetaSchema contract.
+- feat(runtime): add a manager adapter execution contract for orchestrator command plans.
 
 ## 0.1.0 (2026-04-18)
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -18,6 +18,7 @@
 - feat(contracts): 新增 query 与 mutation 响应契约，供生成的 API route manifest 引用。
 - feat(kernel): 新增 Permission Generator V1 manifest 基线，完成 SQL、API 与 permission 输出的 compiler fixture 覆盖。
 - feat(kernel): 将 tenant、app、rule 与 permission 元数据纳入可版本化 MetaSchema 契约。
+- feat(runtime): 新增 manager adapter 执行契约，用于执行 orchestrator command plan。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -6,6 +6,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - feat(runtime): add dependency graph construction and auto-refresh planning for state and mutation events.
 - feat(runtime): add a minimal function registry and rule engine for event-driven runtime effects.
 - feat(runtime): add a manager-first orchestration plan that combines refresh planning, rule effects, next state, manager commands, and WebSocket topics.
+- feat(runtime): add a manager adapter execution contract for orchestrator command plans.
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/runtime/CHANGELOG.zh-CN.md
+++ b/packages/runtime/CHANGELOG.zh-CN.md
@@ -6,6 +6,7 @@
 - feat(runtime): 新增依赖图构建与自动刷新规划，覆盖 state 与 mutation 成功事件。
 - feat(runtime): 新增最小 FunctionRegistry 与 RuleEngine，支持事件驱动的规则 effect 计算。
 - feat(runtime): 新增 manager-first orchestration plan，统一 refresh planning、rule effects、next state、manager commands 与 WebSocket topics。
+- feat(runtime): 新增 manager adapter 执行契约，用于执行 orchestrator command plan。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./runtime-dsl-parser";
 export * from "./dependency-graph";
 export * from "./function-registry";
+export * from "./manager-adapter";
 export * from "./orchestrator";
 export * from "./rule-engine";
 export * from "./template-resolver";

--- a/packages/runtime/src/manager-adapter.ts
+++ b/packages/runtime/src/manager-adapter.ts
@@ -1,0 +1,113 @@
+import type { RuntimeOrchestrationPlan, RuntimeManagerCommand } from "./orchestrator";
+
+export interface RuntimeManagerAdapter {
+  patchState?(patch: Record<string, unknown>, context: RuntimeManagerAdapterContext): void | Promise<void>;
+  refreshDatasource?(datasourceId: string, context: RuntimeManagerAdapterContext): unknown | Promise<unknown>;
+  runAction?(actionId: string, context: RuntimeManagerAdapterContext): unknown | Promise<unknown>;
+}
+
+export interface RuntimeManagerAdapterContext {
+  state: Record<string, unknown>;
+  commandIndex: number;
+  plan: RuntimeOrchestrationPlan;
+}
+
+export type RuntimeManagerCommandResult =
+  | {
+      type: "patchState";
+      patch: Record<string, unknown>;
+    }
+  | {
+      type: "refreshDatasource";
+      datasourceId: string;
+      result: unknown;
+    }
+  | {
+      type: "runAction";
+      actionId: string;
+      result: unknown;
+    };
+
+export interface RuntimeManagerExecutionRequest {
+  plan: RuntimeOrchestrationPlan;
+  adapter: RuntimeManagerAdapter;
+}
+
+export interface RuntimeManagerExecutionResult {
+  nextState: Record<string, unknown>;
+  commandResults: RuntimeManagerCommandResult[];
+  wsTopics: string[];
+}
+
+export async function executeRuntimeManagerPlan(
+  request: RuntimeManagerExecutionRequest
+): Promise<RuntimeManagerExecutionResult> {
+  let nextState = { ...request.plan.nextState };
+  const commandResults: RuntimeManagerCommandResult[] = [];
+
+  for (const [commandIndex, command] of request.plan.managerCommands.entries()) {
+    const context: RuntimeManagerAdapterContext = {
+      state: nextState,
+      commandIndex,
+      plan: request.plan
+    };
+
+    if (command.type === "patchState") {
+      await request.adapter.patchState?.(command.patch, context);
+      nextState = {
+        ...nextState,
+        ...command.patch
+      };
+      commandResults.push({
+        type: "patchState",
+        patch: command.patch
+      });
+      continue;
+    }
+
+    if (command.type === "refreshDatasource") {
+      const result = await request.adapter.refreshDatasource?.(command.datasourceId, context);
+      commandResults.push({
+        type: "refreshDatasource",
+        datasourceId: command.datasourceId,
+        result
+      });
+      continue;
+    }
+
+    const result = await request.adapter.runAction?.(command.actionId, context);
+    commandResults.push({
+      type: "runAction",
+      actionId: command.actionId,
+      result
+    });
+  }
+
+  return {
+    nextState,
+    commandResults,
+    wsTopics: [...request.plan.wsTopics]
+  };
+}
+
+export interface RecordingRuntimeManagerAdapter extends RuntimeManagerAdapter {
+  readonly calls: RuntimeManagerCommand[];
+}
+
+export function createRecordingRuntimeManagerAdapter(): RecordingRuntimeManagerAdapter {
+  const calls: RuntimeManagerCommand[] = [];
+  return {
+    calls,
+    patchState: (patch) => {
+      calls.push({ type: "patchState", patch });
+    },
+    refreshDatasource: (datasourceId) => {
+      calls.push({ type: "refreshDatasource", datasourceId });
+      return { datasourceId };
+    },
+    runAction: (actionId) => {
+      calls.push({ type: "runAction", actionId });
+      return { actionId };
+    }
+  };
+}

--- a/packages/runtime/test/manager-adapter.test.ts
+++ b/packages/runtime/test/manager-adapter.test.ts
@@ -1,0 +1,92 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  createRecordingRuntimeManagerAdapter,
+  executeRuntimeManagerPlan,
+  type RuntimeOrchestrationPlan
+} from "../src";
+
+function createPlan(): RuntimeOrchestrationPlan {
+  return {
+    refreshPlan: {
+      triggeredBy: { type: "state.changed", stateKeys: ["filter"] },
+      targetOrder: [
+        { kind: "datasource", id: "orders" },
+        { kind: "action", id: "notify" }
+      ],
+      datasourceIds: ["orders"],
+      actionIds: ["notify"]
+    },
+    ruleEffects: {
+      triggeredBy: { type: "state.changed", stateKeys: ["filter"] },
+      matchedRuleIds: ["reload"],
+      patchState: { shouldReload: true },
+      refreshDatasourceIds: ["orders"],
+      runActionIds: ["notify"]
+    },
+    nextState: {
+      filter: "PAID",
+      shouldReload: false
+    },
+    managerCommands: [
+      { type: "patchState", patch: { shouldReload: true } },
+      { type: "refreshDatasource", datasourceId: "orders" },
+      { type: "runAction", actionId: "notify" }
+    ],
+    wsTopics: ["tenant.tenant-a.page.orders.instance.instance-1"]
+  };
+}
+
+test("executeRuntimeManagerPlan executes commands in plan order", async () => {
+  const plan = createPlan();
+  const adapter = createRecordingRuntimeManagerAdapter();
+  const result = await executeRuntimeManagerPlan({ plan, adapter });
+
+  assert.deepEqual(adapter.calls, plan.managerCommands);
+  assert.deepEqual(result.commandResults, [
+    { type: "patchState", patch: { shouldReload: true } },
+    { type: "refreshDatasource", datasourceId: "orders", result: { datasourceId: "orders" } },
+    { type: "runAction", actionId: "notify", result: { actionId: "notify" } }
+  ]);
+});
+
+test("executeRuntimeManagerPlan merges patch state and forwards ws topics", async () => {
+  const plan = createPlan();
+  const result = await executeRuntimeManagerPlan({
+    plan,
+    adapter: createRecordingRuntimeManagerAdapter()
+  });
+
+  assert.deepEqual(result.nextState, {
+    filter: "PAID",
+    shouldReload: true
+  });
+  assert.deepEqual(result.wsTopics, ["tenant.tenant-a.page.orders.instance.instance-1"]);
+});
+
+test("executeRuntimeManagerPlan fails fast when adapter throws", async () => {
+  const plan = createPlan();
+  const calls: string[] = [];
+
+  await assert.rejects(
+    () =>
+      executeRuntimeManagerPlan({
+        plan,
+        adapter: {
+          patchState: () => {
+            calls.push("patchState");
+          },
+          refreshDatasource: () => {
+            calls.push("refreshDatasource");
+            throw new Error("datasource failed");
+          },
+          runAction: () => {
+            calls.push("runAction");
+          }
+        }
+      }),
+    /datasource failed/
+  );
+
+  assert.deepEqual(calls, ["patchState", "refreshDatasource"]);
+});


### PR DESCRIPTION
## Summary

- add `RuntimeManagerAdapter` and `executeRuntimeManagerPlan` as the manager execution contract for orchestrator command plans
- preserve command order, merge patchState into nextState, and fail fast on adapter errors
- add a lightweight recording adapter test helper and runtime unit coverage

Refs #21
Refs #17

## Test Plan

- `pnpm --filter @zhongmiao/meta-lc-runtime test`
- `pnpm lint:boundaries`
- `pnpm lint`
- `pnpm -r test`
- `pnpm changelog:gate origin/main HEAD`
- `git diff --check`