### PR TITLE
feat(bff): add view gateway and temporary runtime adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- feat(bff): add a `POST /view/:name` gateway with a temporary runtime-backed adapter so page requests flow through the runtime executor.
+- fix(runtime): align the runtime package entrypoint with the refactored `dist/runtime/src` output so downstream packages can resolve it at runtime.
 - refactor(package-structure): reorganize the workspace packages into layered domain/application/infra/interface/types/utils directories and refresh boundary checks.
 - feat(runtime): add a RuntimeExecutor main engine that schedules DAG layers, commits state snapshots atomically, and resolves final view models.
 - feat(runtime): add a query executor adapter that compiles query nodes and runs datasource queries.

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- feat(bff): 新增 `POST /view/:name` gateway，并接入临时的 runtime-backed adapter，让页面请求进入 runtime 执行链路。
+- fix(runtime): 将 runtime 包入口对齐到重构后的 `dist/runtime/src` 输出，确保下游包在运行时可正确解析。
 - refactor(package-structure): 将工作区包重整为 domain/application/infra/interface/types/utils 分层目录，并同步刷新边界检查。
 - feat(runtime): 新增 RuntimeExecutor 主执行引擎，负责 DAG 分层调度、原子提交 state snapshot 并解析最终 view model。
 - feat(runtime): 新增 QueryExecutor 适配层，负责编译 query 节点并执行 datasource 查询。

--- a/packages/bff/CHANGELOG.md
+++ b/packages/bff/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- feat(gateway): add `POST /view/:name` and a temporary runtime-backed view adapter so BFF can route page requests through the runtime executor.
 - refactor(package-structure): reorganize src into layered domain/application/infra/interface/types/utils directories and update public entrypoints.
 - docs(readme): add bilingual package README and minimal architecture flow.
 - feat(gateway): add meta API, in-memory cache, aggregation summary, and WebSocket lifecycle baseline.

--- a/packages/bff/CHANGELOG.zh-CN.md
+++ b/packages/bff/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- feat(gateway): 新增 `POST /view/:name`，并加入临时的 runtime-backed view adapter，让 BFF 的页面请求进入 runtime 执行链路。
 - refactor(package-structure): 将 src 重整为 domain/application/infra/interface/types/utils 分层目录，并同步更新对外入口。
 - docs(readme): 新增双语子包 README 与最小架构流程图。
 - feat(gateway): 新增 meta API、内存 cache、aggregation summary 与 WebSocket lifecycle 基线。

--- a/packages/bff/package.json
+++ b/packages/bff/package.json
@@ -5,7 +5,7 @@
   "type": "commonjs",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "npm run build && node --test \"dist/**/test/*.test.js\"",
+    "test": "pnpm --filter @zhongmiao/meta-lc-runtime build && npm run build && node --test \"dist/**/test/*.test.js\"",
     "lint": "echo lint:bff",
     "start": "sh -c 'if [ -f ../../.env ]; then exec node --env-file=../../.env dist/bff/src/interface/bootstrap/main.js; else exec node dist/bff/src/interface/bootstrap/main.js; fi'"
   },
@@ -18,6 +18,7 @@
     "@zhongmiao/meta-lc-contracts": "workspace:*",
     "@zhongmiao/meta-lc-permission": "workspace:*",
     "@zhongmiao/meta-lc-query": "workspace:*",
+    "@zhongmiao/meta-lc-runtime": "workspace:*",
     "@zhongmiao/meta-lc-shared": "workspace:*",
     "pg": "^8.13.1",
     "redis": "^4.7.1",

--- a/packages/bff/src/application/index.ts
+++ b/packages/bff/src/application/index.ts
@@ -2,3 +2,4 @@ export * from "./orchestrator/aggregation.service";
 export * from "./orchestrator/mutation-orchestrator.service";
 export * from "./orchestrator/query-orchestrator.service";
 export * from "./orchestrator/query-pipeline.service";
+export * from "./view/temporary-view-adapter.service";

--- a/packages/bff/src/application/view/temporary-view-adapter.service.ts
+++ b/packages/bff/src/application/view/temporary-view-adapter.service.ts
@@ -1,0 +1,220 @@
+import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
+import {
+  compileViewDefinition,
+  executeMergeNode,
+  executeMutationNode,
+  executeQueryNode,
+  executeSubmitPlan,
+  resolveExpression,
+  type RuntimeContext,
+  type RuntimeExecutionResult,
+  type RuntimeStateStore,
+  type ViewDefinition,
+  type RuntimeExecutorDependencies
+} from "@zhongmiao/meta-lc-runtime";
+import { MetaRegistryService } from "../../interface/gateway/meta-registry.service";
+import { OrgScopeService } from "../../infra/integration/org-scope.service";
+import { PostgresQueryExecutorService } from "../../infra/integration/postgres-query-executor.service";
+import type { ViewApiRequest } from "../../types";
+
+export interface TemporaryViewExecutionResult {
+  requestId: string;
+  viewName: string;
+  runtime: RuntimeExecutionResult;
+}
+
+@Injectable()
+export class TemporaryViewAdapter {
+  constructor(
+    private readonly registry: MetaRegistryService,
+    private readonly queryExecutor: PostgresQueryExecutorService,
+    private readonly orgScopeService: OrgScopeService
+  ) {}
+
+  async execute(viewName: string, request: ViewApiRequest, requestId: string): Promise<TemporaryViewExecutionResult> {
+    const view = this.lookupView(viewName);
+    const runtimeContext = await this.buildRuntimeContext(request, requestId, viewName);
+    const plan = compileViewDefinition(view);
+    const runtime = await executeSubmitPlan(plan, runtimeContext, {
+      executors: this.createNodeExecutors()
+    });
+
+    return {
+      requestId,
+      viewName,
+      runtime
+    };
+  }
+
+  private lookupView(viewName: string): ViewDefinition {
+    const view = this.registry.getView(viewName);
+    if (!view) {
+      throw new NotFoundException(`view "${viewName}" not found`);
+    }
+    return view;
+  }
+
+  private async buildRuntimeContext(
+    request: ViewApiRequest,
+    requestId: string,
+    viewName: string
+  ): Promise<RuntimeContext> {
+    this.ensureAuthRequest(request);
+    const orgScope = await this.orgScopeService.resolveContext({
+      tenantId: request.tenantId,
+      userId: request.userId,
+      roles: request.roles
+    });
+    const requestContext = {
+      requestId,
+      tenantId: request.tenantId,
+      userId: request.userId,
+      roles: [...request.roles],
+      ...(request.context ?? {})
+    };
+
+    return {
+      requestId,
+      viewName,
+      tenantId: request.tenantId,
+      userId: request.userId,
+      roles: [...request.roles],
+      input: { ...(request.input ?? {}) },
+      ...(request.context ?? {}),
+      context: requestContext,
+      auth: {
+        tenantId: request.tenantId,
+        userId: request.userId,
+        roles: [...request.roles]
+      },
+      orgScope
+    };
+  }
+
+  private ensureAuthRequest(request: ViewApiRequest): void {
+    if (!request.tenantId?.trim() || !request.userId?.trim()) {
+      throw new BadRequestException("tenantId and userId are required.");
+    }
+    if (!Array.isArray(request.roles)) {
+      throw new BadRequestException("roles must be an array.");
+    }
+  }
+
+  private createNodeExecutors(): RuntimeExecutorDependencies["executors"] {
+    const queryExecutor = this.queryExecutor;
+    return {
+      query: async (node, state, context) =>
+        executeQueryNode(node, state, context, {
+          datasource: {
+            async query(sql, params = []) {
+              return queryExecutor.query(sql, params);
+            }
+          }
+        }),
+      mutation: async (node, state, context) =>
+        executeMutationNode(node, state, context, {
+          adapter: {
+            async execute(command) {
+              if (command.model !== "orders") {
+                throw new BadRequestException(`unsupported mutation model "${command.model}"`);
+              }
+
+              const payload = command.payload as Record<string, unknown>;
+              const id = readRequiredString(payload.id, "payload.id");
+              const orgId = readNullableString(payload.orgId ?? null, "payload.orgId");
+              const owner = readOptionalString(payload.owner, "payload.owner");
+              const channel = readOptionalString(payload.channel, "payload.channel");
+              const priority = readOptionalString(payload.priority, "payload.priority");
+              const status = readOptionalString(payload.status, "payload.status");
+
+              if (command.operation !== "delete" && !owner) {
+                throw new BadRequestException("payload.owner is required for orders mutation.");
+              }
+
+              const result = await queryExecutor.mutateOrder({
+                operation: command.operation,
+                tenantId: String(command.context.tenantId ?? ""),
+                userId: String(command.context.userId ?? ""),
+                superAdmin: Array.isArray(command.context.roles)
+                  ? command.context.roles.includes("SUPER_ADMIN")
+                  : false,
+                orgId,
+                payload: {
+                  id,
+                  orgId,
+                  ...(owner ? { owner } : {}),
+                  ...(channel ? { channel } : {}),
+                  ...(priority ? { priority } : {}),
+                  ...(status ? { status } : {})
+                }
+              });
+
+              return {
+                rowCount: result.rowCount,
+                row: result.afterData ?? result.beforeData,
+                beforeData: result.beforeData,
+                afterData: result.afterData
+              };
+            }
+          }
+        }),
+      merge: async (node, state, context) => executeMergeNode(node, state, context),
+      transform: async (node, state, context) =>
+        resolveExpression(node.definition as never, createExpressionStateSource(state, context))
+    };
+  }
+}
+
+function createExpressionStateSource(state: RuntimeStateStore, context: RuntimeContext) {
+  return {
+    get(path: string): unknown {
+      if (!path.trim()) {
+        return undefined;
+      }
+
+      const stateValue = state.get(path);
+      if (stateValue !== undefined) {
+        return stateValue;
+      }
+
+      return getNestedValue(context, path);
+    }
+  };
+}
+
+function getNestedValue(source: Record<string, unknown>, path: string): unknown {
+  return path.split(".").reduce<unknown>((current, segment) => {
+    if (!isRecordLike(current)) {
+      return undefined;
+    }
+    return current[segment];
+  }, source);
+}
+
+function readRequiredString(value: unknown, key: string): string {
+  const result = readOptionalString(value, key);
+  if (!result) {
+    throw new BadRequestException(`${key} is required.`);
+  }
+  return result;
+}
+
+function readOptionalString(value: unknown, key: string): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    throw new BadRequestException(`${key} must be a string.`);
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function readNullableString(value: unknown, key: string): string | null {
+  const result = readOptionalString(value, key);
+  return result ?? null;
+}
+
+function isRecordLike(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/packages/bff/src/interface/bootstrap/app.module.ts
+++ b/packages/bff/src/interface/bootstrap/app.module.ts
@@ -7,6 +7,7 @@ import { AuditLogService } from "../common/audit-log.service";
 import { HttpExceptionFilter } from "../common/http-exception.filter";
 import { MetaController } from "../gateway/meta.controller";
 import { MetaRegistryService } from "../gateway/meta-registry.service";
+import { ViewController } from "../gateway/view.controller";
 import {
   createRuntimeWsBroadcastBusFromEnv,
   parseRuntimeWsBroadcastBusMode,
@@ -27,10 +28,11 @@ import { OrgScopeService } from "../../infra/integration/org-scope.service";
 import { PostgresQueryExecutorService } from "../../infra/integration/postgres-query-executor.service";
 import { MutationOrchestratorService } from "../../application/orchestrator/mutation-orchestrator.service";
 import { QueryOrchestratorService } from "../../application/orchestrator/query-orchestrator.service";
+import { TemporaryViewAdapter } from "../../application/view/temporary-view-adapter.service";
 
 @Module({
   imports: [],
-  controllers: [QueryController, MetaController, RuntimeWsHealthController],
+  controllers: [QueryController, ViewController, MetaController, RuntimeWsHealthController],
   providers: [
     AggregationService,
     CacheService,
@@ -40,6 +42,7 @@ import { QueryOrchestratorService } from "../../application/orchestrator/query-o
     AuditPersistenceService,
     QueryOrchestratorService,
     MutationOrchestratorService,
+    TemporaryViewAdapter,
     AuditLogService,
     {
       provide: RUNTIME_WS_INSTANCE_ID,

--- a/packages/bff/src/interface/gateway/meta-registry.service.ts
+++ b/packages/bff/src/interface/gateway/meta-registry.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from "@nestjs/common";
+import type { ViewDefinition } from "@zhongmiao/meta-lc-runtime";
 
 export type MetaResourceKind = "tables" | "pages" | "datasources" | "rules" | "permissions";
 
@@ -10,6 +11,30 @@ export interface MetaRegistryItem {
 }
 
 const UPDATED_AT = "2026-04-20T00:00:00.000Z";
+const VIEW_FIXTURES: Record<string, ViewDefinition> = {
+  "orders-workbench": {
+    name: "orders-workbench",
+    nodes: {
+      orders: {
+        type: "query",
+        table: "orders",
+        fields: ["id", "owner", "channel", "priority", "status"],
+        filters: {
+          tenant_id: "{{context.tenantId}}",
+          owner: "{{input.owner}}",
+          created_by: "{{context.userId}}"
+        },
+        limit: "{{input.limit}}"
+      }
+    },
+    output: {
+      requestId: "{{context.requestId}}",
+      tenantId: "{{context.tenantId}}",
+      owner: "{{input.owner}}",
+      rows: "{{orders.rows}}"
+    }
+  }
+};
 
 const FIXTURES: Record<MetaResourceKind, MetaRegistryItem[]> = {
   tables: [
@@ -62,5 +87,14 @@ export class MetaRegistryService {
 
   listKinds(): MetaResourceKind[] {
     return ["tables", "pages", "datasources", "rules", "permissions"];
+  }
+
+  getView(name: string): ViewDefinition | null {
+    const view = VIEW_FIXTURES[name];
+    return view ? structuredClone(view) : null;
+  }
+
+  listViewNames(): string[] {
+    return Object.keys(VIEW_FIXTURES).sort((left, right) => left.localeCompare(right));
   }
 }

--- a/packages/bff/src/interface/gateway/view.controller.ts
+++ b/packages/bff/src/interface/gateway/view.controller.ts
@@ -1,0 +1,42 @@
+import { Body, Controller, InternalServerErrorException, Param, Post, Req, Res } from "@nestjs/common";
+import { HttpException } from "@nestjs/common";
+import { resolveRequestId } from "../common/request-id";
+import { TemporaryViewAdapter } from "../../application/view/temporary-view-adapter.service";
+import type { ViewApiRequest, ViewApiResponse } from "../../types";
+
+interface RequestLike {
+  headers: Record<string, string | string[] | undefined>;
+}
+
+interface ResponseLike {
+  setHeader(name: string, value: string): void;
+}
+
+@Controller()
+export class ViewController {
+  constructor(private readonly temporaryViewAdapter: TemporaryViewAdapter) {}
+
+  @Post("view/:name")
+  async executeView(
+    @Param("name") name: string,
+    @Body() request: ViewApiRequest,
+    @Req() req: RequestLike,
+    @Res({ passthrough: true }) res: ResponseLike
+  ): Promise<ViewApiResponse> {
+    const requestId = resolveRequestId(req.headers["x-request-id"]);
+    res.setHeader("x-request-id", requestId);
+
+    try {
+      const result = await this.temporaryViewAdapter.execute(name, request, requestId);
+      return {
+        requestId,
+        viewModel: result.runtime.viewModel
+      };
+    } catch (error) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      throw new InternalServerErrorException(`runtime execution failed for view "${name}"`);
+    }
+  }
+}

--- a/packages/bff/src/interface/index.ts
+++ b/packages/bff/src/interface/index.ts
@@ -11,6 +11,7 @@ export * from "./common/request-id";
 export * from "./gateway/meta-registry.service";
 export * from "./gateway/meta.controller";
 export * from "./gateway/query.controller";
+export * from "./gateway/view.controller";
 export * from "./gateway/runtime-ws-broadcast.bus";
 export * from "./gateway/runtime-ws-health.controller";
 export * from "./gateway/runtime-ws-operations.state";

--- a/packages/bff/src/types/index.ts
+++ b/packages/bff/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from "./shared.types";
 export * from "./config";
+export * from "./view.types";

--- a/packages/bff/src/types/view.types.ts
+++ b/packages/bff/src/types/view.types.ts
@@ -1,0 +1,12 @@
+export interface ViewApiRequest {
+  tenantId: string;
+  userId: string;
+  roles: string[];
+  input?: Record<string, unknown>;
+  context?: Record<string, unknown>;
+}
+
+export interface ViewApiResponse {
+  requestId: string;
+  viewModel: Record<string, unknown>;
+}

--- a/packages/bff/test/temporary-view-adapter.test.ts
+++ b/packages/bff/test/temporary-view-adapter.test.ts
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { NotFoundException } from "@nestjs/common";
+import { TemporaryViewAdapter } from "../src/application/view/temporary-view-adapter.service";
+import { MetaRegistryService } from "../src/interface/gateway/meta-registry.service";
+
+test("temporary view adapter executes runtime view and propagates context into the query node", async () => {
+  const queryCalls: Array<{ sql: string; params: Array<string | number | boolean> }> = [];
+  const registry = new MetaRegistryService();
+  const adapter = new TemporaryViewAdapter(
+    registry,
+    {
+      async query(sql: string, params: Array<string | number | boolean>) {
+        queryCalls.push({ sql, params });
+        return [
+          {
+            id: "order-1",
+            owner: "Ada",
+            channel: "web",
+            priority: "medium",
+            status: "active"
+          }
+        ];
+      },
+      async health() {
+        return true;
+      },
+      async mutateOrder() {
+        throw new Error("mutation should not be called for the fixture view");
+      },
+      async findOrderById() {
+        return null;
+      }
+    } as never,
+    {
+      async resolveContext(input: { tenantId: string; userId: string; roles: string[] }) {
+        assert.deepEqual(input, {
+          tenantId: "tenant-a",
+          userId: "user-a",
+          roles: ["USER"]
+        });
+        return {
+          tenantId: input.tenantId,
+          userId: input.userId,
+          roles: input.roles,
+          userOrgIds: ["dept-a"],
+          rolePolicies: [],
+          orgNodes: []
+        };
+      }
+    } as never
+  );
+
+  const result = await adapter.execute(
+    "orders-workbench",
+    {
+      tenantId: "tenant-a",
+      userId: "user-a",
+      roles: ["USER"],
+      input: {
+        owner: "Ada",
+        limit: 2
+      },
+      context: {
+        locale: "zh-CN"
+      }
+    },
+    "req-view-1"
+  );
+
+  assert.equal(result.requestId, "req-view-1");
+  assert.equal(result.viewName, "orders-workbench");
+  assert.deepEqual(queryCalls, [
+    {
+      sql: 'SELECT "id", "owner", "channel", "priority", "status" FROM "orders" WHERE "tenant_id" = $1 AND "owner" = $2 AND "created_by" = $3 LIMIT 2',
+      params: ["tenant-a", "Ada", "user-a"]
+    }
+  ]);
+  assert.deepEqual(result.runtime.viewModel, {
+    requestId: "req-view-1",
+    tenantId: "tenant-a",
+    owner: "Ada",
+    rows: [
+      {
+        id: "order-1",
+        owner: "Ada",
+        channel: "web",
+        priority: "medium",
+        status: "active"
+      }
+    ]
+  });
+});
+
+test("temporary view adapter returns a stable 404 when the view is missing", async () => {
+  const adapter = new TemporaryViewAdapter(
+    new MetaRegistryService(),
+    {
+      async query() {
+        throw new Error("should not be called");
+      },
+      async health() {
+        return true;
+      },
+      async mutateOrder() {
+        throw new Error("should not be called");
+      },
+      async findOrderById() {
+        return null;
+      }
+    } as never,
+    {
+      async resolveContext() {
+        return {
+          tenantId: "tenant-a",
+          userId: "user-a",
+          roles: ["USER"],
+          userOrgIds: [],
+          rolePolicies: [],
+          orgNodes: []
+        };
+      }
+    } as never
+  );
+
+  await assert.rejects(
+    () =>
+      adapter.execute(
+        "missing-view",
+        {
+          tenantId: "tenant-a",
+          userId: "user-a",
+          roles: ["USER"]
+        },
+        "req-view-2"
+      ),
+    (error: unknown) => {
+      assert.ok(error instanceof NotFoundException);
+      assert.equal(error.message, 'view "missing-view" not found');
+      return true;
+    }
+  );
+});

--- a/packages/bff/test/view-gateway.test.ts
+++ b/packages/bff/test/view-gateway.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { InternalServerErrorException, NotFoundException } from "@nestjs/common";
+import { ViewController } from "../src/interface/gateway/view.controller";
+import type { ViewApiRequest } from "../src/types";
+
+test("view controller returns the runtime view model and request id", async () => {
+  const headers: Record<string, string> = {};
+  const controller = new ViewController({
+    async execute() {
+      return {
+        requestId: "req-from-adapter",
+        viewName: "orders-workbench",
+        runtime: {
+          viewModel: {
+            rows: [{ id: "order-1" }]
+          }
+        }
+      };
+    }
+  } as never);
+
+  const result = await controller.executeView(
+    "orders-workbench",
+    request({
+      tenantId: "tenant-a",
+      userId: "user-a",
+      roles: ["USER"]
+    }),
+    { headers: { "x-request-id": "req-view-1" } },
+    response(headers)
+  );
+
+  assert.equal(headers["x-request-id"], "req-view-1");
+  assert.deepEqual(result, {
+    requestId: "req-view-1",
+    viewModel: {
+      rows: [{ id: "order-1" }]
+    }
+  });
+});
+
+test("view controller passes 404s through and maps runtime errors to a stable 500", async () => {
+  const missingController = new ViewController({
+    async execute() {
+      throw new NotFoundException('view "missing-view" not found');
+    }
+  } as never);
+  const runtimeFailController = new ViewController({
+    async execute() {
+      throw new Error("boom");
+    }
+  } as never);
+
+  await assert.rejects(
+    () =>
+      missingController.executeView(
+        "missing-view",
+        request({
+          tenantId: "tenant-a",
+          userId: "user-a",
+          roles: ["USER"]
+        }),
+        { headers: {} },
+        response({})
+      ),
+    (error: unknown) => {
+      assert.ok(error instanceof NotFoundException);
+      return true;
+    }
+  );
+
+  await assert.rejects(
+    () =>
+      runtimeFailController.executeView(
+        "orders-workbench",
+        request({
+          tenantId: "tenant-a",
+          userId: "user-a",
+          roles: ["USER"]
+        }),
+        { headers: {} },
+        response({})
+      ),
+    (error: unknown) => {
+      assert.ok(error instanceof InternalServerErrorException);
+      assert.equal(error.message, 'runtime execution failed for view "orders-workbench"');
+      return true;
+    }
+  );
+});
+
+function request(body: ViewApiRequest): ViewApiRequest {
+  return body;
+}
+
+function response(headers: Record<string, string>): { setHeader(name: string, value: string): void } {
+  return {
+    setHeader(name: string, value: string): void {
+      headers[name] = value;
+    }
+  };
+}

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- fix(package): align the runtime package main/types entrypoint with the refactored dist/runtime/src layout so downstream packages can resolve it at runtime.
 - refactor(package-structure): reorganize src into layered domain/application/infra/interface/types/utils directories and update public entrypoints.
 - feat(runtime): add a RuntimeExecutor main engine that schedules DAG layers, commits state snapshots atomically, and resolves final view models.
 - feat(runtime): add a merge executor for V2 fan-in strategies and custom merge hooks.

--- a/packages/runtime/CHANGELOG.zh-CN.md
+++ b/packages/runtime/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- fix(package): 将 runtime 包的 main/types 入口对齐到重构后的 `dist/runtime/src` 目录，确保下游包可在运行时正确解析。
 - refactor(package-structure): 将 src 重整为 domain/application/infra/interface/types/utils 分层目录，并同步更新对外入口。
 - feat(runtime): 新增 RuntimeExecutor 主执行引擎，负责 DAG 分层调度、原子提交 state snapshot 并解析最终 view model。
 - feat(runtime): 新增 merge 执行器，支持 V2 fan-in 策略与自定义 merge hook。

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -17,6 +17,6 @@
     "@types/node": "^22.10.2",
     "typescript": "^5.7.2"
   },
-  "main": "dist/src/index.js",
-  "types": "dist/src/index.d.ts"
+  "main": "dist/runtime/src/index.js",
+  "types": "dist/runtime/src/index.d.ts"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,9 @@ importers:
       '@zhongmiao/meta-lc-query':
         specifier: workspace:*
         version: link:../query
+      '@zhongmiao/meta-lc-runtime':
+        specifier: workspace:*
+        version: link:../runtime
       '@zhongmiao/meta-lc-shared':
         specifier: workspace:*
         version: link:../shared


### PR DESCRIPTION
Closes #86

Summary:
- add POST /view/:name gateway and temporary runtime adapter
- wire MetaRegistryService view fixtures into runtime execution
- align runtime package entrypoint with refactored dist/runtime/src layout

Validation:
- pnpm --filter @zhongmiao/meta-lc-bff test
- pnpm test
- pnpm lint
- pnpm query-gate