### PR TITLE
feat(runtime): add view DSL compiler

### DIFF
--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- feat(runtime): add a pure ViewDefinition to ExecutionPlan compiler for V2 Runtime Orchestrator.
 - docs(readme): add bilingual package README and minimal architecture flow.
 - chore(package): adopt the `@zhongmiao/meta-lc-runtime` scoped package identity for release governance.
 - feat(runtime): add dependency graph construction and auto-refresh planning for state and mutation events.

--- a/packages/runtime/CHANGELOG.zh-CN.md
+++ b/packages/runtime/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- feat(runtime): 新增 V2 Runtime Orchestrator 的纯 ViewDefinition 到 ExecutionPlan 编译器。
 - docs(readme): 新增双语子包 README 与最小架构流程图。
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-runtime` 正式包名。
 - feat(runtime): 新增依赖图构建与自动刷新规划，覆盖 state 与 mutation 成功事件。

--- a/packages/runtime/src/compiler/plan-builder.ts
+++ b/packages/runtime/src/compiler/plan-builder.ts
@@ -1,0 +1,119 @@
+import {
+  type ExecutionNode,
+  type ExecutionPlan,
+  type NodeDefinition,
+  type OutputDefinition,
+  type SubmitDefinition,
+  type ViewCompilerDependency,
+  ViewCompilerError
+} from "../types";
+
+const EXPRESSION_PATTERN = /\{\{\s*([a-zA-Z_$][\w$]*(?:\.[a-zA-Z_$][\w$]*)*)\s*\}\}/g;
+const RUNTIME_CONTEXT_ROOTS = new Set(["input", "params", "user", "ctx", "context", "state"]);
+const SUPPORTED_NODE_TYPES = new Set(["query", "mutation", "transform", "merge"]);
+
+export interface BuildExecutionPlanRequest {
+  nodes: Record<string, NodeDefinition>;
+  output: OutputDefinition;
+  submit?: SubmitDefinition;
+}
+
+export function buildExecutionPlan(request: BuildExecutionPlanRequest): ExecutionPlan {
+  const nodeIds = Object.keys(request.nodes).sort((left, right) => left.localeCompare(right));
+  const knownNodeIds = new Set(nodeIds);
+  const nodes = nodeIds.map<ExecutionNode>((nodeId) => createExecutionNode(nodeId, request.nodes[nodeId]));
+  collectExpressionDependencies(request.output, knownNodeIds, "output");
+  validateSubmitDefinition(request.submit, knownNodeIds);
+  const edges = Object.fromEntries(
+    nodeIds.map((nodeId) => [
+      nodeId,
+      collectNodeDependencies(request.nodes[nodeId], knownNodeIds, `nodes.${nodeId}`)
+    ])
+  );
+
+  return {
+    nodes,
+    edges,
+    output: request.output,
+    ...(request.submit ? { submit: request.submit } : {})
+  };
+}
+
+export function collectExpressionDependencies(
+  value: unknown,
+  knownNodeIds: ReadonlySet<string>,
+  path = "value"
+): ViewCompilerDependency[] {
+  const dependencies = new Map<string, ViewCompilerDependency>();
+
+  visitExpressionValue(value, (template) => {
+    for (const match of template.matchAll(EXPRESSION_PATTERN)) {
+      const expression = match[1];
+      const root = expression?.split(".")[0];
+      if (!expression || !root) {
+        continue;
+      }
+      if (knownNodeIds.has(root)) {
+        dependencies.set(root, { nodeId: root, expression: match[0] });
+        continue;
+      }
+      if (RUNTIME_CONTEXT_ROOTS.has(root)) {
+        continue;
+      }
+      throw new ViewCompilerError(`Unknown node dependency "${root}" referenced by expression "${match[0]}" at ${path}.`);
+    }
+  });
+
+  return [...dependencies.values()].sort((left, right) => left.nodeId.localeCompare(right.nodeId));
+}
+
+function createExecutionNode(id: string, definition: NodeDefinition | undefined): ExecutionNode {
+  if (!definition) {
+    throw new ViewCompilerError(`Missing node definition for "${id}".`);
+  }
+  if (!SUPPORTED_NODE_TYPES.has(definition.type)) {
+    throw new ViewCompilerError(`Unsupported node type "${definition.type}" for node "${id}".`);
+  }
+  return {
+    id,
+    type: definition.type,
+    definition
+  };
+}
+
+function collectNodeDependencies(
+  definition: NodeDefinition | undefined,
+  knownNodeIds: ReadonlySet<string>,
+  path: string
+): string[] {
+  if (!definition) {
+    return [];
+  }
+  return collectExpressionDependencies(definition, knownNodeIds, path).map((dependency) => dependency.nodeId);
+}
+
+function validateSubmitDefinition(submit: SubmitDefinition | undefined, knownNodeIds: ReadonlySet<string>): void {
+  submit?.nodes?.forEach((nodeId) => {
+    if (!knownNodeIds.has(nodeId)) {
+      throw new ViewCompilerError(`SubmitDefinition references unknown node "${nodeId}".`);
+    }
+  });
+}
+
+function visitExpressionValue(value: unknown, onString: (template: string) => void): void {
+  if (typeof value === "string") {
+    onString(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item) => visitExpressionValue(item, onString));
+    return;
+  }
+  if (isPlainObject(value)) {
+    Object.values(value).forEach((item) => visitExpressionValue(item, onString));
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/runtime/src/compiler/view-compiler.ts
+++ b/packages/runtime/src/compiler/view-compiler.ts
@@ -1,0 +1,34 @@
+import {
+  type ExecutionPlan,
+  type ViewDefinition,
+  ViewCompilerError
+} from "../types";
+import { buildExecutionPlan } from "./plan-builder";
+
+export function compileViewDefinition(view: ViewDefinition): ExecutionPlan {
+  validateViewDefinition(view);
+  return buildExecutionPlan({
+    nodes: view.nodes,
+    output: view.output,
+    ...(view.submit ? { submit: view.submit } : {})
+  });
+}
+
+function validateViewDefinition(view: ViewDefinition): void {
+  if (!view.name?.trim()) {
+    throw new ViewCompilerError("ViewDefinition.name is required.");
+  }
+  if (!isPlainObject(view.nodes)) {
+    throw new ViewCompilerError("ViewDefinition.nodes must be an object.");
+  }
+  if (Object.keys(view.nodes).length === 0) {
+    throw new ViewCompilerError("ViewDefinition.nodes must contain at least one node.");
+  }
+  if (!isPlainObject(view.output)) {
+    throw new ViewCompilerError("ViewDefinition.output must be an object.");
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,4 +1,6 @@
 export * from "./runtime-dsl-parser";
+export * from "./compiler/view-compiler";
+export * from "./compiler/plan-builder";
 export * from "./dependency-graph";
 export * from "./function-registry";
 export * from "./manager-adapter";

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -14,6 +14,79 @@ import type {
   RuntimeTemplateDependency
 } from "@zhongmiao/meta-lc-contracts";
 
+export type ViewExpression =
+  | string
+  | number
+  | boolean
+  | null
+  | ViewExpression[]
+  | { [key: string]: ViewExpression };
+
+export interface ViewDefinition {
+  name: string;
+  params?: Record<string, ViewExpression>;
+  nodes: Record<string, NodeDefinition>;
+  output: OutputDefinition;
+  submit?: SubmitDefinition;
+}
+
+export type NodeDefinition = QueryNodeDefinition | MutationNodeDefinition | TransformNodeDefinition | MergeNodeDefinition;
+
+export interface BaseNodeDefinition {
+  type: "query" | "mutation" | "transform" | "merge";
+  [key: string]: unknown;
+}
+
+export interface QueryNodeDefinition extends BaseNodeDefinition {
+  type: "query";
+}
+
+export interface MutationNodeDefinition extends BaseNodeDefinition {
+  type: "mutation";
+}
+
+export interface TransformNodeDefinition extends BaseNodeDefinition {
+  type: "transform";
+}
+
+export interface MergeNodeDefinition extends BaseNodeDefinition {
+  type: "merge";
+}
+
+export interface OutputDefinition {
+  [key: string]: ViewExpression;
+}
+
+export interface SubmitDefinition {
+  nodes?: string[];
+  [key: string]: unknown;
+}
+
+export interface ExecutionNode {
+  id: string;
+  type: NodeDefinition["type"];
+  definition: NodeDefinition;
+}
+
+export interface ExecutionPlan {
+  nodes: ExecutionNode[];
+  edges: Record<string, string[]>;
+  output: OutputDefinition;
+  submit?: SubmitDefinition;
+}
+
+export interface ViewCompilerDependency {
+  nodeId: string;
+  expression: string;
+}
+
+export class ViewCompilerError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ViewCompilerError";
+  }
+}
+
 export interface ParsedRuntimeDatasourceDefinition extends RuntimeDatasourceDefinition {
   dependencies: RuntimeTemplateDependency[];
 }

--- a/packages/runtime/test/view-compiler.test.ts
+++ b/packages/runtime/test/view-compiler.test.ts
@@ -1,0 +1,291 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  compileViewDefinition,
+  type ExecutionPlan,
+  type ViewDefinition,
+  ViewCompilerError
+} from "../src";
+
+test("compileViewDefinition compiles a single query node into a stable plan", () => {
+  const plan = compileViewDefinition({
+    name: "orders",
+    nodes: {
+      orders: {
+        type: "query",
+        table: "orders",
+        params: {
+          tenantId: "{{input.tenantId}}"
+        }
+      }
+    },
+    output: {
+      rows: "{{orders.rows}}"
+    }
+  });
+
+  assert.deepEqual(plan, {
+    nodes: [
+      {
+        id: "orders",
+        type: "query",
+        definition: {
+          type: "query",
+          table: "orders",
+          params: {
+            tenantId: "{{input.tenantId}}"
+          }
+        }
+      }
+    ],
+    edges: {
+      orders: []
+    },
+    output: {
+      rows: "{{orders.rows}}"
+    }
+  });
+});
+
+test("compileViewDefinition keeps multiple root nodes in stable order", () => {
+  const view: ViewDefinition = {
+    name: "dashboard",
+    nodes: {
+      zeta: {
+        type: "query",
+        table: "zeta"
+      },
+      alpha: {
+        type: "query",
+        table: "alpha"
+      }
+    },
+    output: {
+      alpha: "{{alpha.rows}}",
+      zeta: "{{zeta.rows}}"
+    }
+  };
+
+  assert.deepEqual(compileViewDefinition(view), compileViewDefinition(view));
+  assert.deepEqual(
+    compileViewDefinition(view).nodes.map((node) => node.id),
+    ["alpha", "zeta"]
+  );
+  assert.deepEqual(compileViewDefinition(view).edges, {
+    alpha: [],
+    zeta: []
+  });
+});
+
+test("compileViewDefinition extracts query dependencies from expressions", () => {
+  const plan = compileViewDefinition({
+    name: "order-detail",
+    nodes: {
+      user: {
+        type: "query",
+        table: "users",
+        params: {
+          userId: "{{input.userId}}"
+        }
+      },
+      orders: {
+        type: "query",
+        table: "orders",
+        params: {
+          userId: "{{user.id}}"
+        }
+      }
+    },
+    output: {
+      rows: "{{orders.rows}}"
+    }
+  });
+
+  assert.deepEqual(plan.edges, {
+    orders: ["user"],
+    user: []
+  });
+});
+
+test("compileViewDefinition supports merge fan-in dependencies", () => {
+  const plan = compileViewDefinition({
+    name: "account-summary",
+    nodes: {
+      org: {
+        type: "query",
+        table: "orgs",
+        params: {
+          orgId: "{{input.orgId}}"
+        }
+      },
+      user: {
+        type: "query",
+        table: "users",
+        params: {
+          userId: "{{input.userId}}"
+        }
+      },
+      summary: {
+        type: "merge",
+        strategy: "objectMerge",
+        inputs: {
+          org: "{{org.row}}",
+          user: "{{user.row}}"
+        }
+      }
+    },
+    output: {
+      summary: "{{summary.value}}"
+    }
+  });
+
+  assert.deepEqual(plan.edges, {
+    org: [],
+    summary: ["org", "user"],
+    user: []
+  });
+});
+
+test("compileViewDefinition preserves mutation and submit contracts", () => {
+  const plan = compileViewDefinition({
+    name: "save-order",
+    nodes: {
+      save: {
+        type: "mutation",
+        model: "orders",
+        payload: {
+          status: "{{input.status}}"
+        }
+      },
+      refresh: {
+        type: "query",
+        table: "orders",
+        params: {
+          orderId: "{{save.row.id}}"
+        }
+      }
+    },
+    output: {
+      row: "{{refresh.row}}"
+    },
+    submit: {
+      nodes: ["save", "refresh"]
+    }
+  });
+
+  assert.deepEqual(plan.edges, {
+    refresh: ["save"],
+    save: []
+  });
+  assert.deepEqual(plan.submit, {
+    nodes: ["save", "refresh"]
+  });
+});
+
+test("compileViewDefinition rejects unknown node dependencies with a clear error", () => {
+  assert.throws(
+    () =>
+      compileViewDefinition({
+        name: "broken-view",
+        nodes: {
+          orders: {
+            type: "query",
+            table: "orders",
+            params: {
+              userId: "{{missingUser.id}}"
+            }
+          }
+        },
+        output: {
+          rows: "{{orders.rows}}"
+        }
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof ViewCompilerError);
+      assert.equal(
+        error.message,
+        'Unknown node dependency "missingUser" referenced by expression "{{missingUser.id}}" at nodes.orders.'
+      );
+      return true;
+    }
+  );
+
+  assert.throws(
+    () =>
+      compileViewDefinition({
+        name: "broken-output",
+        nodes: {
+          orders: {
+            type: "query",
+            table: "orders"
+          }
+        },
+        output: {
+          rows: "{{missingOrders.rows}}"
+        }
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof ViewCompilerError);
+      assert.equal(
+        error.message,
+        'Unknown node dependency "missingOrders" referenced by expression "{{missingOrders.rows}}" at output.'
+      );
+      return true;
+    }
+  );
+
+  assert.throws(
+    () =>
+      compileViewDefinition({
+        name: "broken-submit",
+        nodes: {
+          save: {
+            type: "mutation"
+          }
+        },
+        output: {
+          row: "{{save.row}}"
+        },
+        submit: {
+          nodes: ["missingSave"]
+        }
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof ViewCompilerError);
+      assert.equal(error.message, 'SubmitDefinition references unknown node "missingSave".');
+      return true;
+    }
+  );
+});
+
+test("compileViewDefinition leaves cycle detection to the downstream scheduler", () => {
+  const plan = compileViewDefinition({
+    name: "cycle-fixture",
+    nodes: {
+      first: {
+        type: "transform",
+        value: "{{second.value}}"
+      },
+      second: {
+        type: "transform",
+        value: "{{first.value}}"
+      }
+    },
+    output: {
+      value: "{{first.value}}"
+    }
+  });
+
+  assert.deepEqual(plan.edges, {
+    first: ["second"],
+    second: ["first"]
+  });
+  assertPlanHasOnlyCompilerShape(plan);
+});
+
+function assertPlanHasOnlyCompilerShape(plan: ExecutionPlan): void {
+  assert.equal(typeof plan, "object");
+  assert.ok(Array.isArray(plan.nodes));
+  assert.equal(typeof plan.edges, "object");
+  assert.equal(typeof plan.output, "object");
+}


### PR DESCRIPTION
## Summary
- add the pure ViewDefinition -> ExecutionPlan compiler in packages/runtime
- add V2 runtime compiler contract types and stable execution node/edge construction
- cover query, mutation, transform, merge, fan-in dependencies, submit preservation, unknown dependency errors, and cycle fixture edges

## Validation
- packages/runtime/node_modules/.bin/tsc -p packages/runtime/tsconfig.json
- node --test "packages/runtime/dist/**/test/*.test.js"
- node --test scripts/check-boundaries.test.mjs

Closes #78