### PR TITLE
feat(bff): add runtime ws room broadcast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - feat(kernel): add tenant, app, rule, and permission metadata to the versioned MetaSchema contract.
 - feat(runtime): add a manager adapter execution contract for orchestrator command plans.
 - feat(runtime): add a Runtime WebSocket manager-executed event contract and BFF emit baseline.
+- feat(bff): add Runtime WebSocket topic-room broadcast and in-memory replay baseline.
 
 ## 0.1.0 (2026-04-18)
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -20,6 +20,7 @@
 - feat(kernel): 将 tenant、app、rule 与 permission 元数据纳入可版本化 MetaSchema 契约。
 - feat(runtime): 新增 manager adapter 执行契约，用于执行 orchestrator command plan。
 - feat(runtime): 新增 Runtime WebSocket manager-executed 事件契约与 BFF emit 基线。
+- feat(bff): 新增 Runtime WebSocket topic room 广播与内存 replay 基线。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/bff/CHANGELOG.md
+++ b/packages/bff/CHANGELOG.md
@@ -10,6 +10,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - test(permission-gate): expand the query/mutation gate baseline to cover `SELF`, `DEPT_AND_CHILDREN`, and `CUSTOM_ORG_SET` permission paths in addition to the existing `DEPT` denied checks.
 - feat(permission-seed): add custom-org and self-scope demo identities so org-scope policies can be exercised in e2e and remote bootstrap flows.
 - feat(gateway): add a WebSocket emit baseline for runtime manager-executed updates.
+- feat(gateway): add topic-room broadcast and in-memory replay for runtime manager-executed updates.
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/bff/CHANGELOG.zh-CN.md
+++ b/packages/bff/CHANGELOG.zh-CN.md
@@ -10,6 +10,7 @@
 - test(permission-gate): 将 query/mutation gate 扩展到 `SELF`、`DEPT_AND_CHILDREN`、`CUSTOM_ORG_SET` 权限路径，不再只覆盖现有 `DEPT` denied 样例。
 - feat(permission-seed): 新增 custom-org 与 self-scope 演示身份，供 e2e 与远端 bootstrap 场景稳定复现组织域权限。
 - feat(gateway): 新增 runtime manager-executed 更新的 WebSocket emit 基线。
+- feat(gateway): 为 runtime manager-executed 更新新增 topic room 广播与内存 replay。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/bff/src/gateway/ws.gateway.ts
+++ b/packages/bff/src/gateway/ws.gateway.ts
@@ -4,6 +4,7 @@ import {
   MessageBody,
   OnGatewayConnection,
   OnGatewayDisconnect,
+  WebSocketServer,
   SubscribeMessage,
   WebSocketGateway
 } from "@nestjs/websockets";
@@ -17,6 +18,15 @@ import {
 export interface WsClientLike {
   id: string;
   emit(event: string, payload: unknown): void;
+  join?(room: string): void | Promise<void>;
+}
+
+export interface WsRoomLike {
+  emit(event: string, payload: unknown): void;
+}
+
+export interface WsServerLike {
+  to(room: string): WsRoomLike;
 }
 
 export interface SubscribePageMessage extends RuntimePageTopicRef {}
@@ -29,6 +39,10 @@ export interface PageSubscribedEvent extends SubscribePageMessage {
 @WebSocketGateway({ namespace: "runtime" })
 export class RuntimeWsGateway implements OnGatewayConnection<WsClientLike>, OnGatewayDisconnect<WsClientLike> {
   private readonly logger = new Logger("RuntimeWsGateway");
+  private readonly latestRuntimeEventsByTopic = new Map<string, RuntimeManagerExecutedEvent>();
+
+  @WebSocketServer()
+  server?: WsServerLike;
 
   handleConnection(client: WsClientLike): void {
     this.logger.log(`client connected: ${client.id}`);
@@ -48,13 +62,30 @@ export class RuntimeWsGateway implements OnGatewayConnection<WsClientLike>, OnGa
       topic: buildPageTopic(message),
       status: "subscribed"
     };
+    this.joinTopic(client, event.topic);
     client.emit("pageSubscribed", event);
+    const replayEvent = this.latestRuntimeEventsByTopic.get(event.topic);
+    if (replayEvent) {
+      this.emitRuntimeManagerExecuted(client, replayEvent);
+    }
     return event;
   }
 
   emitRuntimeManagerExecuted(client: WsClientLike, event: RuntimeManagerExecutedEvent): RuntimeManagerExecutedEvent {
     client.emit(RUNTIME_MANAGER_EXECUTED_EVENT, event);
     return event;
+  }
+
+  broadcastRuntimeManagerExecuted(event: RuntimeManagerExecutedEvent): RuntimeManagerExecutedEvent {
+    this.latestRuntimeEventsByTopic.set(event.topic, event);
+    this.server?.to(event.topic).emit(RUNTIME_MANAGER_EXECUTED_EVENT, event);
+    return event;
+  }
+
+  private joinTopic(client: WsClientLike, topic: string): void {
+    void Promise.resolve(client.join?.(topic)).catch((error) => {
+      this.logger.warn(`client ${client.id} failed to join ${topic}: ${String(error)}`);
+    });
   }
 }
 

--- a/packages/bff/test/ws-gateway.test.ts
+++ b/packages/bff/test/ws-gateway.test.ts
@@ -8,8 +8,25 @@ import {
   buildPageTopic,
   RuntimeWsGateway,
   type PageSubscribedEvent,
-  type WsClientLike
+  type WsClientLike,
+  type WsServerLike
 } from "../src/gateway/ws.gateway";
+
+function createUpdate(topic = "tenant.tenant-a.page.orders.instance.instance-1"): RuntimeManagerExecutedEvent {
+  return {
+    type: "runtime.manager.executed",
+    topic,
+    page: {
+      tenantId: "tenant-a",
+      pageId: "orders",
+      pageInstanceId: "instance-1"
+    },
+    requestId: "req-1",
+    patchState: { shouldReload: true },
+    refreshedDatasourceIds: ["orders"],
+    runActionIds: ["notify"]
+  };
+}
 
 test("buildPageTopic creates tenant/page/instance scoped topic", () => {
   assert.equal(
@@ -25,10 +42,14 @@ test("buildPageTopic creates tenant/page/instance scoped topic", () => {
 test("runtime websocket gateway confirms page subscription", () => {
   const gateway = new RuntimeWsGateway();
   const emitted: Array<{ event: string; payload: unknown }> = [];
+  const joinedRooms: string[] = [];
   const client: WsClientLike = {
     id: "client-1",
     emit(event: string, payload: unknown): void {
       emitted.push({ event, payload });
+    },
+    join(room: string): void {
+      joinedRooms.push(room);
     }
   };
 
@@ -51,7 +72,42 @@ test("runtime websocket gateway confirms page subscription", () => {
     status: "subscribed"
   };
   assert.deepEqual(result, expected);
+  assert.deepEqual(joinedRooms, ["tenant.tenant-a.page.orders.instance.instance-1"]);
   assert.deepEqual(emitted, [{ event: "pageSubscribed", payload: expected }]);
+});
+
+test("runtime websocket gateway confirms page subscription when join is unavailable", () => {
+  const gateway = new RuntimeWsGateway();
+  const emitted: Array<{ event: string; payload: unknown }> = [];
+  const client: WsClientLike = {
+    id: "client-1",
+    emit(event: string, payload: unknown): void {
+      emitted.push({ event, payload });
+    }
+  };
+
+  const result = gateway.subscribePage(
+    {
+      tenantId: "tenant-a",
+      pageId: "orders",
+      pageInstanceId: "instance-1"
+    },
+    client
+  );
+
+  assert.equal(result.topic, "tenant.tenant-a.page.orders.instance.instance-1");
+  assert.deepEqual(emitted, [
+    {
+      event: "pageSubscribed",
+      payload: {
+        tenantId: "tenant-a",
+        pageId: "orders",
+        pageInstanceId: "instance-1",
+        topic: "tenant.tenant-a.page.orders.instance.instance-1",
+        status: "subscribed"
+      }
+    }
+  ]);
 });
 
 test("runtime websocket gateway emits manager executed updates", () => {
@@ -63,22 +119,107 @@ test("runtime websocket gateway emits manager executed updates", () => {
       emitted.push({ event, payload });
     }
   };
-  const update: RuntimeManagerExecutedEvent = {
-    type: "runtime.manager.executed",
-    topic: "tenant.tenant-a.page.orders.instance.instance-1",
-    page: {
-      tenantId: "tenant-a",
-      pageId: "orders",
-      pageInstanceId: "instance-1"
-    },
-    requestId: "req-1",
-    patchState: { shouldReload: true },
-    refreshedDatasourceIds: ["orders"],
-    runActionIds: ["notify"]
-  };
+  const update = createUpdate();
 
   const result = gateway.emitRuntimeManagerExecuted(client, update);
 
   assert.deepEqual(result, update);
   assert.deepEqual(emitted, [{ event: RUNTIME_MANAGER_EXECUTED_EVENT, payload: update }]);
+});
+
+test("runtime websocket gateway broadcasts manager executed updates to topic rooms", () => {
+  const gateway = new RuntimeWsGateway();
+  const emitted: Array<{ room: string; event: string; payload: unknown }> = [];
+  const server: WsServerLike = {
+    to(room: string) {
+      return {
+        emit(event: string, payload: unknown): void {
+          emitted.push({ room, event, payload });
+        }
+      };
+    }
+  };
+  gateway.server = server;
+  const update = createUpdate();
+
+  const result = gateway.broadcastRuntimeManagerExecuted(update);
+
+  assert.deepEqual(result, update);
+  assert.deepEqual(emitted, [
+    {
+      room: "tenant.tenant-a.page.orders.instance.instance-1",
+      event: RUNTIME_MANAGER_EXECUTED_EVENT,
+      payload: update
+    }
+  ]);
+});
+
+test("runtime websocket gateway replays the latest topic update on subscription", () => {
+  const gateway = new RuntimeWsGateway();
+  const emitted: Array<{ event: string; payload: unknown }> = [];
+  const client: WsClientLike = {
+    id: "client-1",
+    emit(event: string, payload: unknown): void {
+      emitted.push({ event, payload });
+    }
+  };
+  const update = createUpdate();
+  gateway.broadcastRuntimeManagerExecuted(update);
+
+  gateway.subscribePage(
+    {
+      tenantId: "tenant-a",
+      pageId: "orders",
+      pageInstanceId: "instance-1"
+    },
+    client
+  );
+
+  assert.deepEqual(emitted, [
+    {
+      event: "pageSubscribed",
+      payload: {
+        tenantId: "tenant-a",
+        pageId: "orders",
+        pageInstanceId: "instance-1",
+        topic: "tenant.tenant-a.page.orders.instance.instance-1",
+        status: "subscribed"
+      }
+    },
+    { event: RUNTIME_MANAGER_EXECUTED_EVENT, payload: update }
+  ]);
+});
+
+test("runtime websocket gateway does not replay updates for other topics", () => {
+  const gateway = new RuntimeWsGateway();
+  const emitted: Array<{ event: string; payload: unknown }> = [];
+  const client: WsClientLike = {
+    id: "client-1",
+    emit(event: string, payload: unknown): void {
+      emitted.push({ event, payload });
+    }
+  };
+  gateway.broadcastRuntimeManagerExecuted(createUpdate("tenant.tenant-a.page.customers.instance.instance-1"));
+
+  gateway.subscribePage(
+    {
+      tenantId: "tenant-a",
+      pageId: "orders",
+      pageInstanceId: "instance-1"
+    },
+    client
+  );
+
+  assert.deepEqual(emitted, [
+    {
+      event: "pageSubscribed",
+      payload: {
+        tenantId: "tenant-a",
+        pageId: "orders",
+        pageInstanceId: "instance-1",
+        topic: "tenant.tenant-a.page.orders.instance.instance-1",
+        status: "subscribed"
+      }
+    }
+  ]);
 });


### PR DESCRIPTION
## Summary
- make runtime page subscriptions join the page topic room when the socket client supports `join`
- add room broadcast for `runtimeManagerExecuted` updates keyed by event topic
- keep an in-memory latest-event replay baseline per topic for new subscribers

Refs #21
Refs #17

## Test Plan
- pnpm --filter @zhongmiao/meta-lc-bff test
- pnpm lint:boundaries
- pnpm lint
- pnpm -r test
- pnpm changelog:gate origin/main HEAD
- git diff --check