### PR TITLE
feat(runtime): add node executor dispatch

### DIFF
--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- feat(runtime): add a pure NodeExecutor dispatch system for V2 runtime nodes.
 - feat(runtime): add a deterministic expression resolver for V2 runtime values.
 - feat(runtime): add a pure DAG scheduler for V2 ExecutionPlan edges.
 - feat(runtime): add a pure ViewDefinition to ExecutionPlan compiler for V2 Runtime Orchestrator.

--- a/packages/runtime/CHANGELOG.zh-CN.md
+++ b/packages/runtime/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- feat(runtime): 新增面向 V2 runtime node 的纯 NodeExecutor 分发系统。
 - feat(runtime): 新增面向 V2 runtime value 的确定性表达式解析器。
 - feat(runtime): 新增面向 V2 ExecutionPlan edges 的纯 DAG 调度器。
 - feat(runtime): 新增 V2 Runtime Orchestrator 的纯 ViewDefinition 到 ExecutionPlan 编译器。

--- a/packages/runtime/src/executor/node-executor.ts
+++ b/packages/runtime/src/executor/node-executor.ts
@@ -1,0 +1,60 @@
+import {
+  type ExecutionNode,
+  type MergeNodeDefinition,
+  type MutationNodeDefinition,
+  type NodeDefinition,
+  type QueryNodeDefinition,
+  type RuntimeContext,
+  type RuntimeStateStore,
+  type TransformNodeDefinition,
+  NodeExecutorError
+} from "../types";
+
+export type NodeExecutionResult = unknown;
+
+export type NodeTypeExecutor<TNode extends NodeDefinition = NodeDefinition> = (
+  node: TNode,
+  state: RuntimeStateStore,
+  context: RuntimeContext
+) => NodeExecutionResult | Promise<NodeExecutionResult>;
+
+export interface NodeExecutorDependencies {
+  query: NodeTypeExecutor<QueryNodeDefinition>;
+  mutation: NodeTypeExecutor<MutationNodeDefinition>;
+  merge: NodeTypeExecutor<MergeNodeDefinition>;
+  transform: NodeTypeExecutor<TransformNodeDefinition>;
+}
+
+export async function executeNode(
+  node: ExecutionNode,
+  state: RuntimeStateStore,
+  context: RuntimeContext,
+  executors: NodeExecutorDependencies
+): Promise<NodeExecutionResult> {
+  switch (node.type) {
+    case "query":
+      return runExecutor("query", executors.query, node.definition as QueryNodeDefinition, state, context);
+    case "mutation":
+      return runExecutor("mutation", executors.mutation, node.definition as MutationNodeDefinition, state, context);
+    case "merge":
+      return runExecutor("merge", executors.merge, node.definition as MergeNodeDefinition, state, context);
+    case "transform":
+      return runExecutor("transform", executors.transform, node.definition as TransformNodeDefinition, state, context);
+    default:
+      throw new NodeExecutorError(`Unsupported node type "${String(node.type)}".`);
+  }
+}
+
+async function runExecutor<TNode extends NodeDefinition>(
+  kind: NodeDefinition["type"],
+  executor: NodeTypeExecutor<TNode> | undefined,
+  node: TNode,
+  state: RuntimeStateStore,
+  context: RuntimeContext
+): Promise<NodeExecutionResult> {
+  if (typeof executor !== "function") {
+    throw new NodeExecutorError(`Missing node executor for "${kind}".`);
+  }
+
+  return executor(node, state, context);
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -2,6 +2,7 @@ export * from "./runtime-dsl-parser";
 export * from "./compiler/view-compiler";
 export * from "./compiler/plan-builder";
 export * from "./dsl/expression";
+export * from "./executor/node-executor";
 export * from "./graph/dependency-graph";
 export * from "./graph/topo-sort";
 export * from "./graph/dep-resolver";

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -83,6 +83,12 @@ export interface ExecutionPlan {
   submit?: SubmitDefinition;
 }
 
+export type RuntimeContext = Record<string, unknown>;
+
+export interface RuntimeStateStore {
+  get(path: string): unknown;
+}
+
 export type DagEdges = Record<string, string[]>;
 
 export interface DagGraphNode {
@@ -122,6 +128,13 @@ export class ExpressionResolverError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "ExpressionResolverError";
+  }
+}
+
+export class NodeExecutorError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NodeExecutorError";
   }
 }
 

--- a/packages/runtime/test/node-executor.test.ts
+++ b/packages/runtime/test/node-executor.test.ts
@@ -1,0 +1,151 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  type ExecutionNode,
+  executeNode,
+  type NodeExecutorDependencies,
+  NodeExecutorError,
+  type RuntimeContext,
+  type RuntimeStateStore
+} from "../src";
+
+function createNode(type: "query" | "mutation" | "merge" | "transform", definition: Record<string, unknown>) {
+  return {
+    id: `${type}-node`,
+    type,
+    definition: { type, ...definition }
+  } as ExecutionNode;
+}
+
+function createExecutors(calls: string[], results: Record<string, unknown>): NodeExecutorDependencies {
+  return {
+    query: async (node, state, context) => {
+      calls.push(`query:${node.type}`);
+      assert.equal(state, runtimeState);
+      assert.equal(context, runtimeContext);
+      return results.query;
+    },
+    mutation: async (node, state, context) => {
+      calls.push(`mutation:${node.type}`);
+      assert.equal(state, runtimeState);
+      assert.equal(context, runtimeContext);
+      return results.mutation;
+    },
+    merge: async (node, state, context) => {
+      calls.push(`merge:${node.type}`);
+      assert.equal(state, runtimeState);
+      assert.equal(context, runtimeContext);
+      return results.merge;
+    },
+    transform: async (node, state, context) => {
+      calls.push(`transform:${node.type}`);
+      assert.equal(state, runtimeState);
+      assert.equal(context, runtimeContext);
+      return results.transform;
+    }
+  };
+}
+
+const runtimeState: RuntimeStateStore = {
+  get(path: string): unknown {
+    return path === "user.id" ? "user-1" : undefined;
+  }
+};
+
+const runtimeContext: RuntimeContext = {
+  requestId: "req-1"
+};
+
+test("executeNode dispatches query nodes", async () => {
+  const calls: string[] = [];
+  const result = await executeNode(
+    createNode("query", { table: "users" }),
+    runtimeState,
+    runtimeContext,
+    createExecutors(calls, { query: "query-result" })
+  );
+
+  assert.deepEqual(calls, ["query:query"]);
+  assert.equal(result, "query-result");
+});
+
+test("executeNode dispatches mutation, merge, and transform nodes", async () => {
+  const calls: string[] = [];
+  const executors = createExecutors(calls, {
+    query: "query-result",
+    mutation: "mutation-result",
+    merge: "merge-result",
+    transform: "transform-result"
+  });
+
+  assert.equal(await executeNode(createNode("mutation", { model: "users" }), runtimeState, runtimeContext, executors), "mutation-result");
+  assert.equal(await executeNode(createNode("merge", { strategy: "objectMerge" }), runtimeState, runtimeContext, executors), "merge-result");
+  assert.equal(await executeNode(createNode("transform", { mapper: true }), runtimeState, runtimeContext, executors), "transform-result");
+  assert.deepEqual(calls, ["mutation:mutation", "merge:merge", "transform:transform"]);
+});
+
+test("executeNode rejects unsupported node types with a clear error", async () => {
+  await assert.rejects(
+    () =>
+      executeNode(
+        {
+          id: "broken-node",
+          type: "other",
+          definition: { type: "other" }
+        } as never,
+        runtimeState,
+        runtimeContext,
+        createExecutors([], {})
+      ),
+    (error: unknown) => {
+      assert.ok(error instanceof NodeExecutorError);
+      assert.equal(error.message, 'Unsupported node type "other".');
+      return true;
+    }
+  );
+});
+
+test("executeNode rejects missing executors with a clear error", async () => {
+  const partialExecutors = {
+    query: undefined,
+    mutation: undefined,
+    merge: undefined,
+    transform: undefined
+  } as unknown as NodeExecutorDependencies;
+
+  await assert.rejects(
+    () => executeNode(createNode("query", { table: "users" }), runtimeState, runtimeContext, partialExecutors),
+    (error: unknown) => {
+      assert.ok(error instanceof NodeExecutorError);
+      assert.equal(error.message, 'Missing node executor for "query".');
+      return true;
+    }
+  );
+});
+
+test("executeNode preserves input references and propagates executor errors", async () => {
+  const state = Object.freeze(runtimeState);
+  const context = Object.freeze(runtimeContext);
+
+  await assert.rejects(
+    () =>
+      executeNode(
+        createNode("query", { table: "users" }),
+        state,
+        context,
+        {
+          query: async () => {
+            throw new Error("query failed");
+          },
+          mutation: async () => "mutation-result",
+          merge: async () => "merge-result",
+          transform: async () => "transform-result"
+        }
+      ),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.equal(error.message, "query failed");
+      return true;
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- add a pure node dispatch layer for query, mutation, merge, and transform nodes
- introduce minimal runtime context/state store placeholder types and node executor dependency injection
- keep DAG, DSL, datasource, and SQL concerns out of this layer

## Validation
- packages/runtime/node_modules/.bin/tsc -p packages/runtime/tsconfig.json
- node --test "packages/runtime/dist/**/test/*.test.js"
- node --test scripts/check-boundaries.test.mjs
- node scripts/check-changelog-gate.mjs origin/main HEAD

Closes #81