### PR TITLE
docs: 补齐平台子包双语说明

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- docs(readme): add bilingual package README index and architecture diagrams.
 - feat(release): add aggregate package `@zhongmiao/meta-lc-platform` and reserve `@zhongmiao/meta-lc-*` naming for workspace packages.
 - feat(ci): add changelog gate, release draft sync, and manual changelog finalize workflow for platform release governance.
 - docs(changelog): establish bilingual root/package changelog baselines for the platform workspace.

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- docs(readme): 新增双语子包 README 索引与架构流程图。
 - feat(release): 新增聚合总包 `@zhongmiao/meta-lc-platform`，并为工作区包统一预留 `@zhongmiao/meta-lc-*` 命名。
 - feat(ci): 新增 changelog gate、release draft 同步与手动 changelog finalize 工作流，补齐平台发版治理基础。
 - docs(changelog): 为平台工作区建立根级与包级双语 changelog 基线。

--- a/README.md
+++ b/README.md
@@ -2,21 +2,63 @@
 
 Core monorepo for Meta-Driven lowcode middleware.
 
-This workspace combines reusable platform libraries under `packages/*` with a runnable middleware service entry under `apps/bff-server`.
+This workspace combines reusable platform libraries under `packages/*` with a runnable NestJS middleware entry under `apps/bff-server`. The package docs describe the current code boundaries only; they do not imply that unfinished product APIs are already available.
 
-## Structure
+English | [中文文档](./README_zh.md)
 
-- `packages/platform`: aggregate package entry for `@zhongmiao/meta-lc-platform`
-- `packages/kernel`: snapshot + migration DSL source of truth
-- `packages/query`: query DSL to SQL compilation
-- `packages/permission`: tenant/role permission injection
-- `packages/datasource`: DB execution adapters
-- `packages/migration`: migration DSL -> SQL compile/apply
-- `packages/audit`: query/mutation/migration/access audit APIs
-- `packages/contracts`: cross-package DTO/types
-- `packages/shared`: shared helpers
-- `packages/bff`: middleware orchestration module
-- `apps/bff-server`: NestJS runtime entry
+## Architecture
+
+The platform keeps the frontend and runtime behind the BFF. Metadata flows through the Meta Kernel and `meta_db`; business data flows through query, permission, and datasource execution against `business_db`; audit records belong to `audit_db`.
+
+```mermaid
+flowchart LR
+  Client["Runtime / Client"] --> BFF["packages/bff<br/>NestJS orchestration"]
+  BFF --> Kernel["packages/kernel<br/>MetaSchema, versions, diff, migration plan"]
+  BFF --> Query["packages/query<br/>Query DSL -> SQL"]
+  BFF --> Permission["packages/permission<br/>RBAC + data scope"]
+  BFF --> Datasource["packages/datasource<br/>Postgres adapter"]
+  BFF --> Audit["packages/audit<br/>Audit sink contract"]
+  BFF --> Runtime["packages/runtime<br/>DSL orchestration contracts"]
+  Kernel --> MetaDb[("meta_db")]
+  Query --> Datasource
+  Permission --> Query
+  Datasource --> BusinessDb[("business_db")]
+  Audit --> AuditDb[("audit_db")]
+  Contracts["packages/contracts<br/>shared API DTOs"] --> BFF
+  Contracts --> Audit
+  Contracts --> Runtime
+  Shared["packages/shared<br/>SQL helpers"] --> BFF
+```
+
+## Package Index
+
+| Package | Role | Docs |
+| --- | --- | --- |
+| `packages/contracts` | Cross-package DTOs, API contracts, and runtime event contracts. | [English](./packages/contracts/README.md) \| [中文文档](./packages/contracts/README_zh.md) |
+| `packages/shared` | Shared SQL quoting and parameter formatting helpers. | [English](./packages/shared/README.md) \| [中文文档](./packages/shared/README_zh.md) |
+| `packages/kernel` | MetaSchema validation, versioning, diff, migration SQL, API and permission manifest compilation. | [English](./packages/kernel/README.md) \| [中文文档](./packages/kernel/README_zh.md) |
+| `packages/query` | Query DSL to SQL compilation. | [English](./packages/query/README.md) \| [中文文档](./packages/query/README_zh.md) |
+| `packages/permission` | RBAC and organization data-scope decisions. | [English](./packages/permission/README.md) \| [中文文档](./packages/permission/README_zh.md) |
+| `packages/datasource` | Postgres datasource configuration and execution adapter. | [English](./packages/datasource/README.md) \| [中文文档](./packages/datasource/README_zh.md) |
+| `packages/migration` | Facade for compiling and applying kernel migration DSL. | [English](./packages/migration/README.md) \| [中文文档](./packages/migration/README_zh.md) |
+| `packages/audit` | Query, mutation, migration, and access audit service contract. | [English](./packages/audit/README.md) \| [中文文档](./packages/audit/README_zh.md) |
+| `packages/runtime` | Runtime DSL parser, dependency graph, rule/function/orchestrator, and WS event contracts. | [English](./packages/runtime/README.md) \| [中文文档](./packages/runtime/README_zh.md) |
+| `packages/bff` | NestJS BFF orchestration for query, mutation, meta, cache, audit, and websocket flows. | [English](./packages/bff/README.md) \| [中文文档](./packages/bff/README_zh.md) |
+| `packages/platform` | Aggregate package entry for library consumers. It is not the runnable BFF. | [English](./packages/platform/README.md) \| [中文文档](./packages/platform/README_zh.md) |
+
+## Dependency Direction
+
+- `contracts` and `shared` are foundation packages.
+- `kernel`, `query`, `permission`, `runtime`, `datasource`, `migration`, and `audit` expose focused platform capabilities.
+- `bff` composes platform capabilities into HTTP, WebSocket, query, mutation, meta, cache, and audit flows.
+- `platform` is an aggregate library identity for consumers and does not package `apps/bff-server`.
+- Deep cross-package imports are forbidden; import through package entrypoints.
+
+## Runtime Entries
+
+- `packages/bff`: library form of the NestJS BFF module.
+- `apps/bff-server`: runnable middleware process entry.
+- `packages/platform`: aggregate package entry for `@zhongmiao/meta-lc-platform`.
 
 ## Commands
 
@@ -30,15 +72,16 @@ pnpm infra:up
 pnpm infra:query-gate
 ```
 
-## Architectural constraints
+## Architectural Constraints
 
-- No deep cross-package imports (entrypoint imports only).
-- DB driver access is restricted and being converged to datasource package.
-- Kernel cannot depend on bff/query/datasource implementations.
-- Frontend must use middleware (`lowcode -> middleware -> backend`).
+- Frontend and runtime consumers must go through the BFF for data access and realtime updates.
+- `meta_db`, `business_db`, and `audit_db` stay separated.
+- Kernel remains the structural source for metadata and migration planning.
+- BFF applies orchestration and integration logic; runtime packages must not embed business-specific rules.
+- DB driver access is intentionally restricted by boundary checks.
 
 ## Release Governance
 
 - Publishable library identities use the `@zhongmiao/meta-lc-*` scope.
-- `@zhongmiao/meta-lc-platform` is the aggregate library entry and does not package the runnable BFF program.
-- Root changelogs record platform/runtime/service changes; package changelogs record package-local API and behavior changes.
+- Root changelogs record platform, runtime, and service-level changes.
+- Package changelogs record package-local API and behavior changes.

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,0 +1,87 @@
+# meta-lc-platform
+
+`meta-lc-platform` 是 Meta-Driven lowcode middleware 的核心 monorepo。
+
+本仓库把 `packages/*` 下的可复用平台库和 `apps/bff-server` 下的可运行 NestJS middleware 入口放在同一个工作区中。本文档只描述当前代码边界，不表示尚未实现的产品接口已经可用。
+
+[English](./README.md) | 中文文档
+
+## 总体架构
+
+平台约束是所有前端与 runtime 数据访问必须经过 BFF。元数据通过 Meta Kernel 进入 `meta_db`；业务查询与变更通过 query、permission、datasource 访问 `business_db`；审计记录进入 `audit_db`。
+
+```mermaid
+flowchart LR
+  Client["Runtime / Client"] --> BFF["packages/bff<br/>NestJS 编排层"]
+  BFF --> Kernel["packages/kernel<br/>MetaSchema、版本、diff、迁移计划"]
+  BFF --> Query["packages/query<br/>Query DSL -> SQL"]
+  BFF --> Permission["packages/permission<br/>RBAC + 数据域"]
+  BFF --> Datasource["packages/datasource<br/>Postgres adapter"]
+  BFF --> Audit["packages/audit<br/>审计 sink contract"]
+  BFF --> Runtime["packages/runtime<br/>DSL 编排 contract"]
+  Kernel --> MetaDb[("meta_db")]
+  Query --> Datasource
+  Permission --> Query
+  Datasource --> BusinessDb[("business_db")]
+  Audit --> AuditDb[("audit_db")]
+  Contracts["packages/contracts<br/>共享 API DTO"] --> BFF
+  Contracts --> Audit
+  Contracts --> Runtime
+  Shared["packages/shared<br/>SQL 工具"] --> BFF
+```
+
+## 子包索引
+
+| Package | 定位 | 文档 |
+| --- | --- | --- |
+| `packages/contracts` | 跨包 DTO、API contract、runtime event contract。 | [English](./packages/contracts/README.md) \| [中文文档](./packages/contracts/README_zh.md) |
+| `packages/shared` | SQL quoting 与参数格式化共享工具。 | [English](./packages/shared/README.md) \| [中文文档](./packages/shared/README_zh.md) |
+| `packages/kernel` | MetaSchema 校验、版本、diff、migration SQL、API/permission manifest 编译。 | [English](./packages/kernel/README.md) \| [中文文档](./packages/kernel/README_zh.md) |
+| `packages/query` | Query DSL 到 SQL 编译。 | [English](./packages/query/README.md) \| [中文文档](./packages/query/README_zh.md) |
+| `packages/permission` | RBAC 与组织数据域决策。 | [English](./packages/permission/README.md) \| [中文文档](./packages/permission/README_zh.md) |
+| `packages/datasource` | Postgres datasource 配置与执行 adapter。 | [English](./packages/datasource/README.md) \| [中文文档](./packages/datasource/README_zh.md) |
+| `packages/migration` | kernel migration DSL 的 compile/apply facade。 | [English](./packages/migration/README.md) \| [中文文档](./packages/migration/README_zh.md) |
+| `packages/audit` | query、mutation、migration、access 审计服务 contract。 | [English](./packages/audit/README.md) \| [中文文档](./packages/audit/README_zh.md) |
+| `packages/runtime` | Runtime DSL parser、dependency graph、rule/function/orchestrator、WS event contract。 | [English](./packages/runtime/README.md) \| [中文文档](./packages/runtime/README_zh.md) |
+| `packages/bff` | NestJS BFF 编排层，串联 query、mutation、meta、cache、audit、websocket。 | [English](./packages/bff/README.md) \| [中文文档](./packages/bff/README_zh.md) |
+| `packages/platform` | 面向库消费者的聚合入口，不是可运行 BFF。 | [English](./packages/platform/README.md) \| [中文文档](./packages/platform/README_zh.md) |
+
+## 依赖方向
+
+- `contracts` 和 `shared` 是底座包。
+- `kernel`、`query`、`permission`、`runtime`、`datasource`、`migration`、`audit` 提供聚焦的平台能力。
+- `bff` 把这些能力编排为 HTTP、WebSocket、query、mutation、meta、cache、audit 流程。
+- `platform` 是面向消费者的聚合包身份，不打包 `apps/bff-server`。
+- 禁止 deep import，跨包引用必须通过 package entrypoint。
+
+## 运行入口
+
+- `packages/bff`：NestJS BFF module 的库形态。
+- `apps/bff-server`：middleware 进程入口。
+- `packages/platform`：`@zhongmiao/meta-lc-platform` 聚合包入口。
+
+## 常用命令
+
+```bash
+pnpm install
+pnpm -r build
+pnpm -r test
+pnpm lint
+pnpm --filter @zhongmiao/meta-lc-bff-server start
+pnpm infra:up
+pnpm infra:query-gate
+```
+
+## 架构约束
+
+- 前端和 runtime consumer 的数据访问与实时推送必须经过 BFF。
+- `meta_db`、`business_db`、`audit_db` 保持三库分离。
+- Kernel 是元数据结构与迁移计划的来源。
+- BFF 承担编排与集成逻辑；runtime 包不内嵌业务专用规则。
+- DB driver access 受 boundary check 限制。
+
+## 发版治理
+
+- 可发布库身份使用 `@zhongmiao/meta-lc-*` scope。
+- 根 changelog 记录平台、runtime、service 级变化。
+- 子包 changelog 记录包内 API 与行为变化。

--- a/packages/audit/CHANGELOG.md
+++ b/packages/audit/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- docs(readme): add bilingual package README and minimal architecture flow.
 - chore(package): adopt the `@zhongmiao/meta-lc-audit` scoped package identity for release governance.
 - refactor(boundary): narrow the package back to audit contracts and compatibility helpers so audit DB execution stays inside the BFF boundary.
 

--- a/packages/audit/CHANGELOG.zh-CN.md
+++ b/packages/audit/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- docs(readme): 新增双语子包 README 与最小架构流程图。
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-audit` 正式包名。
 - refactor(boundary): 将本包收回为审计契约与兼容辅助层，避免审计数据库执行职责继续外溢到 BFF 边界之外。
 

--- a/packages/audit/README.md
+++ b/packages/audit/README.md
@@ -1,0 +1,42 @@
+# @zhongmiao/meta-lc-audit
+
+English | [中文文档](./README_zh.md)
+
+## Package Role
+
+`audit` defines audit log shapes and a pluggable audit service/sink contract for query, mutation, migration, and access events.
+
+## Responsibilities
+
+- Define audit log interfaces for mutation, migration, and access events.
+- Reuse `QueryAuditLog` from `contracts`.
+- Provide `AuditService` with an injectable sink.
+- Default to a no-op sink when no persistence implementation is supplied.
+
+## Relationship With Other Packages
+
+- Depends on `contracts` for query audit log shape.
+- BFF can call audit service or equivalent integration after query/mutation outcomes.
+- Migration orchestration can report migration audit records through this contract.
+- Persistence details belong to the sink implementation or BFF integration layer.
+
+## Minimal Flow
+
+```mermaid
+flowchart LR
+  Event["query / mutation / migration / access outcome"] --> Service["AuditService"]
+  Service --> Sink["AuditSink"]
+  Sink --> AuditDb[("audit_db or external sink")]
+```
+
+## Commands
+
+```bash
+pnpm --filter @zhongmiao/meta-lc-audit build
+pnpm --filter @zhongmiao/meta-lc-audit test
+```
+
+## Boundary Notes
+
+- Keep audit persistence pluggable through `AuditSink`.
+- Do not couple this package to NestJS controllers or concrete BFF request handling.

--- a/packages/audit/README_zh.md
+++ b/packages/audit/README_zh.md
@@ -1,0 +1,42 @@
+# @zhongmiao/meta-lc-audit
+
+[English](./README.md) | 中文文档
+
+## 包定位
+
+`audit` 定义 query、mutation、migration、access 事件的 audit log 形状，以及可插拔的 audit service/sink contract。
+
+## 核心职责
+
+- 定义 mutation、migration、access audit log interface。
+- 复用 `contracts` 中的 `QueryAuditLog`。
+- 提供可注入 sink 的 `AuditService`。
+- 未提供 persistence implementation 时默认使用 no-op sink。
+
+## 与其他包关系
+
+- 依赖 `contracts` 获取 query audit log 形状。
+- BFF 可在 query/mutation 结果后调用 audit service 或等价 integration。
+- Migration orchestration 可通过此 contract 上报 migration audit record。
+- 持久化细节属于 sink implementation 或 BFF integration layer。
+
+## 最小闭环
+
+```mermaid
+flowchart LR
+  Event["query / mutation / migration / access outcome"] --> Service["AuditService"]
+  Service --> Sink["AuditSink"]
+  Sink --> AuditDb[("audit_db or external sink")]
+```
+
+## 常用命令
+
+```bash
+pnpm --filter @zhongmiao/meta-lc-audit build
+pnpm --filter @zhongmiao/meta-lc-audit test
+```
+
+## 边界约束
+
+- 通过 `AuditSink` 保持 audit persistence 可插拔。
+- 不把本包耦合到 NestJS controller 或具体 BFF request handling。

--- a/packages/bff/CHANGELOG.md
+++ b/packages/bff/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- docs(readme): add bilingual package README and minimal architecture flow.
 - feat(gateway): add meta API, in-memory cache, aggregation summary, and WebSocket lifecycle baseline.
 - feat(api-contracts): annotate query and mutation controller responses with shared API response contracts.
 - chore(gateway): reuse the shared runtime page topic helper for WebSocket subscription acknowledgements.

--- a/packages/bff/CHANGELOG.zh-CN.md
+++ b/packages/bff/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- docs(readme): 新增双语子包 README 与最小架构流程图。
 - feat(gateway): 新增 meta API、内存 cache、aggregation summary 与 WebSocket lifecycle 基线。
 - feat(api-contracts): 为 query 与 mutation controller 响应标注共享 API response contract。
 - chore(gateway): WebSocket subscription acknowledgement 复用共享 runtime page topic helper。

--- a/packages/bff/README.md
+++ b/packages/bff/README.md
@@ -1,0 +1,50 @@
+# @zhongmiao/meta-lc-bff
+
+English | [中文文档](./README_zh.md)
+
+## Package Role
+
+`bff` is the NestJS middleware orchestration package. It exposes the BFF module, query/mutation controllers, meta gateway, cache, audit integration, Postgres execution integration, organization-scope integration, and runtime websocket gateway.
+
+## Responsibilities
+
+- Accept HTTP query, mutation, health, and meta requests.
+- Orchestrate query compilation, permission decisions, datasource execution, audit logging, caching, and response shaping.
+- Coordinate mutation execution and audit outcomes.
+- Serve runtime websocket events and replay/health support.
+- Bootstrap meta, business, and audit database baselines for dev/test environments when configured.
+
+## Relationship With Other Packages
+
+- Uses `contracts` for API request/response shapes.
+- Uses `query` and `permission` for server-side query and access decisions.
+- Uses shared helpers and direct Postgres integration at approved BFF edge files.
+- Should compose `kernel` for metadata versioning and migration orchestration as meta APIs mature.
+- `apps/bff-server` is the runnable process entry built from this package.
+
+## Minimal Flow
+
+```mermaid
+flowchart LR
+  Http["HTTP / WS request"] --> Controller["BFF controller / gateway"]
+  Controller --> Orchestrator["query / mutation / ws orchestrator"]
+  Orchestrator --> Permission["permission decision"]
+  Orchestrator --> Query["query compiler"]
+  Query --> Db["Postgres execution"]
+  Orchestrator --> Audit["audit log"]
+  Orchestrator --> Response["HTTP response / WS event"]
+```
+
+## Commands
+
+```bash
+pnpm --filter @zhongmiao/meta-lc-bff build
+pnpm --filter @zhongmiao/meta-lc-bff test
+pnpm --filter @zhongmiao/meta-lc-bff start
+```
+
+## Boundary Notes
+
+- BFF is the integration boundary for frontend and runtime data access.
+- Keep direct DB driver use inside approved edge files and boundary checks.
+- Do not move runtime UI or package-level kernel source-of-truth logic into BFF.

--- a/packages/bff/README_zh.md
+++ b/packages/bff/README_zh.md
@@ -1,0 +1,50 @@
+# @zhongmiao/meta-lc-bff
+
+[English](./README.md) | 中文文档
+
+## 包定位
+
+`bff` 是 NestJS middleware 编排包。它暴露 BFF module、query/mutation controller、meta gateway、cache、audit integration、Postgres execution integration、organization-scope integration 与 runtime websocket gateway。
+
+## 核心职责
+
+- 接收 HTTP query、mutation、health、meta request。
+- 编排 query compilation、permission decision、datasource execution、audit logging、cache 与 response shaping。
+- 协调 mutation execution 与 audit outcome。
+- 提供 runtime websocket event、replay 与 health 支持。
+- 在配置允许时为 dev/test 环境 bootstrap meta、business、audit database baseline。
+
+## 与其他包关系
+
+- 使用 `contracts` 作为 API request/response 形状。
+- 使用 `query` 与 `permission` 完成服务端 query 与 access decision。
+- 在受允许的 BFF edge files 中使用 shared helper 与直接 Postgres integration。
+- 随着 meta API 成熟，应编排接入 `kernel` 完成 metadata versioning 与 migration orchestration。
+- `apps/bff-server` 是基于本包构建的可运行进程入口。
+
+## 最小闭环
+
+```mermaid
+flowchart LR
+  Http["HTTP / WS request"] --> Controller["BFF controller / gateway"]
+  Controller --> Orchestrator["query / mutation / ws orchestrator"]
+  Orchestrator --> Permission["permission decision"]
+  Orchestrator --> Query["query compiler"]
+  Query --> Db["Postgres execution"]
+  Orchestrator --> Audit["audit log"]
+  Orchestrator --> Response["HTTP response / WS event"]
+```
+
+## 常用命令
+
+```bash
+pnpm --filter @zhongmiao/meta-lc-bff build
+pnpm --filter @zhongmiao/meta-lc-bff test
+pnpm --filter @zhongmiao/meta-lc-bff start
+```
+
+## 边界约束
+
+- BFF 是 frontend 与 runtime 数据访问的 integration boundary。
+- direct DB driver use 必须保留在允许的 edge files 内，并通过 boundary check。
+- 不把 runtime UI 或 kernel 的结构真源逻辑搬进 BFF。

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- docs(readme): add bilingual package README and minimal architecture flow.
 - chore(package): adopt the `@zhongmiao/meta-lc-contracts` scoped package identity for release governance.
 - feat(runtime-contracts): add refresh planning event and target contracts for dependency graph execution.
 - feat(runtime-contracts): add rule and function contracts for event-driven runtime evaluation.

--- a/packages/contracts/CHANGELOG.zh-CN.md
+++ b/packages/contracts/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- docs(readme): 新增双语子包 README 与最小架构流程图。
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-contracts` 正式包名。
 - feat(runtime-contracts): 补充依赖图执行所需的刷新事件与目标契约类型。
 - feat(runtime-contracts): 补充事件驱动规则求值所需的规则与函数契约类型。

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -1,0 +1,41 @@
+# @zhongmiao/meta-lc-contracts
+
+English | [中文文档](./README_zh.md)
+
+## Package Role
+
+`contracts` defines cross-package DTOs and protocol contracts for query, mutation, permission scope, audit, runtime page topics, runtime events, nodes, datasources, actions, and rules.
+
+## Responsibilities
+
+- Keep request and response shapes shared by BFF, audit, runtime, and consumers.
+- Provide stable helper constructors for runtime manager executed events.
+- Avoid runtime dependencies so contracts can remain a low-level package.
+
+## Relationship With Other Packages
+
+- Used by `bff` for HTTP request and response contracts.
+- Used by `audit` for `QueryAuditLog`.
+- Used by `runtime` for runtime event and DSL-facing shapes.
+- Referenced by `platform` as part of the aggregate package identity.
+
+## Minimal Flow
+
+```mermaid
+flowchart LR
+  Request["QueryApiRequest / MutationApiRequest"] --> BFF["packages/bff"]
+  RuntimeEvent["Runtime event contracts"] --> Runtime["packages/runtime"]
+  QueryAudit["QueryAuditLog"] --> Audit["packages/audit"]
+```
+
+## Commands
+
+```bash
+pnpm --filter @zhongmiao/meta-lc-contracts build
+pnpm --filter @zhongmiao/meta-lc-contracts test
+```
+
+## Boundary Notes
+
+- Do not add service, database, or framework logic here.
+- Keep exported types broad enough for package boundaries but specific enough for contract tests.

--- a/packages/contracts/README_zh.md
+++ b/packages/contracts/README_zh.md
@@ -1,0 +1,41 @@
+# @zhongmiao/meta-lc-contracts
+
+[English](./README.md) | 中文文档
+
+## 包定位
+
+`contracts` 定义跨包 DTO 与协议 contract，包括 query、mutation、permission scope、audit、runtime page topic、runtime event、node、datasource、action、rule 等形状。
+
+## 核心职责
+
+- 统一 BFF、audit、runtime 与消费方共享的 request/response 结构。
+- 提供 runtime manager executed event 的稳定构造函数。
+- 避免运行时依赖，让 contracts 保持底层包属性。
+
+## 与其他包关系
+
+- `bff` 使用它作为 HTTP request/response contract。
+- `audit` 使用其中的 `QueryAuditLog`。
+- `runtime` 使用 runtime event 与 DSL 相关类型。
+- `platform` 把它纳入聚合包身份。
+
+## 最小闭环
+
+```mermaid
+flowchart LR
+  Request["QueryApiRequest / MutationApiRequest"] --> BFF["packages/bff"]
+  RuntimeEvent["Runtime event contracts"] --> Runtime["packages/runtime"]
+  QueryAudit["QueryAuditLog"] --> Audit["packages/audit"]
+```
+
+## 常用命令
+
+```bash
+pnpm --filter @zhongmiao/meta-lc-contracts build
+pnpm --filter @zhongmiao/meta-lc-contracts test
+```
+
+## 边界约束
+
+- 不在这里加入 service、database 或 framework 逻辑。
+- 导出的类型需要服务包边界，同时由 contract tests 约束。

--- a/packages/datasource/CHANGELOG.md
+++ b/packages/datasource/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- docs(readme): add bilingual package README and minimal architecture flow.
 - chore(package): adopt the `@zhongmiao/meta-lc-datasource` scoped package identity for release governance.
 
 ## 0.1.0 (2026-04-18)

--- a/packages/datasource/CHANGELOG.zh-CN.md
+++ b/packages/datasource/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- docs(readme): 新增双语子包 README 与最小架构流程图。
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-datasource` 正式包名。
 
 ## 0.1.0 (2026-04-18)

--- a/packages/datasource/README.md
+++ b/packages/datasource/README.md
@@ -1,0 +1,42 @@
+# @zhongmiao/meta-lc-datasource
+
+English | [中文文档](./README_zh.md)
+
+## Package Role
+
+`datasource` owns database adapter concerns. The current implementation focuses on Postgres configuration and a Postgres datasource adapter.
+
+## Responsibilities
+
+- Define datasource and DB configuration types.
+- Create Postgres clients from environment-backed configuration.
+- Execute SQL through the adapter boundary.
+
+## Relationship With Other Packages
+
+- `bff` uses datasource-style execution for query and mutation integration.
+- `query` produces SQL that a datasource adapter can execute.
+- `permission` affects the constraints included before execution.
+- `kernel` remains separate; metadata versioning is not owned by this package.
+
+## Minimal Flow
+
+```mermaid
+flowchart LR
+  Config["DbConfig"] --> Adapter["PostgresDatasourceAdapter"]
+  Sql["SQL + params"] --> Adapter
+  Adapter --> BusinessDb[("business_db")]
+  BusinessDb --> Rows["rows / rowCount"]
+```
+
+## Commands
+
+```bash
+pnpm --filter @zhongmiao/meta-lc-datasource build
+pnpm --filter @zhongmiao/meta-lc-datasource test
+```
+
+## Boundary Notes
+
+- Keep adapter code focused on database execution and lifecycle.
+- Do not add HTTP controller or runtime orchestration here.

--- a/packages/datasource/README_zh.md
+++ b/packages/datasource/README_zh.md
@@ -1,0 +1,42 @@
+# @zhongmiao/meta-lc-datasource
+
+[English](./README.md) | 中文文档
+
+## 包定位
+
+`datasource` 承担数据库 adapter 边界。当前实现聚焦 Postgres 配置与 Postgres datasource adapter。
+
+## 核心职责
+
+- 定义 datasource 与 DB configuration 类型。
+- 基于环境配置创建 Postgres client。
+- 通过 adapter 边界执行 SQL。
+
+## 与其他包关系
+
+- `bff` 在 query 与 mutation integration 中使用 datasource 风格的执行能力。
+- `query` 生成 datasource adapter 可执行的 SQL。
+- `permission` 影响执行前加入的约束。
+- `kernel` 保持独立；metadata versioning 不属于本包职责。
+
+## 最小闭环
+
+```mermaid
+flowchart LR
+  Config["DbConfig"] --> Adapter["PostgresDatasourceAdapter"]
+  Sql["SQL + params"] --> Adapter
+  Adapter --> BusinessDb[("business_db")]
+  BusinessDb --> Rows["rows / rowCount"]
+```
+
+## 常用命令
+
+```bash
+pnpm --filter @zhongmiao/meta-lc-datasource build
+pnpm --filter @zhongmiao/meta-lc-datasource test
+```
+
+## 边界约束
+
+- adapter 代码只关注数据库执行与生命周期。
+- 不在这里加入 HTTP controller 或 runtime orchestration。

--- a/packages/kernel/CHANGELOG.md
+++ b/packages/kernel/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- docs(readme): add bilingual package README and minimal architecture flow.
 - chore(package): adopt the `@zhongmiao/meta-lc-kernel` scoped package identity for release governance.
 - feat(sql-generator): add table, index, relation SQL generation and a compiler fixture baseline.
 - test(compiler): add a reusable compiler contract fixture for SQL generator output.

--- a/packages/kernel/CHANGELOG.zh-CN.md
+++ b/packages/kernel/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- docs(readme): 新增双语子包 README 与最小架构流程图。
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-kernel` 正式包名。
 - feat(sql-generator): 新增 table、index、relation SQL 生成能力与 compiler fixture 基线。
 - test(compiler): 新增可复用 compiler contract fixture，固化 SQL generator 输出。

--- a/packages/kernel/README.md
+++ b/packages/kernel/README.md
@@ -1,0 +1,46 @@
+# @zhongmiao/meta-lc-kernel
+
+English | [中文文档](./README_zh.md)
+
+## Package Role
+
+`kernel` is the structural metadata source for the platform. It owns MetaSchema types, schema validation, snapshot and migration DSL helpers, schema diff, SQL generation, API route manifest generation, permission manifest generation, version publishing, rollback, and migration audit persistence.
+
+## Responsibilities
+
+- Define table, field, relation, index, tenant, app, rule, and permission schema types.
+- Validate schemas before they are published.
+- Persist and retrieve versioned schemas through the Postgres repository.
+- Generate schema SQL, migration SQL, API route manifests, and permission manifests.
+- Guard destructive migration statements and record migration audits.
+
+## Relationship With Other Packages
+
+- `migration` reuses kernel migration compile and safety helpers.
+- `bff` should compose kernel services for meta APIs and migration orchestration.
+- `query`, `permission`, and `datasource` must not become kernel dependencies.
+- `platform` may expose kernel-facing capabilities through package composition later, but the runnable BFF remains separate.
+
+## Minimal Flow
+
+```mermaid
+flowchart LR
+  Schema["MetaSchema"] --> Validate["validateSchema"]
+  Validate --> Publish["publishSchema"]
+  Publish --> Version["meta_kernel_versions"]
+  Version --> Diff["diff / buildMigrationPlan"]
+  Diff --> Sql["migration SQL + safety report"]
+```
+
+## Commands
+
+```bash
+pnpm --filter @zhongmiao/meta-lc-kernel build
+pnpm --filter @zhongmiao/meta-lc-kernel test
+```
+
+## Boundary Notes
+
+- Kernel is the metadata source of truth and must stay independent from BFF orchestration.
+- DB access here is limited to meta-kernel persistence and migration audit responsibilities.
+- Do not add HTTP, NestJS controller, runtime UI, or business execution logic here.

--- a/packages/kernel/README_zh.md
+++ b/packages/kernel/README_zh.md
@@ -1,0 +1,46 @@
+# @zhongmiao/meta-lc-kernel
+
+[English](./README.md) | 中文文档
+
+## 包定位
+
+`kernel` 是平台结构元数据来源。它负责 MetaSchema 类型、schema 校验、snapshot/migration DSL helper、schema diff、SQL 生成、API route manifest 生成、permission manifest 生成、版本发布、回滚与 migration audit 持久化。
+
+## 核心职责
+
+- 定义 table、field、relation、index、tenant、app、rule、permission schema 类型。
+- 在发布前校验 schema。
+- 通过 Postgres repository 持久化和读取版本化 schema。
+- 生成 schema SQL、migration SQL、API route manifest 与 permission manifest。
+- 拦截破坏性 migration statement，并记录 migration audit。
+
+## 与其他包关系
+
+- `migration` 复用 kernel 的 migration compile 与 safety helper。
+- `bff` 应通过编排接入 kernel service，承载 meta API 与 migration orchestration。
+- `query`、`permission`、`datasource` 不能成为 kernel 依赖。
+- `platform` 后续可聚合 kernel 能力，但可运行 BFF 仍保持独立。
+
+## 最小闭环
+
+```mermaid
+flowchart LR
+  Schema["MetaSchema"] --> Validate["validateSchema"]
+  Validate --> Publish["publishSchema"]
+  Publish --> Version["meta_kernel_versions"]
+  Version --> Diff["diff / buildMigrationPlan"]
+  Diff --> Sql["migration SQL + safety report"]
+```
+
+## 常用命令
+
+```bash
+pnpm --filter @zhongmiao/meta-lc-kernel build
+pnpm --filter @zhongmiao/meta-lc-kernel test
+```
+
+## 边界约束
+
+- Kernel 是元数据结构真源，必须独立于 BFF 编排。
+- 这里的 DB access 仅服务 meta-kernel persistence 与 migration audit。
+- 不在这里加入 HTTP、NestJS controller、runtime UI 或业务执行逻辑。

--- a/packages/migration/CHANGELOG.md
+++ b/packages/migration/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- docs(readme): add bilingual package README and minimal architecture flow.
 - chore(package): adopt the `@zhongmiao/meta-lc-migration` scoped package identity for release governance.
 
 ## 0.1.0 (2026-04-18)

--- a/packages/migration/CHANGELOG.zh-CN.md
+++ b/packages/migration/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- docs(readme): 新增双语子包 README 与最小架构流程图。
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-migration` 正式包名。
 
 ## 0.1.0 (2026-04-18)

--- a/packages/migration/README.md
+++ b/packages/migration/README.md
@@ -1,0 +1,42 @@
+# @zhongmiao/meta-lc-migration
+
+English | [中文文档](./README_zh.md)
+
+## Package Role
+
+`migration` is a thin facade over kernel migration DSL compilation and migration safety checks. It provides compile and apply helpers without owning schema version storage.
+
+## Responsibilities
+
+- Compile `MigrationDslV1` into SQL bundles by delegating to kernel.
+- Apply SQL statements through an injected executor.
+- Enforce destructive statement checks before execution.
+- Tag migration targets as `meta`, `business`, or `audit`.
+
+## Relationship With Other Packages
+
+- Depends on `kernel` for migration DSL types, SQL compilation, and safety checks.
+- BFF or infrastructure code supplies the actual SQL executor.
+- Does not own Postgres connection setup; execution remains injected.
+
+## Minimal Flow
+
+```mermaid
+flowchart LR
+  Dsl["MigrationDslV1"] --> Compile["compileToSql"]
+  Compile --> Sql["up/down SQL"]
+  Sql --> Safety["assertMigrationSafety"]
+  Safety --> Apply["apply with injected executor"]
+```
+
+## Commands
+
+```bash
+pnpm --filter @zhongmiao/meta-lc-migration build
+pnpm --filter @zhongmiao/meta-lc-migration test
+```
+
+## Boundary Notes
+
+- Keep this package as orchestration glue, not a metadata repository.
+- Do not bypass safety checks when applying statements.

--- a/packages/migration/README_zh.md
+++ b/packages/migration/README_zh.md
@@ -1,0 +1,42 @@
+# @zhongmiao/meta-lc-migration
+
+[English](./README.md) | 中文文档
+
+## 包定位
+
+`migration` 是 kernel migration DSL 编译与 migration safety check 的轻量 facade。它提供 compile/apply helper，但不拥有 schema version storage。
+
+## 核心职责
+
+- 委托 kernel 将 `MigrationDslV1` 编译成 SQL bundle。
+- 通过注入的 executor 执行 SQL statement。
+- 在执行前强制 destructive statement check。
+- 将 migration target 标记为 `meta`、`business` 或 `audit`。
+
+## 与其他包关系
+
+- 依赖 `kernel` 获取 migration DSL 类型、SQL 编译与 safety check。
+- BFF 或 infrastructure code 提供实际 SQL executor。
+- 不负责 Postgres connection setup；执行能力保持注入。
+
+## 最小闭环
+
+```mermaid
+flowchart LR
+  Dsl["MigrationDslV1"] --> Compile["compileToSql"]
+  Compile --> Sql["up/down SQL"]
+  Sql --> Safety["assertMigrationSafety"]
+  Safety --> Apply["apply with injected executor"]
+```
+
+## 常用命令
+
+```bash
+pnpm --filter @zhongmiao/meta-lc-migration build
+pnpm --filter @zhongmiao/meta-lc-migration test
+```
+
+## 边界约束
+
+- 本包保持编排胶水定位，不成为 metadata repository。
+- apply statements 时不能绕过 safety checks。

--- a/packages/permission/CHANGELOG.md
+++ b/packages/permission/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- docs(readme): add bilingual package README and minimal architecture flow.
 - chore(package): adopt the `@zhongmiao/meta-lc-permission` scoped package identity for release governance.
 
 ## 0.1.0 (2026-04-18)

--- a/packages/permission/CHANGELOG.zh-CN.md
+++ b/packages/permission/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- docs(readme): 新增双语子包 README 与最小架构流程图。
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-permission` 正式包名。
 
 ## 0.1.0 (2026-04-18)

--- a/packages/permission/README.md
+++ b/packages/permission/README.md
@@ -1,0 +1,42 @@
+# @zhongmiao/meta-lc-permission
+
+English | [中文文档](./README_zh.md)
+
+## Package Role
+
+`permission` evaluates role and organization data-scope policies. It produces permission decisions that BFF and query orchestration can use to restrict data access.
+
+## Responsibilities
+
+- Model role data policies and organization scope context.
+- Resolve data scopes such as `SELF`, `DEPT`, `DEPT_AND_CHILDREN`, `CUSTOM_ORG_SET`, and `TENANT_ALL`.
+- Return decisions with allowed organization ids, fallback flags, and reason text.
+
+## Relationship With Other Packages
+
+- `bff` loads user/org/policy context and calls permission evaluation.
+- `query` consumes the resulting constraints through BFF orchestration.
+- `contracts` contains shared data-scope DTOs used at API boundaries.
+- `audit` can record allow/deny outcomes through BFF integration.
+
+## Minimal Flow
+
+```mermaid
+flowchart LR
+  Context["OrgScopeContext"] --> Engine["PermissionEngine"]
+  Engine --> Decision["DataScopeDecision"]
+  Decision --> Query["BFF query / mutation guard"]
+  Query --> Audit["audit outcome"]
+```
+
+## Commands
+
+```bash
+pnpm --filter @zhongmiao/meta-lc-permission build
+pnpm --filter @zhongmiao/meta-lc-permission test
+```
+
+## Boundary Notes
+
+- Keep policy evaluation deterministic.
+- Do not fetch users, roles, or organization data directly from this package; BFF integration supplies context.

--- a/packages/permission/README_zh.md
+++ b/packages/permission/README_zh.md
@@ -1,0 +1,42 @@
+# @zhongmiao/meta-lc-permission
+
+[English](./README.md) | 中文文档
+
+## 包定位
+
+`permission` 负责评估角色与组织数据域策略，产出 BFF 与 query orchestration 可用于限制数据访问的 permission decision。
+
+## 核心职责
+
+- 建模 role data policy 与 organization scope context。
+- 解析 `SELF`、`DEPT`、`DEPT_AND_CHILDREN`、`CUSTOM_ORG_SET`、`TENANT_ALL` 等数据域。
+- 返回 allowed organization ids、fallback flags 与 reason text。
+
+## 与其他包关系
+
+- `bff` 加载 user/org/policy context 后调用 permission evaluation。
+- `query` 通过 BFF 编排消费权限约束。
+- `contracts` 包含 API 边界共享的数据域 DTO。
+- `audit` 可通过 BFF integration 记录 allow/deny 结果。
+
+## 最小闭环
+
+```mermaid
+flowchart LR
+  Context["OrgScopeContext"] --> Engine["PermissionEngine"]
+  Engine --> Decision["DataScopeDecision"]
+  Decision --> Query["BFF query / mutation guard"]
+  Query --> Audit["audit outcome"]
+```
+
+## 常用命令
+
+```bash
+pnpm --filter @zhongmiao/meta-lc-permission build
+pnpm --filter @zhongmiao/meta-lc-permission test
+```
+
+## 边界约束
+
+- 保持 policy evaluation 确定性。
+- 不在此包中直接读取 users、roles 或 organization data；上下文由 BFF integration 提供。

--- a/packages/platform/CHANGELOG.md
+++ b/packages/platform/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- docs(readme): add bilingual package README and minimal architecture flow.
 - feat(aggregate): add the `@zhongmiao/meta-lc-platform` aggregate package to group public library-facing platform modules.
 
 ## 0.1.0 (2026-04-18)

--- a/packages/platform/CHANGELOG.zh-CN.md
+++ b/packages/platform/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- docs(readme): 新增双语子包 README 与最小架构流程图。
 - feat(aggregate): 新增 `@zhongmiao/meta-lc-platform` 聚合总包，用于汇总面向库消费者的平台模块。
 
 ## 0.1.0 (2026-04-18)

--- a/packages/platform/README.md
+++ b/packages/platform/README.md
@@ -1,0 +1,43 @@
+# @zhongmiao/meta-lc-platform
+
+English | [中文文档](./README_zh.md)
+
+## Package Role
+
+`platform` is the aggregate package identity for platform library consumers. It groups public platform package dependencies but does not package the runnable BFF server.
+
+## Responsibilities
+
+- Provide the aggregate `@zhongmiao/meta-lc-platform` package name.
+- Keep aggregate dependency declarations aligned with library-facing packages.
+- Build a minimal package entry through `scripts/build.mjs`.
+
+## Relationship With Other Packages
+
+- Depends on `contracts`, `query`, `permission`, `runtime`, and `shared`.
+- Does not include `bff`, `datasource`, `kernel`, `migration`, or `audit` as runnable service internals.
+- `apps/bff-server` remains the process entry for middleware runtime.
+
+## Minimal Flow
+
+```mermaid
+flowchart LR
+  Consumer["Library consumer"] --> Platform["@zhongmiao/meta-lc-platform"]
+  Platform --> Contracts["contracts"]
+  Platform --> Query["query"]
+  Platform --> Permission["permission"]
+  Platform --> Runtime["runtime"]
+  Platform --> Shared["shared"]
+```
+
+## Commands
+
+```bash
+pnpm --filter @zhongmiao/meta-lc-platform build
+pnpm --filter @zhongmiao/meta-lc-platform test
+```
+
+## Boundary Notes
+
+- This package is an aggregate entry, not a NestJS application.
+- Do not add server startup, DB connection, or deployment concerns here.

--- a/packages/platform/README_zh.md
+++ b/packages/platform/README_zh.md
@@ -1,0 +1,43 @@
+# @zhongmiao/meta-lc-platform
+
+[English](./README.md) | 中文文档
+
+## 包定位
+
+`platform` 是面向平台库消费者的聚合包身份。它聚合 public platform package dependencies，但不打包可运行 BFF server。
+
+## 核心职责
+
+- 提供 `@zhongmiao/meta-lc-platform` 聚合包名。
+- 保持聚合依赖声明与 library-facing packages 对齐。
+- 通过 `scripts/build.mjs` 构建最小 package entry。
+
+## 与其他包关系
+
+- 依赖 `contracts`、`query`、`permission`、`runtime`、`shared`。
+- 不把 `bff`、`datasource`、`kernel`、`migration`、`audit` 作为 runnable service internals 纳入。
+- `apps/bff-server` 仍是 middleware runtime 的进程入口。
+
+## 最小闭环
+
+```mermaid
+flowchart LR
+  Consumer["Library consumer"] --> Platform["@zhongmiao/meta-lc-platform"]
+  Platform --> Contracts["contracts"]
+  Platform --> Query["query"]
+  Platform --> Permission["permission"]
+  Platform --> Runtime["runtime"]
+  Platform --> Shared["shared"]
+```
+
+## 常用命令
+
+```bash
+pnpm --filter @zhongmiao/meta-lc-platform build
+pnpm --filter @zhongmiao/meta-lc-platform test
+```
+
+## 边界约束
+
+- 本包是 aggregate entry，不是 NestJS application。
+- 不在这里加入 server startup、DB connection 或 deployment concerns。

--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- docs(readme): add bilingual package README and minimal architecture flow.
 - chore(package): adopt the `@zhongmiao/meta-lc-query` scoped package identity for release governance.
 
 ## 0.1.0 (2026-04-18)

--- a/packages/query/CHANGELOG.zh-CN.md
+++ b/packages/query/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- docs(readme): 新增双语子包 README 与最小架构流程图。
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-query` 正式包名。
 
 ## 0.1.0 (2026-04-18)

--- a/packages/query/README.md
+++ b/packages/query/README.md
@@ -1,0 +1,42 @@
+# @zhongmiao/meta-lc-query
+
+English | [中文文档](./README_zh.md)
+
+## Package Role
+
+`query` compiles platform query DSL into SQL and parameter lists. It is a compiler package, not a database executor.
+
+## Responsibilities
+
+- Define query compiler input and output types.
+- Convert table, fields, filters, and limit into safe SQL fragments.
+- Keep SQL generation testable without a live database.
+
+## Relationship With Other Packages
+
+- `bff` calls query compilation before datasource execution.
+- `permission` decisions can contribute filters or scope constraints before final query execution.
+- `datasource` executes compiled SQL; `query` does not depend on `datasource`.
+- `contracts` provides the API request shapes that BFF adapts into query compiler input.
+
+## Minimal Flow
+
+```mermaid
+flowchart LR
+  Request["QueryApiRequest"] --> BFF["BFF adapter"]
+  BFF --> Compiler["QueryCompiler"]
+  Compiler --> Sql["SQL + params"]
+  Sql --> Executor["BFF datasource executor"]
+```
+
+## Commands
+
+```bash
+pnpm --filter @zhongmiao/meta-lc-query build
+pnpm --filter @zhongmiao/meta-lc-query test
+```
+
+## Boundary Notes
+
+- Do not open DB connections here.
+- Keep permission policy resolution outside this package; consume already-resolved filters or constraints.

--- a/packages/query/README_zh.md
+++ b/packages/query/README_zh.md
@@ -1,0 +1,42 @@
+# @zhongmiao/meta-lc-query
+
+[English](./README.md) | 中文文档
+
+## 包定位
+
+`query` 将平台 Query DSL 编译成 SQL 与参数列表。它是 compiler 包，不是数据库执行器。
+
+## 核心职责
+
+- 定义 query compiler 的输入与输出类型。
+- 将 table、fields、filters、limit 转成安全 SQL 片段。
+- 保持 SQL 生成逻辑可在无数据库环境下测试。
+
+## 与其他包关系
+
+- `bff` 在 datasource 执行前调用 query compiler。
+- `permission` 的决策可以在最终执行前贡献 filters 或数据域约束。
+- `datasource` 执行编译后的 SQL；`query` 不依赖 `datasource`。
+- `contracts` 提供 API request 形状，由 BFF 适配为 compiler input。
+
+## 最小闭环
+
+```mermaid
+flowchart LR
+  Request["QueryApiRequest"] --> BFF["BFF adapter"]
+  BFF --> Compiler["QueryCompiler"]
+  Compiler --> Sql["SQL + params"]
+  Sql --> Executor["BFF datasource executor"]
+```
+
+## 常用命令
+
+```bash
+pnpm --filter @zhongmiao/meta-lc-query build
+pnpm --filter @zhongmiao/meta-lc-query test
+```
+
+## 边界约束
+
+- 不在这里打开数据库连接。
+- 权限策略解析留在包外；本包消费已经解析好的 filters 或约束。

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- docs(readme): add bilingual package README and minimal architecture flow.
 - chore(package): adopt the `@zhongmiao/meta-lc-runtime` scoped package identity for release governance.
 - feat(runtime): add dependency graph construction and auto-refresh planning for state and mutation events.
 - feat(runtime): add a minimal function registry and rule engine for event-driven runtime effects.

--- a/packages/runtime/CHANGELOG.zh-CN.md
+++ b/packages/runtime/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- docs(readme): 新增双语子包 README 与最小架构流程图。
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-runtime` 正式包名。
 - feat(runtime): 新增依赖图构建与自动刷新规划，覆盖 state 与 mutation 成功事件。
 - feat(runtime): 新增最小 FunctionRegistry 与 RuleEngine，支持事件驱动的规则 effect 计算。

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -1,0 +1,45 @@
+# @zhongmiao/meta-lc-runtime
+
+English | [中文文档](./README_zh.md)
+
+## Package Role
+
+`runtime` contains runtime-side orchestration primitives: DSL parsing, template resolution, dependency tracking, function registry, rule evaluation, manager adapter, orchestrator, and websocket event helpers.
+
+## Responsibilities
+
+- Parse runtime DSL and collect dependencies.
+- Track dependency changes and orchestrate refresh/action execution.
+- Resolve template values from runtime state.
+- Register and execute runtime functions.
+- Create and validate websocket event payloads.
+
+## Relationship With Other Packages
+
+- Depends on `contracts` for shared runtime event and page topic contracts.
+- BFF websocket code can publish runtime events compatible with these contracts.
+- Frontend runtime adapters consume the package contract without direct database or business API access.
+- `query`, `permission`, and `datasource` remain server-side concerns composed by BFF.
+
+## Minimal Flow
+
+```mermaid
+flowchart LR
+  Dsl["Runtime DSL"] --> Parser["runtime-dsl-parser"]
+  Parser --> Deps["DependencyGraph"]
+  Deps --> Orchestrator["RuntimeOrchestrator"]
+  Orchestrator --> Event["WS event contract"]
+  Event --> BFF["BFF websocket gateway"]
+```
+
+## Commands
+
+```bash
+pnpm --filter @zhongmiao/meta-lc-runtime build
+pnpm --filter @zhongmiao/meta-lc-runtime test
+```
+
+## Boundary Notes
+
+- Runtime orchestration must not embed business-specific backend logic.
+- Runtime consumers must still access data through BFF contracts.

--- a/packages/runtime/README_zh.md
+++ b/packages/runtime/README_zh.md
@@ -1,0 +1,45 @@
+# @zhongmiao/meta-lc-runtime
+
+[English](./README.md) | 中文文档
+
+## 包定位
+
+`runtime` 包含 runtime 侧编排原语：DSL parsing、template resolution、dependency tracking、function registry、rule evaluation、manager adapter、orchestrator 与 websocket event helper。
+
+## 核心职责
+
+- 解析 runtime DSL 并收集 dependencies。
+- 跟踪 dependency changes，并编排 refresh/action execution。
+- 从 runtime state 解析 template value。
+- 注册并执行 runtime function。
+- 创建与校验 websocket event payload。
+
+## 与其他包关系
+
+- 依赖 `contracts` 获取共享 runtime event 与 page topic contract。
+- BFF websocket code 可以发布与这些 contract 兼容的 runtime event。
+- 前端 runtime adapter 消费本包 contract，但不直连数据库或业务 API。
+- `query`、`permission`、`datasource` 仍是 BFF 编排的服务端关注点。
+
+## 最小闭环
+
+```mermaid
+flowchart LR
+  Dsl["Runtime DSL"] --> Parser["runtime-dsl-parser"]
+  Parser --> Deps["DependencyGraph"]
+  Deps --> Orchestrator["RuntimeOrchestrator"]
+  Orchestrator --> Event["WS event contract"]
+  Event --> BFF["BFF websocket gateway"]
+```
+
+## 常用命令
+
+```bash
+pnpm --filter @zhongmiao/meta-lc-runtime build
+pnpm --filter @zhongmiao/meta-lc-runtime test
+```
+
+## 边界约束
+
+- Runtime orchestration 不能内嵌业务专用后端逻辑。
+- Runtime consumer 的数据访问仍必须经过 BFF contract。

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- docs(readme): add bilingual package README and minimal architecture flow.
 - chore(package): adopt the `@zhongmiao/meta-lc-shared` scoped package identity for release governance.
 
 ## 0.1.0 (2026-04-18)

--- a/packages/shared/CHANGELOG.zh-CN.md
+++ b/packages/shared/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- docs(readme): 新增双语子包 README 与最小架构流程图。
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-shared` 正式包名。
 
 ## 0.1.0 (2026-04-18)

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,0 +1,40 @@
+# @zhongmiao/meta-lc-shared
+
+English | [中文文档](./README_zh.md)
+
+## Package Role
+
+`shared` provides small reusable helpers shared across platform packages. The current surface focuses on SQL identifier quoting, literal quoting, parameter formatting, and parameter index shifting.
+
+## Responsibilities
+
+- Validate and quote SQL identifiers.
+- Quote primitive SQL literals and arrays for readable final SQL output.
+- Shift positional SQL parameter markers when composing clauses.
+
+## Relationship With Other Packages
+
+- Intended for packages that need common SQL formatting behavior.
+- Kept separate from `query` and `datasource` so low-level helpers do not pull in compilers or DB adapters.
+- Included by `platform` as a foundational utility package.
+
+## Minimal Flow
+
+```mermaid
+flowchart LR
+  Clause["SQL clause + params"] --> Shared["shared helpers"]
+  Shared --> FinalSql["formatted SQL / shifted params"]
+  FinalSql --> Caller["BFF or compiler caller"]
+```
+
+## Commands
+
+```bash
+pnpm --filter @zhongmiao/meta-lc-shared build
+pnpm --filter @zhongmiao/meta-lc-shared test
+```
+
+## Boundary Notes
+
+- Keep helpers deterministic and side-effect free.
+- Do not add package-specific orchestration here.

--- a/packages/shared/README_zh.md
+++ b/packages/shared/README_zh.md
@@ -1,0 +1,40 @@
+# @zhongmiao/meta-lc-shared
+
+[English](./README.md) | 中文文档
+
+## 包定位
+
+`shared` 提供平台包之间复用的小型工具。当前公开能力聚焦 SQL identifier quoting、literal quoting、参数格式化与参数下标偏移。
+
+## 核心职责
+
+- 校验并 quote SQL identifier。
+- quote primitive SQL literal 与数组，用于生成可读 final SQL。
+- 在组合 SQL clause 时调整 positional parameter 下标。
+
+## 与其他包关系
+
+- 面向需要通用 SQL formatting 行为的包。
+- 与 `query`、`datasource` 分离，避免底层工具反向依赖 compiler 或 DB adapter。
+- 被 `platform` 纳入基础工具包集合。
+
+## 最小闭环
+
+```mermaid
+flowchart LR
+  Clause["SQL clause + params"] --> Shared["shared helpers"]
+  Shared --> FinalSql["formatted SQL / shifted params"]
+  FinalSql --> Caller["BFF or compiler caller"]
+```
+
+## 常用命令
+
+```bash
+pnpm --filter @zhongmiao/meta-lc-shared build
+pnpm --filter @zhongmiao/meta-lc-shared test
+```
+
+## 边界约束
+
+- 保持工具函数确定性和无副作用。
+- 不在这里加入某个包专属的编排逻辑。


### PR DESCRIPTION
## Summary
- 更新根 README，补充平台架构图、包索引、依赖方向、运行入口和三库边界说明。
- 新增根 README_zh.md，提供中文对等文档。
- 为 packages 下所有子包新增 README.md / README_zh.md，说明包定位、职责、关联关系、最小闭环流程图、命令和边界约束。
- 统一语言切换展示为 English | 中文文档。
- 补齐 root 与所有受影响子包的双语 changelog 条目，满足 changelog gate。

## Validation
- `node scripts/check-changelog-gate.mjs origin/main HEAD` passed.
- `node scripts/check-boundaries.mjs` passed.
- `node --test scripts/check-boundaries.test.mjs` passed, 5/5.
- README relative link check passed.
- `pnpm lint` / `pnpm -r test` not run locally because `pnpm` and `corepack` are not available in this shell.

## Risk / Rollback
- Risk: documentation-only change; main risk is stale wording or Mermaid rendering issues.
- Rollback: revert this commit to restore the previous README and changelog state.
