### PR TITLE
feat(runtime): add expression engine

### DIFF
--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- feat(runtime): add a deterministic expression resolver for V2 runtime values.
 - feat(runtime): add a pure DAG scheduler for V2 ExecutionPlan edges.
 - feat(runtime): add a pure ViewDefinition to ExecutionPlan compiler for V2 Runtime Orchestrator.
 - docs(readme): add bilingual package README and minimal architecture flow.

--- a/packages/runtime/CHANGELOG.zh-CN.md
+++ b/packages/runtime/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- feat(runtime): 新增面向 V2 runtime value 的确定性表达式解析器。
 - feat(runtime): 新增面向 V2 ExecutionPlan edges 的纯 DAG 调度器。
 - feat(runtime): 新增 V2 Runtime Orchestrator 的纯 ViewDefinition 到 ExecutionPlan 编译器。
 - docs(readme): 新增双语子包 README 与最小架构流程图。

--- a/packages/runtime/src/dsl/expression.ts
+++ b/packages/runtime/src/dsl/expression.ts
@@ -1,0 +1,82 @@
+import {
+  type Expression,
+  type ExpressionStateSource,
+  ExpressionResolverError
+} from "../types";
+
+const EXPRESSION_PATTERN = /\{\{\s*([a-zA-Z_$][\w$]*(?:\.[a-zA-Z_$][\w$]*)*)\s*\}\}/g;
+const WHOLE_EXPRESSION_PATTERN = /^\{\{\s*([a-zA-Z_$][\w$]*(?:\.[a-zA-Z_$][\w$]*)*)\s*\}\}$/;
+
+export function resolveExpression(value: Expression, state: ExpressionStateSource): unknown {
+  if (typeof value === "string") {
+    return resolveExpressionString(value, state);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => resolveExpression(item, state));
+  }
+
+  if (isPlainObject(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [key, resolveExpression(nestedValue, state)])
+    );
+  }
+
+  return value;
+}
+
+export function resolveExpressionString(template: string, state: ExpressionStateSource): unknown {
+  const wholeExpressionMatch = template.match(WHOLE_EXPRESSION_PATTERN);
+  if (wholeExpressionMatch?.[1]) {
+    return getExpressionPathValue(wholeExpressionMatch[1], state);
+  }
+
+  return template.replace(EXPRESSION_PATTERN, (_match, path: string) => {
+    const resolved = getExpressionPathValue(path, state);
+    return resolved === undefined || resolved === null ? "" : String(resolved);
+  });
+}
+
+export function getExpressionPathValue(path: string, state: ExpressionStateSource): unknown {
+  if (!path.trim()) {
+    throw new ExpressionResolverError("Expression path is required.");
+  }
+
+  if (state instanceof Map) {
+    if (state.has(path)) {
+      return state.get(path);
+    }
+    return getNestedPathValue(path, Object.fromEntries(state.entries()));
+  }
+
+  if (isExpressionStateGetter(state)) {
+    return state.get(path);
+  }
+
+  if (isPlainObject(state)) {
+    return getNestedPathValue(path, state);
+  }
+
+  throw new ExpressionResolverError("Expression state source must be an object, Map, or get(path) store.");
+}
+
+function getNestedPathValue(path: string, source: Record<string, unknown>): unknown {
+  return path.split(".").reduce<unknown>((current, segment) => {
+    if (!isRecordLike(current)) {
+      return undefined;
+    }
+    return current[segment];
+  }, source);
+}
+
+function isExpressionStateGetter(value: unknown): value is { get(path: string): unknown } {
+  return typeof value === "object" && value !== null && !(value instanceof Map) && typeof (value as { get?: unknown }).get === "function";
+}
+
+function isRecordLike(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isPlainObject(value: unknown): value is Record<string, Expression> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./runtime-dsl-parser";
 export * from "./compiler/view-compiler";
 export * from "./compiler/plan-builder";
+export * from "./dsl/expression";
 export * from "./graph/dependency-graph";
 export * from "./graph/topo-sort";
 export * from "./graph/dep-resolver";

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -22,6 +22,14 @@ export type ViewExpression =
   | ViewExpression[]
   | { [key: string]: ViewExpression };
 
+export type Expression = ViewExpression;
+
+export interface ExpressionStateGetter {
+  get(path: string): unknown;
+}
+
+export type ExpressionStateSource = Record<string, unknown> | Map<string, unknown> | ExpressionStateGetter;
+
 export interface ViewDefinition {
   name: string;
   params?: Record<string, ViewExpression>;
@@ -107,6 +115,13 @@ export class DagSchedulerError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "DagSchedulerError";
+  }
+}
+
+export class ExpressionResolverError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ExpressionResolverError";
   }
 }
 

--- a/packages/runtime/test/expression.test.ts
+++ b/packages/runtime/test/expression.test.ts
@@ -1,0 +1,136 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  ExpressionResolverError,
+  getExpressionPathValue,
+  resolveExpression,
+  resolveExpressionString
+} from "../src";
+
+test("resolveExpressionString resolves simple and nested paths", () => {
+  const state = {
+    user: {
+      id: "user-1"
+    },
+    input: {
+      order: {
+        user: {
+          id: "order-user-1"
+        }
+      }
+    }
+  };
+
+  assert.equal(resolveExpressionString("{{user.id}}", state), "user-1");
+  assert.equal(resolveExpressionString("{{input.order.user.id}}", state), "order-user-1");
+});
+
+test("resolveExpressionString preserves whole-expression value types", () => {
+  const profile = {
+    id: "user-1",
+    name: "Ada"
+  };
+  const state = {
+    user: {
+      age: 36,
+      profile,
+      deletedAt: null
+    }
+  };
+
+  assert.equal(resolveExpressionString("{{user.age}}", state), 36);
+  assert.deepEqual(resolveExpressionString("{{user.profile}}", state), profile);
+  assert.equal(resolveExpressionString("{{user.deletedAt}}", state), null);
+});
+
+test("resolveExpression recursively maps objects without mutating input", () => {
+  const expression = {
+    userId: "{{user.id}}",
+    label: "hello {{user.name}}",
+    nested: {
+      age: "{{user.age}}"
+    }
+  };
+  const snapshot = structuredClone(expression);
+
+  const resolved = resolveExpression(expression, {
+    user: {
+      id: "user-1",
+      name: "Ada",
+      age: 36
+    }
+  });
+
+  assert.deepEqual(resolved, {
+    userId: "user-1",
+    label: "hello Ada",
+    nested: {
+      age: 36
+    }
+  });
+  assert.deepEqual(expression, snapshot);
+});
+
+test("resolveExpression recursively maps arrays without mutating input", () => {
+  const expression = ["{{user.id}}", "hello {{user.name}}", { age: "{{user.age}}" }];
+  const snapshot = structuredClone(expression);
+
+  const resolved = resolveExpression(expression, {
+    user: {
+      id: "user-1",
+      name: "Ada",
+      age: 36
+    }
+  });
+
+  assert.deepEqual(resolved, ["user-1", "hello Ada", { age: 36 }]);
+  assert.deepEqual(expression, snapshot);
+});
+
+test("resolveExpression handles missing values explicitly", () => {
+  assert.equal(resolveExpressionString("{{user.missing}}", { user: {} }), undefined);
+  assert.equal(resolveExpressionString("hello {{user.missing}}", { user: {} }), "hello ");
+  assert.deepEqual(resolveExpression({ value: "{{user.missing}}" }, { user: {} }), { value: undefined });
+});
+
+test("resolveExpression returns non-expression values unchanged", () => {
+  assert.equal(resolveExpression(1, {}), 1);
+  assert.equal(resolveExpression(true, {}), true);
+  assert.equal(resolveExpression(null, {}), null);
+});
+
+test("getExpressionPathValue supports Map and get(path) state sources", () => {
+  const mapState = new Map<string, unknown>([
+    ["user.id", "map-user-1"],
+    ["user", { name: "Ada" }]
+  ]);
+  const storeState = {
+    get(path: string): unknown {
+      return path === "user.id" ? "store-user-1" : undefined;
+    }
+  };
+
+  assert.equal(getExpressionPathValue("user.id", mapState), "map-user-1");
+  assert.equal(getExpressionPathValue("user.name", mapState), "Ada");
+  assert.equal(resolveExpressionString("{{user.id}}", storeState), "store-user-1");
+});
+
+test("getExpressionPathValue rejects invalid state sources", () => {
+  assert.throws(
+    () => getExpressionPathValue("user.id", undefined as never),
+    (error: unknown) => {
+      assert.ok(error instanceof ExpressionResolverError);
+      assert.equal(error.message, "Expression state source must be an object, Map, or get(path) store.");
+      return true;
+    }
+  );
+
+  assert.throws(
+    () => getExpressionPathValue("", {}),
+    (error: unknown) => {
+      assert.ok(error instanceof ExpressionResolverError);
+      assert.equal(error.message, "Expression path is required.");
+      return true;
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- add a pure synchronous V2 expression resolver for runtime values
- support whole-expression value preservation, nested paths, object/array mapping, Map state, and get(path) stores
- keep legacy template-resolver behavior untouched

## Validation
- packages/runtime/node_modules/.bin/tsc -p packages/runtime/tsconfig.json
- node --test "packages/runtime/dist/**/test/*.test.js"
- node --test scripts/check-boundaries.test.mjs
- node scripts/check-changelog-gate.mjs origin/main HEAD

Closes #80