### PR TITLE
feat(runtime): add ws update event baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - feat(kernel): add a Permission Generator V1 manifest baseline and complete compiler fixture coverage across SQL, API, and permission outputs.
 - feat(kernel): add tenant, app, rule, and permission metadata to the versioned MetaSchema contract.
 - feat(runtime): add a manager adapter execution contract for orchestrator command plans.
+- feat(runtime): add a Runtime WebSocket manager-executed event contract and BFF emit baseline.
 
 ## 0.1.0 (2026-04-18)
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -19,6 +19,7 @@
 - feat(kernel): 新增 Permission Generator V1 manifest 基线，完成 SQL、API 与 permission 输出的 compiler fixture 覆盖。
 - feat(kernel): 将 tenant、app、rule 与 permission 元数据纳入可版本化 MetaSchema 契约。
 - feat(runtime): 新增 manager adapter 执行契约，用于执行 orchestrator command plan。
+- feat(runtime): 新增 Runtime WebSocket manager-executed 事件契约与 BFF emit 基线。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/bff/CHANGELOG.md
+++ b/packages/bff/CHANGELOG.md
@@ -9,6 +9,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - fix(local-dev): move the default BFF local port to `6001` and bind an explicit host so browser-based integration can reach the service without unsafe-port blocking.
 - test(permission-gate): expand the query/mutation gate baseline to cover `SELF`, `DEPT_AND_CHILDREN`, and `CUSTOM_ORG_SET` permission paths in addition to the existing `DEPT` denied checks.
 - feat(permission-seed): add custom-org and self-scope demo identities so org-scope policies can be exercised in e2e and remote bootstrap flows.
+- feat(gateway): add a WebSocket emit baseline for runtime manager-executed updates.
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/bff/CHANGELOG.zh-CN.md
+++ b/packages/bff/CHANGELOG.zh-CN.md
@@ -9,6 +9,7 @@
 - fix(local-dev): 将 BFF 本地默认端口调整为 `6001`，并显式绑定 host，避免浏览器因 unsafe port 策略阻断联调访问。
 - test(permission-gate): 将 query/mutation gate 扩展到 `SELF`、`DEPT_AND_CHILDREN`、`CUSTOM_ORG_SET` 权限路径，不再只覆盖现有 `DEPT` denied 样例。
 - feat(permission-seed): 新增 custom-org 与 self-scope 演示身份，供 e2e 与远端 bootstrap 场景稳定复现组织域权限。
+- feat(gateway): 新增 runtime manager-executed 更新的 WebSocket emit 基线。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/bff/src/gateway/ws.gateway.ts
+++ b/packages/bff/src/gateway/ws.gateway.ts
@@ -9,6 +9,8 @@ import {
 } from "@nestjs/websockets";
 import {
   buildRuntimePageTopic,
+  RUNTIME_MANAGER_EXECUTED_EVENT,
+  type RuntimeManagerExecutedEvent,
   type RuntimePageTopicRef
 } from "@zhongmiao/meta-lc-contracts";
 
@@ -47,6 +49,11 @@ export class RuntimeWsGateway implements OnGatewayConnection<WsClientLike>, OnGa
       status: "subscribed"
     };
     client.emit("pageSubscribed", event);
+    return event;
+  }
+
+  emitRuntimeManagerExecuted(client: WsClientLike, event: RuntimeManagerExecutedEvent): RuntimeManagerExecutedEvent {
+    client.emit(RUNTIME_MANAGER_EXECUTED_EVENT, event);
     return event;
   }
 }

--- a/packages/bff/test/ws-gateway.test.ts
+++ b/packages/bff/test/ws-gateway.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  RUNTIME_MANAGER_EXECUTED_EVENT,
+  type RuntimeManagerExecutedEvent
+} from "@zhongmiao/meta-lc-contracts";
+import {
   buildPageTopic,
   RuntimeWsGateway,
   type PageSubscribedEvent,
@@ -48,4 +52,33 @@ test("runtime websocket gateway confirms page subscription", () => {
   };
   assert.deepEqual(result, expected);
   assert.deepEqual(emitted, [{ event: "pageSubscribed", payload: expected }]);
+});
+
+test("runtime websocket gateway emits manager executed updates", () => {
+  const gateway = new RuntimeWsGateway();
+  const emitted: Array<{ event: string; payload: unknown }> = [];
+  const client: WsClientLike = {
+    id: "client-1",
+    emit(event: string, payload: unknown): void {
+      emitted.push({ event, payload });
+    }
+  };
+  const update: RuntimeManagerExecutedEvent = {
+    type: "runtime.manager.executed",
+    topic: "tenant.tenant-a.page.orders.instance.instance-1",
+    page: {
+      tenantId: "tenant-a",
+      pageId: "orders",
+      pageInstanceId: "instance-1"
+    },
+    requestId: "req-1",
+    patchState: { shouldReload: true },
+    refreshedDatasourceIds: ["orders"],
+    runActionIds: ["notify"]
+  };
+
+  const result = gateway.emitRuntimeManagerExecuted(client, update);
+
+  assert.deepEqual(result, update);
+  assert.deepEqual(emitted, [{ event: RUNTIME_MANAGER_EXECUTED_EVENT, payload: update }]);
 });

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -7,6 +7,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - feat(runtime-contracts): add rule and function contracts for event-driven runtime evaluation.
 - feat(runtime-contracts): add the shared runtime page topic helper used by BFF WebSocket and runtime orchestration boundaries.
 - feat(api-contracts): add query and mutation response contracts for generated API route manifests.
+- feat(runtime-contracts): add a manager-executed WebSocket event envelope for runtime page updates.
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/contracts/CHANGELOG.zh-CN.md
+++ b/packages/contracts/CHANGELOG.zh-CN.md
@@ -7,6 +7,7 @@
 - feat(runtime-contracts): 补充事件驱动规则求值所需的规则与函数契约类型。
 - feat(runtime-contracts): 新增共享 runtime page topic helper，用于 BFF WebSocket 与 runtime orchestration 边界对齐。
 - feat(api-contracts): 新增 query 与 mutation 响应契约，供生成的 API route manifest 引用。
+- feat(runtime-contracts): 新增 manager-executed WebSocket 事件 envelope，用于 runtime 页面更新。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -125,6 +125,42 @@ export function buildRuntimePageTopic(ref: RuntimePageTopicRef): string {
   return `tenant.${ref.tenantId}.page.${ref.pageId}.instance.${ref.pageInstanceId}`;
 }
 
+export const RUNTIME_MANAGER_EXECUTED_EVENT = "runtimeManagerExecuted";
+
+export type RuntimeManagerExecutedEventType = "runtime.manager.executed";
+
+export interface RuntimeManagerExecutedEvent {
+  type: RuntimeManagerExecutedEventType;
+  topic: string;
+  page: RuntimePageTopicRef;
+  requestId?: string;
+  patchState: Record<string, unknown>;
+  refreshedDatasourceIds: string[];
+  runActionIds: string[];
+}
+
+export interface CreateRuntimeManagerExecutedEventRequest {
+  page: RuntimePageTopicRef;
+  requestId?: string;
+  patchState?: Record<string, unknown>;
+  refreshedDatasourceIds?: string[];
+  runActionIds?: string[];
+}
+
+export function createRuntimeManagerExecutedEvent(
+  request: CreateRuntimeManagerExecutedEventRequest
+): RuntimeManagerExecutedEvent {
+  return {
+    type: "runtime.manager.executed",
+    topic: buildRuntimePageTopic(request.page),
+    page: { ...request.page },
+    ...(request.requestId ? { requestId: request.requestId } : {}),
+    patchState: { ...(request.patchState ?? {}) },
+    refreshedDatasourceIds: [...(request.refreshedDatasourceIds ?? [])],
+    runActionIds: [...(request.runActionIds ?? [])]
+  };
+}
+
 export interface RuntimeNodeSchema {
   id: string;
   componentType: string;

--- a/packages/contracts/test/smoke.test.ts
+++ b/packages/contracts/test/smoke.test.ts
@@ -2,9 +2,12 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   buildRuntimePageTopic,
+  createRuntimeManagerExecutedEvent,
+  RUNTIME_MANAGER_EXECUTED_EVENT,
   type MutationApiResponse,
   type QueryApiRequest,
   type QueryApiResponse,
+  type RuntimeManagerExecutedEvent,
   type RuntimeFunctionCallDefinition,
   type RuntimePageDsl,
   type RuntimeRuleDefinition,
@@ -114,4 +117,33 @@ test("contracts exports runtime page topic helper", () => {
     }),
     "tenant.tenant-a.page.orders-page.instance.instance-1"
   );
+});
+
+test("contracts exports runtime manager executed event helper", () => {
+  const event: RuntimeManagerExecutedEvent = createRuntimeManagerExecutedEvent({
+    page: {
+      tenantId: "tenant-a",
+      pageId: "orders-page",
+      pageInstanceId: "instance-1"
+    },
+    requestId: "req-1",
+    patchState: { status: "PAID" },
+    refreshedDatasourceIds: ["orders"],
+    runActionIds: ["notify"]
+  });
+
+  assert.equal(RUNTIME_MANAGER_EXECUTED_EVENT, "runtimeManagerExecuted");
+  assert.deepEqual(event, {
+    type: "runtime.manager.executed",
+    topic: "tenant.tenant-a.page.orders-page.instance.instance-1",
+    page: {
+      tenantId: "tenant-a",
+      pageId: "orders-page",
+      pageInstanceId: "instance-1"
+    },
+    requestId: "req-1",
+    patchState: { status: "PAID" },
+    refreshedDatasourceIds: ["orders"],
+    runActionIds: ["notify"]
+  });
 });

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -7,6 +7,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - feat(runtime): add a minimal function registry and rule engine for event-driven runtime effects.
 - feat(runtime): add a manager-first orchestration plan that combines refresh planning, rule effects, next state, manager commands, and WebSocket topics.
 - feat(runtime): add a manager adapter execution contract for orchestrator command plans.
+- feat(runtime): add a helper that converts manager execution results into WebSocket update events.
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/runtime/CHANGELOG.zh-CN.md
+++ b/packages/runtime/CHANGELOG.zh-CN.md
@@ -7,6 +7,7 @@
 - feat(runtime): 新增最小 FunctionRegistry 与 RuleEngine，支持事件驱动的规则 effect 计算。
 - feat(runtime): 新增 manager-first orchestration plan，统一 refresh planning、rule effects、next state、manager commands 与 WebSocket topics。
 - feat(runtime): 新增 manager adapter 执行契约，用于执行 orchestrator command plan。
+- feat(runtime): 新增 helper，将 manager 执行结果转换为 WebSocket 更新事件。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -3,6 +3,7 @@ export * from "./dependency-graph";
 export * from "./function-registry";
 export * from "./manager-adapter";
 export * from "./orchestrator";
+export * from "./ws-events";
 export * from "./rule-engine";
 export * from "./template-resolver";
 export * from "./types";

--- a/packages/runtime/src/ws-events.ts
+++ b/packages/runtime/src/ws-events.ts
@@ -1,0 +1,42 @@
+import {
+  createRuntimeManagerExecutedEvent,
+  type RuntimeManagerExecutedEvent,
+  type RuntimePageTopicRef
+} from "@zhongmiao/meta-lc-contracts";
+import type { RuntimeManagerExecutionResult } from "./manager-adapter";
+
+export interface CreateRuntimeManagerExecutionWsEventRequest {
+  page: RuntimePageTopicRef;
+  executionResult: RuntimeManagerExecutionResult;
+  requestId?: string;
+}
+
+export function createRuntimeManagerExecutionWsEvent(
+  request: CreateRuntimeManagerExecutionWsEventRequest
+): RuntimeManagerExecutedEvent {
+  const patchState: Record<string, unknown> = {};
+  const refreshedDatasourceIds: string[] = [];
+  const runActionIds: string[] = [];
+
+  for (const result of request.executionResult.commandResults) {
+    if (result.type === "patchState") {
+      Object.assign(patchState, result.patch);
+      continue;
+    }
+
+    if (result.type === "refreshDatasource") {
+      refreshedDatasourceIds.push(result.datasourceId);
+      continue;
+    }
+
+    runActionIds.push(result.actionId);
+  }
+
+  return createRuntimeManagerExecutedEvent({
+    page: request.page,
+    ...(request.requestId ? { requestId: request.requestId } : {}),
+    patchState,
+    refreshedDatasourceIds,
+    runActionIds
+  });
+}

--- a/packages/runtime/test/ws-events.test.ts
+++ b/packages/runtime/test/ws-events.test.ts
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  createRuntimeManagerExecutionWsEvent,
+  type RuntimeManagerExecutionResult
+} from "../src";
+
+const page = {
+  tenantId: "tenant-a",
+  pageId: "orders",
+  pageInstanceId: "instance-1"
+};
+
+test("createRuntimeManagerExecutionWsEvent summarizes manager command results", () => {
+  const executionResult: RuntimeManagerExecutionResult = {
+    nextState: {
+      filter: "PAID",
+      shouldReload: true
+    },
+    commandResults: [
+      { type: "patchState", patch: { shouldReload: true } },
+      { type: "refreshDatasource", datasourceId: "orders", result: { datasourceId: "orders" } },
+      { type: "runAction", actionId: "notify", result: { actionId: "notify" } }
+    ],
+    wsTopics: ["tenant.tenant-a.page.orders.instance.instance-1"]
+  };
+
+  assert.deepEqual(
+    createRuntimeManagerExecutionWsEvent({
+      page,
+      requestId: "req-1",
+      executionResult
+    }),
+    {
+      type: "runtime.manager.executed",
+      topic: "tenant.tenant-a.page.orders.instance.instance-1",
+      page,
+      requestId: "req-1",
+      patchState: { shouldReload: true },
+      refreshedDatasourceIds: ["orders"],
+      runActionIds: ["notify"]
+    }
+  );
+});
+
+test("createRuntimeManagerExecutionWsEvent handles empty command results", () => {
+  const executionResult: RuntimeManagerExecutionResult = {
+    nextState: {},
+    commandResults: [],
+    wsTopics: ["tenant.tenant-a.page.orders.instance.instance-1"]
+  };
+
+  assert.deepEqual(createRuntimeManagerExecutionWsEvent({ page, executionResult }), {
+    type: "runtime.manager.executed",
+    topic: "tenant.tenant-a.page.orders.instance.instance-1",
+    page,
+    patchState: {},
+    refreshedDatasourceIds: [],
+    runActionIds: []
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared runtime manager-executed WebSocket event envelope in contracts
- add a runtime helper that summarizes manager execution results into the WS update event
- add a BFF WebSocket emit baseline for manager-executed updates

Refs #21
Refs #17

## Test Plan
- pnpm --filter @zhongmiao/meta-lc-contracts test
- pnpm --filter @zhongmiao/meta-lc-runtime test
- pnpm --filter @zhongmiao/meta-lc-bff test
- pnpm lint:boundaries
- pnpm lint
- pnpm -r test
- pnpm changelog:gate origin/main HEAD
- git diff --check