### PR TITLE
refactor(bff): extract view request contracts

### DIFF
--- a/packages/bff/src/interface/gateway/view.controller.ts
+++ b/packages/bff/src/interface/gateway/view.controller.ts
@@ -3,14 +3,7 @@ import { HttpException } from "@nestjs/common";
 import { resolveRequestId } from "../common/request-id";
 import { TemporaryViewAdapter } from "../../application/view/temporary-view-adapter.service";
 import type { ViewApiRequest, ViewApiResponse } from "../../application/view/view.contract";
-
-interface RequestLike {
-  headers: Record<string, string | string[] | undefined>;
-}
-
-interface ResponseLike {
-  setHeader(name: string, value: string): void;
-}
+import type { ViewRequestLike, ViewResponseLike } from "./view.http";
 
 @Controller()
 export class ViewController {
@@ -20,8 +13,8 @@ export class ViewController {
   async executeView(
     @Param("name") name: string,
     @Body() request: ViewApiRequest,
-    @Req() req: RequestLike,
-    @Res({ passthrough: true }) res: ResponseLike
+    @Req() req: ViewRequestLike,
+    @Res({ passthrough: true }) res: ViewResponseLike
   ): Promise<ViewApiResponse> {
     const requestId = resolveRequestId(req.headers["x-request-id"]);
     res.setHeader("x-request-id", requestId);

--- a/packages/bff/src/interface/gateway/view.http.ts
+++ b/packages/bff/src/interface/gateway/view.http.ts
@@ -1,0 +1,7 @@
+export interface ViewRequestLike {
+  headers: Record<string, string | string[] | undefined>;
+}
+
+export interface ViewResponseLike {
+  setHeader(name: string, value: string): void;
+}

--- a/packages/bff/src/interface/index.ts
+++ b/packages/bff/src/interface/index.ts
@@ -12,6 +12,7 @@ export * from "./gateway/meta-registry.service";
 export * from "./gateway/meta.controller";
 export * from "./gateway/query.controller";
 export * from "./gateway/view.controller";
+export * from "./gateway/view.http";
 export * from "./gateway/runtime-ws-broadcast.bus";
 export * from "./gateway/runtime-ws-health.controller";
 export * from "./gateway/runtime-ws-operations.state";


### PR DESCRIPTION
Refs #86

This follow-up moves the remaining controller-local HTTP interfaces into `src/interface/gateway/view.http.ts` so the controller stays behavior-only.