### PR TITLE
feat(bff): add runtime ws ops status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - feat(bff): add Runtime WebSocket topic-room broadcast and in-memory replay baseline.
 - feat(bff): add a configurable Runtime WebSocket replay store with a Redis-backed latest-event adapter.
 - feat(bff): add a configurable Runtime WebSocket broadcast bus with Redis pub/sub fanout.
+- feat(bff): add Runtime WebSocket operations status and health visibility.
 
 ## 0.1.0 (2026-04-18)
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -23,6 +23,7 @@
 - feat(bff): 新增 Runtime WebSocket topic room 广播与内存 replay 基线。
 - feat(bff): 新增可配置的 Runtime WebSocket replay store 与 Redis latest-event adapter。
 - feat(bff): 新增可配置的 Runtime WebSocket broadcast bus 与 Redis pub/sub fanout。
+- feat(bff): 新增 Runtime WebSocket 运维状态与健康检查可见性。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/bff/CHANGELOG.md
+++ b/packages/bff/CHANGELOG.md
@@ -13,6 +13,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - feat(gateway): add topic-room broadcast and in-memory replay for runtime manager-executed updates.
 - feat(gateway): add a configurable runtime WebSocket replay store with a Redis-backed latest-event adapter.
 - feat(gateway): add a configurable runtime WebSocket broadcast bus with Redis pub/sub fanout.
+- feat(gateway): add runtime WebSocket operations status and health visibility.
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/bff/CHANGELOG.zh-CN.md
+++ b/packages/bff/CHANGELOG.zh-CN.md
@@ -13,6 +13,7 @@
 - feat(gateway): 为 runtime manager-executed 更新新增 topic room 广播与内存 replay。
 - feat(gateway): 新增可配置的 runtime WebSocket replay store 与 Redis latest-event adapter。
 - feat(gateway): 新增可配置的 runtime WebSocket broadcast bus 与 Redis pub/sub fanout。
+- feat(gateway): 新增 runtime WebSocket 运维状态与健康检查可见性。
 
 ## 0.1.0 (2026-04-18)
 

--- a/packages/bff/src/app.module.ts
+++ b/packages/bff/src/app.module.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { Module } from "@nestjs/common";
 import { APP_FILTER } from "@nestjs/core";
 import { AggregationService } from "./aggregation/aggregation.service";
@@ -8,10 +9,15 @@ import { MetaController } from "./gateway/meta.controller";
 import { MetaRegistryService } from "./gateway/meta-registry.service";
 import {
   createRuntimeWsBroadcastBusFromEnv,
-  RUNTIME_WS_BROADCAST_BUS
+  parseRuntimeWsBroadcastBusMode,
+  RUNTIME_WS_BROADCAST_BUS,
+  RUNTIME_WS_INSTANCE_ID
 } from "./gateway/runtime-ws-broadcast.bus";
+import { RuntimeWsHealthController } from "./gateway/runtime-ws-health.controller";
+import { RuntimeWsOperationsState } from "./gateway/runtime-ws-operations.state";
 import {
   createRuntimeWsReplayStoreFromEnv,
+  parseRuntimeWsReplayStoreMode,
   RUNTIME_WS_REPLAY_STORE
 } from "./gateway/runtime-ws-replay.store";
 import { QueryController } from "./gateway/query.controller";
@@ -24,7 +30,7 @@ import { QueryOrchestratorService } from "./orchestration/query-orchestrator.ser
 
 @Module({
   imports: [],
-  controllers: [QueryController, MetaController],
+  controllers: [QueryController, MetaController, RuntimeWsHealthController],
   providers: [
     AggregationService,
     CacheService,
@@ -35,6 +41,20 @@ import { QueryOrchestratorService } from "./orchestration/query-orchestrator.ser
     QueryOrchestratorService,
     MutationOrchestratorService,
     AuditLogService,
+    {
+      provide: RUNTIME_WS_INSTANCE_ID,
+      useFactory: () => randomUUID()
+    },
+    {
+      provide: RuntimeWsOperationsState,
+      useFactory: (instanceId: string) =>
+        new RuntimeWsOperationsState({
+          replayStoreMode: parseRuntimeWsReplayStoreMode(process.env.LC_RUNTIME_WS_REPLAY_STORE),
+          broadcastBusMode: parseRuntimeWsBroadcastBusMode(process.env.LC_RUNTIME_WS_BROADCAST_BUS),
+          instanceId
+        }),
+      inject: [RUNTIME_WS_INSTANCE_ID]
+    },
     {
       provide: RUNTIME_WS_REPLAY_STORE,
       useFactory: () => createRuntimeWsReplayStoreFromEnv()

--- a/packages/bff/src/gateway/runtime-ws-health.controller.ts
+++ b/packages/bff/src/gateway/runtime-ws-health.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Get } from "@nestjs/common";
+import {
+  RuntimeWsOperationsState,
+  type RuntimeWsOperationsSnapshot
+} from "./runtime-ws-operations.state";
+
+@Controller()
+export class RuntimeWsHealthController {
+  constructor(private readonly operationsState: RuntimeWsOperationsState) {}
+
+  @Get("health/runtime-ws")
+  health(): RuntimeWsOperationsSnapshot {
+    return this.operationsState.snapshot();
+  }
+}

--- a/packages/bff/src/gateway/runtime-ws-operations.state.ts
+++ b/packages/bff/src/gateway/runtime-ws-operations.state.ts
@@ -1,0 +1,61 @@
+import { type RuntimeWsBroadcastBusMode } from "./runtime-ws-broadcast.bus";
+import { type RuntimeWsReplayStoreMode } from "./runtime-ws-replay.store";
+
+export interface RuntimeWsOperationError {
+  operation: "replay" | "broadcast";
+  message: string;
+  occurredAt: string;
+}
+
+export interface RuntimeWsOperationsSnapshot {
+  ok: boolean;
+  replayStoreMode: RuntimeWsReplayStoreMode;
+  broadcastBusMode: RuntimeWsBroadcastBusMode;
+  instanceId: string;
+  connectedClients: number;
+  lastError?: RuntimeWsOperationError;
+}
+
+export interface RuntimeWsOperationsStateOptions {
+  replayStoreMode: RuntimeWsReplayStoreMode;
+  broadcastBusMode: RuntimeWsBroadcastBusMode;
+  instanceId: string;
+}
+
+export class RuntimeWsOperationsState {
+  private readonly connectedClientIds = new Set<string>();
+  private lastError?: RuntimeWsOperationError;
+
+  constructor(private readonly options: RuntimeWsOperationsStateOptions) {}
+
+  clientConnected(clientId: string): void {
+    this.connectedClientIds.add(clientId);
+  }
+
+  clientDisconnected(clientId: string): void {
+    this.connectedClientIds.delete(clientId);
+  }
+
+  recordSuccess(): void {
+    this.lastError = undefined;
+  }
+
+  recordError(operation: RuntimeWsOperationError["operation"], error: unknown): void {
+    this.lastError = {
+      operation,
+      message: error instanceof Error ? error.message : String(error),
+      occurredAt: new Date().toISOString()
+    };
+  }
+
+  snapshot(): RuntimeWsOperationsSnapshot {
+    return {
+      ok: this.lastError === undefined,
+      replayStoreMode: this.options.replayStoreMode,
+      broadcastBusMode: this.options.broadcastBusMode,
+      instanceId: this.options.instanceId,
+      connectedClients: this.connectedClientIds.size,
+      ...(this.lastError ? { lastError: this.lastError } : {})
+    };
+  }
+}

--- a/packages/bff/src/gateway/ws.gateway.ts
+++ b/packages/bff/src/gateway/ws.gateway.ts
@@ -27,6 +27,7 @@ import {
   type RuntimeWsBroadcastBus,
   type RuntimeWsBroadcastMessage
 } from "./runtime-ws-broadcast.bus";
+import { RuntimeWsOperationsState } from "./runtime-ws-operations.state";
 
 export interface WsClientLike {
   id: string;
@@ -54,6 +55,7 @@ export class RuntimeWsGateway
   implements OnModuleInit, OnModuleDestroy, OnGatewayConnection<WsClientLike>, OnGatewayDisconnect<WsClientLike>
 {
   private readonly logger = new Logger("RuntimeWsGateway");
+  private readonly operationsState: RuntimeWsOperationsState;
 
   constructor(
     @Optional()
@@ -64,8 +66,18 @@ export class RuntimeWsGateway
     private readonly broadcastBus: RuntimeWsBroadcastBus = new InProcessRuntimeWsBroadcastBus(),
     @Optional()
     @Inject(RUNTIME_WS_INSTANCE_ID)
-    private readonly instanceId: string = randomUUID()
-  ) {}
+    private readonly instanceId: string = randomUUID(),
+    @Optional()
+    operationsState?: RuntimeWsOperationsState
+  ) {
+    this.operationsState =
+      operationsState ??
+      new RuntimeWsOperationsState({
+        replayStoreMode: "memory",
+        broadcastBusMode: "local",
+        instanceId: this.instanceId
+      });
+  }
 
   @WebSocketServer()
   server?: WsServerLike;
@@ -79,10 +91,12 @@ export class RuntimeWsGateway
   }
 
   handleConnection(client: WsClientLike): void {
+    this.operationsState.clientConnected(client.id);
     this.logger.log(`client connected: ${client.id}`);
   }
 
   handleDisconnect(client: WsClientLike): void {
+    this.operationsState.clientDisconnected(client.id);
     this.logger.log(`client disconnected: ${client.id}`);
   }
 
@@ -98,7 +112,14 @@ export class RuntimeWsGateway
     };
     this.joinTopic(client, event.topic);
     client.emit("pageSubscribed", event);
-    const replayEvent = await this.replayStore.getLatest(event.topic);
+    let replayEvent: RuntimeManagerExecutedEvent | undefined;
+    try {
+      replayEvent = await this.replayStore.getLatest(event.topic);
+      this.operationsState.recordSuccess();
+    } catch (error) {
+      this.operationsState.recordError("replay", error);
+      throw error;
+    }
     if (replayEvent) {
       this.emitRuntimeManagerExecuted(client, replayEvent);
     }
@@ -111,9 +132,15 @@ export class RuntimeWsGateway
   }
 
   async broadcastRuntimeManagerExecuted(event: RuntimeManagerExecutedEvent): Promise<RuntimeManagerExecutedEvent> {
-    await this.replayStore.saveLatest(event);
-    this.emitRuntimeManagerExecutedToTopic(event);
-    await this.broadcastBus.publish(event, { originId: this.instanceId });
+    try {
+      await this.replayStore.saveLatest(event);
+      this.emitRuntimeManagerExecutedToTopic(event);
+      await this.broadcastBus.publish(event, { originId: this.instanceId });
+      this.operationsState.recordSuccess();
+    } catch (error) {
+      this.operationsState.recordError("broadcast", error);
+      throw error;
+    }
     return event;
   }
 
@@ -121,8 +148,14 @@ export class RuntimeWsGateway
     if (message.originId === this.instanceId) {
       return;
     }
-    await this.replayStore.saveLatest(message.event);
-    this.emitRuntimeManagerExecutedToTopic(message.event);
+    try {
+      await this.replayStore.saveLatest(message.event);
+      this.emitRuntimeManagerExecutedToTopic(message.event);
+      this.operationsState.recordSuccess();
+    } catch (error) {
+      this.operationsState.recordError("broadcast", error);
+      throw error;
+    }
   }
 
   private emitRuntimeManagerExecutedToTopic(event: RuntimeManagerExecutedEvent): void {

--- a/packages/bff/test/ws-gateway.test.ts
+++ b/packages/bff/test/ws-gateway.test.ts
@@ -13,6 +13,8 @@ import {
   type RuntimeWsBroadcastHandler,
   type RuntimeWsBroadcastPublishOptions
 } from "../src/gateway/runtime-ws-broadcast.bus";
+import { RuntimeWsHealthController } from "../src/gateway/runtime-ws-health.controller";
+import { RuntimeWsOperationsState } from "../src/gateway/runtime-ws-operations.state";
 import {
   InMemoryRuntimeWsReplayStore,
   parseRuntimeWsReplayStoreMode,
@@ -64,6 +66,18 @@ class RecordingReplayStore implements RuntimeWsReplayStore {
   }
 }
 
+class FailingReplayStore implements RuntimeWsReplayStore {
+  constructor(private readonly error: Error) {}
+
+  async saveLatest(): Promise<void> {
+    throw this.error;
+  }
+
+  async getLatest(): Promise<RuntimeManagerExecutedEvent | undefined> {
+    throw this.error;
+  }
+}
+
 class RecordingBroadcastBus implements RuntimeWsBroadcastBus {
   readonly published: Array<{ event: RuntimeManagerExecutedEvent; options: RuntimeWsBroadcastPublishOptions }> = [];
   readonly handlers: RuntimeWsBroadcastHandler[] = [];
@@ -80,6 +94,18 @@ class RecordingBroadcastBus implements RuntimeWsBroadcastBus {
   async close(): Promise<void> {
     this.closed = true;
   }
+}
+
+class FailingBroadcastBus implements RuntimeWsBroadcastBus {
+  constructor(private readonly error: Error) {}
+
+  async publish(): Promise<void> {
+    throw this.error;
+  }
+
+  async subscribe(): Promise<void> {}
+
+  async close(): Promise<void> {}
 }
 
 class FakeRedisClient implements RedisRuntimeWsReplayClient, RedisRuntimeWsBroadcastClient {
@@ -187,6 +213,30 @@ test("runtime websocket gateway confirms page subscription", async () => {
   assert.deepEqual(emitted, [{ event: "pageSubscribed", payload: expected }]);
 });
 
+test("runtime websocket operations state tracks connected client count", () => {
+  const operationsState = new RuntimeWsOperationsState({
+    replayStoreMode: "memory",
+    broadcastBusMode: "local",
+    instanceId: "instance-a"
+  });
+  const gateway = new RuntimeWsGateway(
+    new RecordingReplayStore(),
+    new RecordingBroadcastBus(),
+    "instance-a",
+    operationsState
+  );
+  const client: WsClientLike = {
+    id: "client-1",
+    emit(): void {}
+  };
+
+  gateway.handleConnection(client);
+  assert.equal(operationsState.snapshot().connectedClients, 1);
+
+  gateway.handleDisconnect(client);
+  assert.equal(operationsState.snapshot().connectedClients, 0);
+});
+
 test("runtime websocket gateway confirms page subscription when join is unavailable", async () => {
   const gateway = new RuntimeWsGateway();
   const emitted: Array<{ event: string; payload: unknown }> = [];
@@ -241,7 +291,13 @@ test("runtime websocket gateway emits manager executed updates", () => {
 test("runtime websocket gateway broadcasts manager executed updates to topic rooms", async () => {
   const replayStore = new RecordingReplayStore();
   const broadcastBus = new RecordingBroadcastBus();
-  const gateway = new RuntimeWsGateway(replayStore, broadcastBus, "instance-a");
+  const operationsState = new RuntimeWsOperationsState({
+    replayStoreMode: "memory",
+    broadcastBusMode: "local",
+    instanceId: "instance-a"
+  });
+  operationsState.recordError("broadcast", new Error("previous error"));
+  const gateway = new RuntimeWsGateway(replayStore, broadcastBus, "instance-a", operationsState);
   const emitted: Array<{ room: string; event: string; payload: unknown }> = [];
   const server: WsServerLike = {
     to(room: string) {
@@ -258,6 +314,8 @@ test("runtime websocket gateway broadcasts manager executed updates to topic roo
   const result = await gateway.broadcastRuntimeManagerExecuted(update);
 
   assert.deepEqual(result, update);
+  assert.equal(operationsState.snapshot().ok, true);
+  assert.equal(operationsState.snapshot().lastError, undefined);
   assert.deepEqual(replayStore.saved, [update]);
   assert.deepEqual(broadcastBus.published, [{ event: update, options: { originId: "instance-a" } }]);
   assert.deepEqual(emitted, [
@@ -267,6 +325,81 @@ test("runtime websocket gateway broadcasts manager executed updates to topic roo
       payload: update
     }
   ]);
+});
+
+test("runtime websocket gateway records replay errors and preserves fail-fast behavior", async () => {
+  const operationsState = new RuntimeWsOperationsState({
+    replayStoreMode: "memory",
+    broadcastBusMode: "local",
+    instanceId: "instance-a"
+  });
+  const gateway = new RuntimeWsGateway(
+    new FailingReplayStore(new Error("replay unavailable")),
+    new RecordingBroadcastBus(),
+    "instance-a",
+    operationsState
+  );
+  const client: WsClientLike = {
+    id: "client-1",
+    emit(): void {}
+  };
+
+  await assert.rejects(
+    () =>
+      gateway.subscribePage(
+        {
+          tenantId: "tenant-a",
+          pageId: "orders",
+          pageInstanceId: "instance-1"
+        },
+        client
+      ),
+    /replay unavailable/
+  );
+
+  assert.deepEqual(operationsState.snapshot().lastError?.operation, "replay");
+  assert.deepEqual(operationsState.snapshot().lastError?.message, "replay unavailable");
+  assert.equal(operationsState.snapshot().ok, false);
+});
+
+test("runtime websocket gateway records broadcast errors and preserves fail-fast behavior", async () => {
+  const operationsState = new RuntimeWsOperationsState({
+    replayStoreMode: "memory",
+    broadcastBusMode: "local",
+    instanceId: "instance-a"
+  });
+  const gateway = new RuntimeWsGateway(
+    new RecordingReplayStore(),
+    new FailingBroadcastBus(new Error("broadcast unavailable")),
+    "instance-a",
+    operationsState
+  );
+
+  await assert.rejects(() => gateway.broadcastRuntimeManagerExecuted(createUpdate()), /broadcast unavailable/);
+
+  assert.equal(operationsState.snapshot().lastError?.operation, "broadcast");
+  assert.equal(operationsState.snapshot().lastError?.message, "broadcast unavailable");
+  assert.equal(operationsState.snapshot().ok, false);
+});
+
+test("runtime websocket health controller returns stable operations status", () => {
+  const operationsState = new RuntimeWsOperationsState({
+    replayStoreMode: "redis",
+    broadcastBusMode: "redis",
+    instanceId: "instance-health"
+  });
+  const controller = new RuntimeWsHealthController(operationsState);
+
+  operationsState.clientConnected("client-1");
+  const health = controller.health();
+
+  assert.deepEqual(health, {
+    ok: true,
+    replayStoreMode: "redis",
+    broadcastBusMode: "redis",
+    instanceId: "instance-health",
+    connectedClients: 1
+  });
 });
 
 test("runtime websocket gateway emits remote broadcast bus events once", async () => {


### PR DESCRIPTION
## Summary

- Add a lightweight runtime WebSocket operations state for replay store mode, broadcast bus mode, instance id, connected client count, and last replay/broadcast error.
- Wire RuntimeWsGateway lifecycle, replay, local broadcast, and remote bus delivery paths into the operations state while preserving existing fail-fast behavior.
- Add a stable read-only `/health/runtime-ws` status endpoint for runtime WS smoke checks.

Refs #21
Refs #17

## Validation

- `pnpm --filter @zhongmiao/meta-lc-bff test`
- `pnpm lint:boundaries`
- `pnpm lint`
- `pnpm -r test`
- `pnpm changelog:gate origin/main HEAD`
- `pnpm install --frozen-lockfile`
- `git diff --check`
