### PR TITLE
feat(runtime): add runtime executor main engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- feat(runtime): add a RuntimeExecutor main engine that schedules DAG layers, commits state snapshots atomically, and resolves final view models.
 - feat(runtime): add a query executor adapter that compiles query nodes and runs datasource queries.
 - docs(readme): add bilingual package README index and architecture diagrams.
 - feat(release): add aggregate package `@zhongmiao/meta-lc-platform` and reserve `@zhongmiao/meta-lc-*` naming for workspace packages.

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- feat(runtime): 新增 RuntimeExecutor 主执行引擎，负责 DAG 分层调度、原子提交 state snapshot 并解析最终 view model。
 - feat(runtime): 新增 QueryExecutor 适配层，负责编译 query 节点并执行 datasource 查询。
 - docs(readme): 新增双语子包 README 索引与架构流程图。
 - feat(release): 新增聚合总包 `@zhongmiao/meta-lc-platform`，并为工作区包统一预留 `@zhongmiao/meta-lc-*` 命名。

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- feat(runtime): add a RuntimeExecutor main engine that schedules DAG layers, commits state snapshots atomically, and resolves final view models.
 - feat(runtime): add a merge executor for V2 fan-in strategies and custom merge hooks.
 - feat(runtime): add a query executor adapter that compiles query nodes and runs datasource queries.
 - feat(runtime): add a pure NodeExecutor dispatch system for V2 runtime nodes.

--- a/packages/runtime/CHANGELOG.zh-CN.md
+++ b/packages/runtime/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- feat(runtime): 新增 RuntimeExecutor 主执行引擎，负责 DAG 分层调度、原子提交 state snapshot 并解析最终 view model。
 - feat(runtime): 新增 merge 执行器，支持 V2 fan-in 策略与自定义 merge hook。
 - feat(runtime): 新增 QueryExecutor 适配层，负责编译 query 节点并执行 datasource 查询。
 - feat(runtime): 新增面向 V2 runtime node 的纯 NodeExecutor 分发系统。

--- a/packages/runtime/src/executor/merge-executor.ts
+++ b/packages/runtime/src/executor/merge-executor.ts
@@ -25,7 +25,7 @@ export async function executeMergeNode(
   dependencies: MergeExecutorDependencies = {}
 ): Promise<MergeExecutorResult> {
   const strategy = node.strategy ?? "objectMerge";
-  const inputs = resolveMergeInputs(node.inputs, state, strategy);
+  const inputs = resolveMergeInputs(node.inputs, state, strategy, context);
 
   switch (strategy) {
     case "objectMerge":
@@ -42,16 +42,18 @@ export async function executeMergeNode(
 function resolveMergeInputs(
   inputs: MergeNodeDefinition["inputs"],
   state: RuntimeStateStore,
-  strategy: MergeStrategy
+  strategy: MergeStrategy,
+  context: RuntimeContext
 ): Record<string, unknown> {
   if (!inputs || Object.keys(inputs).length === 0) {
     throw new MergeExecutorError(`Merge node requires a non-empty inputs object for "${strategy}".`, strategy);
   }
 
   const resolved: Record<string, unknown> = {};
+  const expressionStateSource = new MergeExpressionStateSource(state, context);
 
   for (const [key, expression] of Object.entries(inputs)) {
-    const value = resolveExpression(expression, state);
+    const value = resolveExpression(expression, expressionStateSource);
     if (value === undefined) {
       throw new MergeExecutorError(`Merge input "${key}" resolved to undefined.`, strategy);
     }
@@ -107,4 +109,41 @@ async function executeCustomMerge(
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+class MergeExpressionStateSource {
+  constructor(
+    private readonly state: RuntimeStateStore,
+    private readonly context: RuntimeContext
+  ) {}
+
+  get(path: string): unknown {
+    if (!path.trim()) {
+      return undefined;
+    }
+
+    const stateValue = this.state.get(path);
+    if (stateValue !== undefined) {
+      return stateValue;
+    }
+
+    return getNestedValue(this.context, path);
+  }
+}
+
+function getNestedValue(source: Record<string, unknown>, path: string): unknown {
+  return path.split(".").reduce<unknown>((current, segment) => {
+    if (!isRecordLike(current)) {
+      return undefined;
+    }
+    return current[segment];
+  }, source);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isRecordLike(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }

--- a/packages/runtime/src/executor/query-executor.ts
+++ b/packages/runtime/src/executor/query-executor.ts
@@ -138,17 +138,21 @@ function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 function getNestedValue(source: Record<string, unknown>, path: string): unknown {
   return path.split(".").reduce<unknown>((current, segment) => {
-    if (!isPlainObject(current)) {
+    if (!isRecordLike(current)) {
       return undefined;
     }
     return current[segment];
   }, source);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isRecordLike(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }
 
 class QueryExpressionStateSource {

--- a/packages/runtime/src/executor/runtime-executor.ts
+++ b/packages/runtime/src/executor/runtime-executor.ts
@@ -1,0 +1,263 @@
+import type { QueryResultRow } from "@zhongmiao/meta-lc-datasource";
+import { resolveExpression } from "../dsl/expression";
+import { resolveExecutionOrder } from "../graph/dep-resolver";
+import { executeNode, type NodeExecutorDependencies } from "./node-executor";
+import {
+  type ExecutionNode,
+  type ExecutionPlan,
+  RuntimeExecutionError,
+  type RuntimeExecutionResult,
+  type RuntimeExecutionStage,
+  type RuntimeNodeResult,
+  type RuntimeQueryNodeResult,
+  type RuntimeStateStore,
+  type RuntimeValueNodeResult,
+  type RuntimeContext
+} from "../types";
+
+export interface RuntimeExecutorDependencies {
+  executors: NodeExecutorDependencies;
+}
+
+export class RuntimeExecutor {
+  async execute(
+    plan: ExecutionPlan,
+    context: RuntimeContext,
+    deps: RuntimeExecutorDependencies
+  ): Promise<RuntimeExecutionResult> {
+    const nodeById = buildNodeLookup(plan.nodes);
+    validatePlanCoverage(plan, nodeById);
+
+    let layers: string[][];
+    try {
+      layers = resolveExecutionOrder(plan.edges);
+    } catch (error) {
+      throw wrapRuntimeExecutionError("schedule", error);
+    }
+
+    let currentState: Record<string, unknown> = {};
+    const nodeResults: Record<string, RuntimeNodeResult> = {};
+    const executedLayers: string[][] = [];
+
+    for (const layer of layers) {
+      const layerSnapshot = cloneValue(currentState);
+      const layerState = createRuntimeStateStore(layerSnapshot);
+      const layerResults = await Promise.all(
+        layer.map(async (nodeId) => {
+          const node = nodeById.get(nodeId);
+          if (!node) {
+            throw new RuntimeExecutionError(
+              `Execution plan references unknown node "${nodeId}".`,
+              "schedule",
+              undefined,
+              nodeId
+            );
+          }
+
+          try {
+            const result = await executeNode(node, layerState, context, deps.executors);
+            return {
+              node,
+              nodeId,
+              result
+            };
+          } catch (error) {
+            throw wrapRuntimeExecutionError("execute", error, node);
+          }
+        })
+      );
+
+      const committedLayerResults: Record<string, RuntimeNodeResult> = {};
+      for (const { node, nodeId, result } of layerResults) {
+        const normalized = normalizeNodeResult(node, result, nodeId);
+        committedLayerResults[nodeId] = cloneValue(normalized);
+        nodeResults[nodeId] = cloneValue(normalized);
+      }
+
+      currentState = {
+        ...currentState,
+        ...committedLayerResults
+      };
+      executedLayers.push([...layer]);
+    }
+
+    let viewModel: Record<string, unknown>;
+    try {
+      viewModel = resolveExpression(plan.output, createRuntimeExpressionStateSource(currentState, context)) as Record<
+        string,
+        unknown
+      >;
+    } catch (error) {
+      throw wrapRuntimeExecutionError("output", error);
+    }
+
+    return {
+      viewModel: cloneValue(viewModel),
+      state: cloneValue(currentState),
+      nodeResults: cloneValue(nodeResults),
+      layers: executedLayers.map((layer) => [...layer])
+    };
+  }
+}
+
+function buildNodeLookup(nodes: ExecutionPlan["nodes"]): Map<string, ExecutionNode> {
+  return new Map(nodes.map((node) => [node.id, node]));
+}
+
+function validatePlanCoverage(plan: ExecutionPlan, nodeById: Map<string, ExecutionNode>): void {
+  for (const node of plan.nodes) {
+    if (!Object.prototype.hasOwnProperty.call(plan.edges, node.id)) {
+      throw new RuntimeExecutionError(
+        `Execution plan is missing dependencies for node "${node.id}".`,
+        "schedule",
+        undefined,
+        node.id,
+        node.type
+      );
+    }
+  }
+
+  for (const nodeId of Object.keys(plan.edges)) {
+    if (!nodeById.has(nodeId)) {
+      throw new RuntimeExecutionError(
+        `Execution plan references unknown node "${nodeId}" in edges.`,
+        "schedule",
+        undefined,
+        nodeId
+      );
+    }
+  }
+}
+
+function normalizeNodeResult(
+  node: ExecutionNode,
+  result: unknown,
+  nodeId: string
+): RuntimeNodeResult {
+  switch (node.type) {
+    case "query":
+      return normalizeQueryNodeResult(result, nodeId);
+    case "mutation":
+    case "merge":
+    case "transform":
+      return {
+        value: result
+      } satisfies RuntimeValueNodeResult;
+    default:
+      const unsupportedType = (node as { type: string }).type as ExecutionNode["type"];
+      throw new RuntimeExecutionError(
+        `Unsupported node type "${String(unsupportedType)}" in execution result normalization.`,
+        "execute",
+        undefined,
+        nodeId,
+        unsupportedType
+      );
+  }
+}
+
+function normalizeQueryNodeResult(result: unknown, nodeId: string): RuntimeQueryNodeResult {
+  if (Array.isArray(result)) {
+    return {
+      rows: result as QueryResultRow[],
+      row: (result[0] as QueryResultRow | undefined) ?? null
+    };
+  }
+
+  if (isPlainObject(result) && Array.isArray(result.rows)) {
+    const rows = result.rows as QueryResultRow[];
+    return {
+      rows,
+      row: (result.row as QueryResultRow | null | undefined) ?? (rows[0] ?? null)
+    };
+  }
+
+  throw new RuntimeExecutionError(
+    `Query node "${nodeId}" returned an invalid result shape.`,
+    "execute",
+    result,
+    nodeId,
+    "query"
+  );
+}
+
+function createRuntimeStateStore(snapshot: Record<string, unknown>): RuntimeStateStore {
+  return {
+    get(path: string): unknown {
+      if (!path.trim()) {
+        return undefined;
+      }
+
+      return getNestedValue(snapshot, path);
+    }
+  };
+}
+
+function createRuntimeExpressionStateSource(
+  snapshot: Record<string, unknown>,
+  context: RuntimeContext
+): RuntimeStateStore {
+  return {
+    get(path: string): unknown {
+      if (!path.trim()) {
+        return undefined;
+      }
+
+      const stateValue = getNestedValue(snapshot, path);
+      if (stateValue !== undefined) {
+        return stateValue;
+      }
+
+      return getNestedValue(context, path);
+    }
+  };
+}
+
+function getNestedValue(source: Record<string, unknown>, path: string): unknown {
+  return path.split(".").reduce<unknown>((current, segment) => {
+    if (!isRecordLike(current)) {
+      return undefined;
+    }
+    return current[segment];
+  }, source);
+}
+
+function wrapRuntimeExecutionError(
+  stage: RuntimeExecutionStage,
+  error: unknown,
+  node?: ExecutionNode
+): RuntimeExecutionError {
+  if (error instanceof RuntimeExecutionError) {
+    return error;
+  }
+
+  const message =
+    node && stage === "execute"
+      ? `RuntimeExecutor failed for node "${node.id}" (${node.type}): ${getErrorMessage(error)}`
+      : stage === "output"
+        ? `RuntimeExecutor failed while resolving output: ${getErrorMessage(error)}`
+        : `RuntimeExecutor failed while scheduling execution plan: ${getErrorMessage(error)}`;
+
+  return new RuntimeExecutionError(
+    message,
+    stage,
+    error,
+    node?.id,
+    node?.type
+  );
+}
+
+function cloneValue<T>(value: T): T {
+  return structuredClone(value);
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isRecordLike(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -5,6 +5,7 @@ export * from "./dsl/expression";
 export * from "./executor/node-executor";
 export * from "./executor/merge-executor";
 export * from "./executor/query-executor";
+export * from "./executor/runtime-executor";
 export * from "./adapter/query-adapter";
 export * from "./graph/dependency-graph";
 export * from "./graph/topo-sort";

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -13,6 +13,7 @@ import type {
   RuntimePageDsl,
   RuntimeTemplateDependency
 } from "@zhongmiao/meta-lc-contracts";
+import type { QueryResultRow } from "@zhongmiao/meta-lc-datasource";
 
 export type ViewExpression =
   | string
@@ -97,6 +98,39 @@ export type RuntimeContext = Record<string, unknown>;
 
 export interface RuntimeStateStore {
   get(path: string): unknown;
+}
+
+export type RuntimeExecutionStage = "schedule" | "execute" | "output";
+
+export interface RuntimeQueryNodeResult {
+  rows: QueryResultRow[];
+  row: QueryResultRow | null;
+}
+
+export interface RuntimeValueNodeResult {
+  value: unknown;
+}
+
+export type RuntimeNodeResult = RuntimeQueryNodeResult | RuntimeValueNodeResult;
+
+export interface RuntimeExecutionResult {
+  viewModel: Record<string, unknown>;
+  state: Record<string, unknown>;
+  nodeResults: Record<string, RuntimeNodeResult>;
+  layers: string[][];
+}
+
+export class RuntimeExecutionError extends Error {
+  constructor(
+    message: string,
+    public readonly stage: RuntimeExecutionStage,
+    public readonly cause?: unknown,
+    public readonly nodeId?: string,
+    public readonly nodeType?: ExecutionNode["type"]
+  ) {
+    super(message);
+    this.name = "RuntimeExecutionError";
+  }
 }
 
 export type DagEdges = Record<string, string[]>;

--- a/packages/runtime/test/runtime-executor.test.ts
+++ b/packages/runtime/test/runtime-executor.test.ts
@@ -1,0 +1,308 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  executeMergeNode,
+  RuntimeExecutionError,
+  RuntimeExecutor,
+  type ExecutionNode,
+  type ExecutionPlan,
+  type NodeExecutorDependencies,
+  type RuntimeContext
+} from "../src";
+
+const executor = new RuntimeExecutor();
+
+const runtimeContext: RuntimeContext = {
+  input: {
+    tenantId: "tenant-a",
+    userId: "user-1"
+  },
+  traceId: "trace-1"
+};
+
+function createExecutors(overrides: Partial<NodeExecutorDependencies> = {}): NodeExecutorDependencies {
+  return {
+    query: async () => {
+      throw new Error("query executor should be overridden in this test.");
+    },
+    mutation: async () => {
+      throw new Error("mutation executor should be overridden in this test.");
+    },
+    merge: async (node, state, context) => executeMergeNode(node as never, state, context),
+    transform: async () => {
+      throw new Error("transform executor should be overridden in this test.");
+    },
+    ...overrides
+  };
+}
+
+function createQueryNode(id: string, table: string): ExecutionNode {
+  return {
+    id,
+    type: "query",
+    definition: {
+      type: "query",
+      table
+    }
+  };
+}
+
+function createMergeNode(id: string, inputs: Record<string, string>): ExecutionNode {
+  return {
+    id,
+    type: "merge",
+    definition: {
+      type: "merge",
+      strategy: "objectMerge",
+      inputs
+    }
+  };
+}
+
+function createPlan(
+  nodes: ExecutionNode[],
+  edges: Record<string, string[]>,
+  output: ExecutionPlan["output"]
+): ExecutionPlan {
+  return {
+    nodes,
+    edges,
+    output
+  };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+test("RuntimeExecutor executes a single query plan and resolves output against the final snapshot", async () => {
+  const plan = createPlan(
+    [createQueryNode("orders", "orders")],
+    {
+      orders: []
+    },
+    {
+      rows: "{{orders.rows}}",
+      firstOrderId: "{{orders.row.id}}",
+      tenantId: "{{input.tenantId}}"
+    }
+  );
+
+  const result = await executor.execute(plan, runtimeContext, {
+    executors: createExecutors({
+      query: async (node) => [
+        {
+          id: `${node.table}-1`,
+          total: 42
+        }
+      ]
+    })
+  });
+
+  assert.deepEqual(result.layers, [["orders"]]);
+  assert.deepEqual(result.state, {
+    orders: {
+      rows: [
+        {
+          id: "orders-1",
+          total: 42
+        }
+      ],
+      row: {
+        id: "orders-1",
+        total: 42
+      }
+    }
+  });
+  assert.deepEqual(result.nodeResults.orders, {
+    rows: [
+      {
+        id: "orders-1",
+        total: 42
+      }
+    ],
+    row: {
+      id: "orders-1",
+      total: 42
+    }
+  });
+  assert.deepEqual(result.viewModel, {
+    rows: [
+      {
+        id: "orders-1",
+        total: 42
+      }
+    ],
+    firstOrderId: "orders-1",
+    tenantId: "tenant-a"
+  });
+
+  const snapshot = structuredClone(result);
+  (result.state.orders as { row: { id: string } }).row.id = "mutated";
+  assert.deepEqual(result.viewModel, snapshot.viewModel);
+  assert.deepEqual(result.nodeResults, snapshot.nodeResults);
+});
+
+test("RuntimeExecutor commits a layer atomically when one sibling fails", async () => {
+  const plan = createPlan(
+    [createQueryNode("alpha", "alpha"), createQueryNode("zeta", "zeta")],
+    {
+      alpha: [],
+      zeta: []
+    },
+    {
+      alpha: "{{alpha.rows}}",
+      zeta: "{{zeta.rows}}"
+    }
+  );
+
+  await assert.rejects(
+    () =>
+      executor.execute(plan, runtimeContext, {
+      executors: createExecutors({
+        query: async (node, state) => {
+          if (node.table === "alpha") {
+            await delay(10);
+            assert.equal(state.get("alpha"), undefined);
+            return [{ id: "alpha-1" }];
+          }
+
+          if (node.table === "zeta") {
+            await delay(20);
+            assert.equal(state.get("alpha"), undefined);
+            throw new Error("boom");
+            }
+
+            throw new Error(`Unexpected node "${node.id}".`);
+          }
+        })
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof RuntimeExecutionError);
+      assert.equal(error.stage, "execute");
+      assert.equal(error.nodeId, "zeta");
+      assert.equal(error.nodeType, "query");
+      assert.equal(error.cause instanceof Error ? error.cause.message : "", "boom");
+      assert.match(error.message, /RuntimeExecutor failed for node "zeta" \(query\): boom/);
+      return true;
+    }
+  );
+});
+
+test("RuntimeExecutor executes merge fan-in plans and preserves node envelopes", async () => {
+  const plan = createPlan(
+    [
+      createQueryNode("user", "users"),
+      createQueryNode("orders", "orders"),
+      createMergeNode("summary", {
+        user: "{{user.row}}",
+        orders: "{{orders.rows}}"
+      })
+    ],
+    {
+      user: [],
+      orders: [],
+      summary: ["orders", "user"]
+    },
+    {
+      summary: "{{summary.value}}",
+      userName: "{{summary.value.user.name}}",
+      orderCount: "{{summary.value.orders.length}}"
+    }
+  );
+
+  const result = await executor.execute(plan, runtimeContext, {
+    executors: createExecutors({
+      query: async (node) => {
+        if (node.table === "users") {
+          return [
+            {
+              id: "user-1",
+              name: "Ada"
+            }
+          ];
+        }
+
+        if (node.table === "orders") {
+          return [
+            {
+              id: "order-1",
+              total: 12
+            },
+            {
+              id: "order-2",
+              total: 34
+            }
+          ];
+        }
+
+        throw new Error(`Unexpected query node "${node.table}".`);
+      }
+    })
+  });
+
+  assert.deepEqual(result.layers, [["orders", "user"], ["summary"]]);
+  assert.deepEqual(result.state.summary, {
+    value: {
+      user: {
+        id: "user-1",
+        name: "Ada"
+      },
+      orders: [
+        {
+          id: "order-1",
+          total: 12
+        },
+        {
+          id: "order-2",
+          total: 34
+        }
+      ]
+    }
+  });
+  assert.deepEqual(result.viewModel, {
+    summary: {
+      user: {
+        id: "user-1",
+        name: "Ada"
+      },
+      orders: [
+        {
+          id: "order-1",
+          total: 12
+        },
+        {
+          id: "order-2",
+          total: 34
+        }
+      ]
+    },
+    userName: "Ada",
+    orderCount: 2
+  });
+});
+
+test("RuntimeExecutor handles empty plans against the provided context", async () => {
+  const result = await executor.execute(
+    {
+      nodes: [],
+      edges: {},
+      output: {
+        greeting: "hello {{input.userId}}",
+        traceId: "{{traceId}}"
+      }
+    },
+    runtimeContext,
+    {
+      executors: createExecutors()
+    }
+  );
+
+  assert.deepEqual(result.layers, []);
+  assert.deepEqual(result.state, {});
+  assert.deepEqual(result.nodeResults, {});
+  assert.deepEqual(result.viewModel, {
+    greeting: "hello user-1",
+    traceId: "trace-1"
+  });
+});


### PR DESCRIPTION
Closes #84

Summary:
- add RuntimeExecutor to schedule DAG layers and commit state snapshots atomically
- normalize node results and resolve output view models
- keep node execution delegated through injected executors

Validation:
- ./node_modules/.bin/tsc -p packages/runtime/tsconfig.json --pretty false
- node --test packages/runtime/dist/runtime/test/runtime-executor.test.js
- node --test "packages/runtime/dist/**/test/*.test.js"
- node --test scripts/check-boundaries.test.mjs
- node scripts/check-changelog-gate.mjs origin/main HEAD