### PR TITLE
feat(query): add AST-first select compiler

### DIFF
--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- feat(query-ast): add AST-first select query builder and SQL compiler while keeping the legacy request entrypoint.
 - refactor(package-structure): reorganize src into layered domain/application/infra/interface/types/utils directories and update public entrypoints.
 - docs(readme): add bilingual package README and minimal architecture flow.
 - chore(package): adopt the `@zhongmiao/meta-lc-query` scoped package identity for release governance.

--- a/packages/query/CHANGELOG.zh-CN.md
+++ b/packages/query/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- feat(query-ast): 新增 AST-first select query builder 与 SQL compiler，同时保留旧 request 入口兼容。
 - refactor(package-structure): 将 src 重整为 domain/application/infra/interface/types/utils 分层目录，并同步更新对外入口。
 - docs(readme): 新增双语子包 README 与最小架构流程图。
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-query` 正式包名。

--- a/packages/query/README.md
+++ b/packages/query/README.md
@@ -4,29 +4,31 @@ English | [中文文档](./README_zh.md)
 
 ## Package Role
 
-`query` compiles platform query DSL into SQL and parameter lists. It is a compiler package, not a database executor.
+`query` compiles platform query AST into SQL and parameter lists. It is an AST-first compiler package, not a database executor or orchestration layer.
 
 ## Responsibilities
 
-- Define query compiler input and output types.
-- Convert table, fields, filters, and limit into safe SQL fragments.
+- Define query AST, compiler input, and output types.
+- Build `SelectQueryAst` from legacy query requests for compatibility.
+- Convert AST table, fields, predicates, and limit into safe SQL fragments.
 - Keep SQL generation testable without a live database.
 
 ## Relationship With Other Packages
 
-- `bff` calls query compilation before datasource execution.
-- `permission` decisions can contribute filters or scope constraints before final query execution.
+- `runtime` calls query compilation through its query compiler adapter before datasource execution.
+- `permission` can later transform query AST before final SQL compilation.
 - `datasource` executes compiled SQL; `query` does not depend on `datasource`.
-- `contracts` provides the API request shapes that BFF adapts into query compiler input.
+- `contracts` provides V2 query node shapes that runtime adapts into query compiler input.
 
 ## Minimal Flow
 
 ```mermaid
 flowchart LR
-  Request["QueryApiRequest"] --> BFF["BFF adapter"]
-  BFF --> Compiler["QueryCompiler"]
+  Request["QueryRequest compatibility input"] --> AstBuilder["Query AST Builder"]
+  AstBuilder --> Ast["SelectQueryAst"]
+  Ast --> Compiler["AST SQL Compiler"]
   Compiler --> Sql["SQL + params"]
-  Sql --> Executor["BFF datasource executor"]
+  Sql --> Executor["Datasource adapter"]
 ```
 
 ## Commands
@@ -39,4 +41,5 @@ pnpm --filter @zhongmiao/meta-lc-query test
 ## Boundary Notes
 
 - Do not open DB connections here.
-- Keep permission policy resolution outside this package; consume already-resolved filters or constraints.
+- Do not add runtime orchestration or BFF page request semantics here.
+- Keep permission policy resolution outside this package; consume AST predicates or later permission-transformed AST.

--- a/packages/query/README_zh.md
+++ b/packages/query/README_zh.md
@@ -4,29 +4,31 @@
 
 ## 包定位
 
-`query` 将平台 Query DSL 编译成 SQL 与参数列表。它是 compiler 包，不是数据库执行器。
+`query` 将平台 Query AST 编译成 SQL 与参数列表。它是 AST-first compiler 包，不是数据库执行器，也不是编排层。
 
 ## 核心职责
 
-- 定义 query compiler 的输入与输出类型。
-- 将 table、fields、filters、limit 转成安全 SQL 片段。
+- 定义 Query AST、compiler 输入与输出类型。
+- 为兼容旧调用，将 `QueryRequest` 构建为 `SelectQueryAst`。
+- 将 AST table、fields、predicates、limit 转成安全 SQL 片段。
 - 保持 SQL 生成逻辑可在无数据库环境下测试。
 
 ## 与其他包关系
 
-- `bff` 在 datasource 执行前调用 query compiler。
-- `permission` 的决策可以在最终执行前贡献 filters 或数据域约束。
+- `runtime` 通过 query compiler adapter 在 datasource 执行前调用 query compiler。
+- `permission` 后续可以在最终 SQL 编译前 transform query AST。
 - `datasource` 执行编译后的 SQL；`query` 不依赖 `datasource`。
-- `contracts` 提供 API request 形状，由 BFF 适配为 compiler input。
+- `contracts` 提供 V2 query node 形状，由 runtime 适配为 compiler input。
 
 ## 最小闭环
 
 ```mermaid
 flowchart LR
-  Request["QueryApiRequest"] --> BFF["BFF adapter"]
-  BFF --> Compiler["QueryCompiler"]
+  Request["QueryRequest 兼容输入"] --> AstBuilder["Query AST Builder"]
+  AstBuilder --> Ast["SelectQueryAst"]
+  Ast --> Compiler["AST SQL Compiler"]
   Compiler --> Sql["SQL + params"]
-  Sql --> Executor["BFF datasource executor"]
+  Sql --> Executor["Datasource adapter"]
 ```
 
 ## 常用命令
@@ -39,4 +41,5 @@ pnpm --filter @zhongmiao/meta-lc-query test
 ## 边界约束
 
 - 不在这里打开数据库连接。
-- 权限策略解析留在包外；本包消费已经解析好的 filters 或约束。
+- 不在这里新增 runtime orchestration 或 BFF 页面请求语义。
+- 权限策略解析留在包外；本包消费 AST predicates 或后续 permission-transformed AST。

--- a/packages/query/src/domain/query-compiler.ts
+++ b/packages/query/src/domain/query-compiler.ts
@@ -1,44 +1,18 @@
-import type { CompiledQuery, QueryRequest } from "../types/shared.types";
+import type {
+  CompiledQuery,
+  QueryComparisonPredicate,
+  QueryFieldRef,
+  QueryLogicalPredicate,
+  QueryPredicate,
+  QueryRequest,
+  QueryScalarValue,
+  QuerySelectItem,
+  QueryTableRef,
+  SelectQueryAst
+} from "../types/shared.types";
 
-function quoteIdentifier(value: string): string {
-  if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(value)) {
-    throw new Error(`Invalid identifier: ${value}`);
-  }
-  return `"${value}"`;
-}
-
-export function compileSelectQuery(request: QueryRequest): CompiledQuery {
-  if (!request.fields.length) {
-    throw new Error("At least one field is required.");
-  }
-
-  const params: Array<string | number | boolean> = [];
-  const quotedFields = request.fields.map(quoteIdentifier).join(", ");
-  const quotedTable = quoteIdentifier(request.table);
-  const whereParts: string[] = [];
-
-  for (const [key, value] of Object.entries(request.filters ?? {})) {
-    if (key === "keyword" && typeof value === "string" && value.trim()) {
-      const likeParamIndex = params.push(`%${value.trim()}%`);
-      whereParts.push(`("id" ILIKE $${likeParamIndex} OR "owner" ILIKE $${likeParamIndex})`);
-      continue;
-    }
-
-    if (!SUPPORTED_EXACT_FILTERS.has(key)) {
-      continue;
-    }
-
-    params.push(value);
-    whereParts.push(`${quoteIdentifier(key)} = $${params.length}`);
-  }
-
-  const whereSql = whereParts.length > 0 ? ` WHERE ${whereParts.join(" AND ")}` : "";
-  const limit = Number.isFinite(request.limit) ? Math.max(1, Number(request.limit)) : 100;
-  const sql = `SELECT ${quotedFields} FROM ${quotedTable}${whereSql} LIMIT ${limit}`;
-
-  return { sql, params };
-}
-
+const DEFAULT_LIMIT = 100;
+const KEYWORD_SEARCH_FIELDS = ["id", "owner"] as const;
 const SUPPORTED_EXACT_FILTERS = new Set([
   "status",
   "owner",
@@ -48,3 +22,134 @@ const SUPPORTED_EXACT_FILTERS = new Set([
   "tenant_id",
   "created_by"
 ]);
+
+function quoteIdentifier(value: string): string {
+  if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(value)) {
+    throw new Error(`Invalid identifier: ${value}`);
+  }
+  return `"${value}"`;
+}
+
+export function buildSelectQueryAst(request: QueryRequest): SelectQueryAst {
+  if (!request.fields.length) {
+    throw new Error("At least one field is required.");
+  }
+
+  const predicates: QueryPredicate[] = [];
+
+  for (const [key, value] of Object.entries(request.filters ?? {})) {
+    if (key === "keyword" && typeof value === "string" && value.trim()) {
+      const keyword = `%${value.trim()}%`;
+      predicates.push({
+        type: "logical",
+        operator: "or",
+        predicates: KEYWORD_SEARCH_FIELDS.map((field) => ({
+          type: "comparison",
+          left: { name: field },
+          operator: "ilike",
+          value: keyword
+        }))
+      });
+      continue;
+    }
+
+    if (!SUPPORTED_EXACT_FILTERS.has(key)) {
+      continue;
+    }
+
+    predicates.push({
+      type: "comparison",
+      left: { name: key },
+      operator: "eq",
+      value
+    });
+  }
+
+  return {
+    type: "select",
+    table: { name: request.table },
+    fields: request.fields.map((field) => ({ name: field })),
+    ...(predicates.length > 0
+      ? {
+          where: {
+            type: "logical",
+            operator: "and",
+            predicates
+          }
+        }
+      : {}),
+    limit: normalizeLimit(request.limit)
+  };
+}
+
+export function compileSelectAst(ast: SelectQueryAst): CompiledQuery {
+  if (ast.type !== "select") {
+    throw new Error(`Unsupported query AST type: ${String(ast.type)}`);
+  }
+  if (!ast.fields.length) {
+    throw new Error("At least one field is required.");
+  }
+
+  const params: QueryScalarValue[] = [];
+  const quotedFields = ast.fields.map(compileSelectItem).join(", ");
+  const quotedTable = compileTableRef(ast.table);
+  const whereSql = ast.where ? ` WHERE ${compilePredicate(ast.where, params, true)}` : "";
+  const limit = normalizeLimit(ast.limit);
+  const sql = `SELECT ${quotedFields} FROM ${quotedTable}${whereSql} LIMIT ${limit}`;
+
+  return { sql, params };
+}
+
+export function compileSelectQuery(request: QueryRequest): CompiledQuery {
+  return compileSelectAst(buildSelectQueryAst(request));
+}
+
+function compileTableRef(table: QueryTableRef): string {
+  const quotedName = quoteIdentifier(table.name);
+  return table.alias ? `${quotedName} AS ${quoteIdentifier(table.alias)}` : quotedName;
+}
+
+function compileSelectItem(item: QuerySelectItem): string {
+  const field = compileFieldRef(item);
+  return item.alias ? `${field} AS ${quoteIdentifier(item.alias)}` : field;
+}
+
+function compilePredicate(predicate: QueryPredicate, params: QueryScalarValue[], isRoot = false): string {
+  if (predicate.type === "comparison") {
+    return compileComparisonPredicate(predicate, params);
+  }
+  return compileLogicalPredicate(predicate, params, isRoot);
+}
+
+function compileComparisonPredicate(predicate: QueryComparisonPredicate, params: QueryScalarValue[]): string {
+  params.push(predicate.value);
+  const operator = predicate.operator === "ilike" ? "ILIKE" : "=";
+  return `${compileFieldRef(predicate.left)} ${operator} $${params.length}`;
+}
+
+function compileLogicalPredicate(
+  predicate: QueryLogicalPredicate,
+  params: QueryScalarValue[],
+  isRoot: boolean
+): string {
+  if (!predicate.predicates.length) {
+    throw new Error("Logical predicate requires at least one child predicate.");
+  }
+
+  const joiner = predicate.operator === "or" ? " OR " : " AND ";
+  const compiled = predicate.predicates.map((child) => compilePredicate(child, params));
+  const sql = compiled.join(joiner);
+  return isRoot ? sql : `(${sql})`;
+}
+
+function compileFieldRef(field: QueryFieldRef): string {
+  const quotedName = quoteIdentifier(field.name);
+  return field.tableAlias ? `${quoteIdentifier(field.tableAlias)}.${quotedName}` : quotedName;
+}
+
+function normalizeLimit(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return DEFAULT_LIMIT;
+  }
+  return Math.max(1, Math.floor(value));
+}

--- a/packages/query/src/types/shared.types.ts
+++ b/packages/query/src/types/shared.types.ts
@@ -1,11 +1,52 @@
+export type QueryScalarValue = string | number | boolean;
+
 export interface QueryRequest {
   table: string;
   fields: string[];
-  filters?: Record<string, string | number | boolean>;
+  filters?: Record<string, QueryScalarValue>;
   limit?: number;
 }
 
 export interface CompiledQuery {
   sql: string;
-  params: Array<string | number | boolean>;
+  params: QueryScalarValue[];
+}
+
+export interface QueryTableRef {
+  name: string;
+  alias?: string;
+}
+
+export interface QueryFieldRef {
+  name: string;
+  tableAlias?: string;
+}
+
+export interface QuerySelectItem extends QueryFieldRef {
+  alias?: string;
+}
+
+export type QueryComparisonOperator = "eq" | "ilike";
+
+export interface QueryComparisonPredicate {
+  type: "comparison";
+  left: QueryFieldRef;
+  operator: QueryComparisonOperator;
+  value: QueryScalarValue;
+}
+
+export interface QueryLogicalPredicate {
+  type: "logical";
+  operator: "and" | "or";
+  predicates: QueryPredicate[];
+}
+
+export type QueryPredicate = QueryComparisonPredicate | QueryLogicalPredicate;
+
+export interface SelectQueryAst {
+  type: "select";
+  table: QueryTableRef;
+  fields: QuerySelectItem[];
+  where?: QueryPredicate;
+  limit: number;
 }

--- a/packages/query/test/query-compiler.test.ts
+++ b/packages/query/test/query-compiler.test.ts
@@ -1,6 +1,78 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { compileSelectQuery } from "../src/domain/query-compiler";
+import {
+  buildSelectQueryAst,
+  compileSelectAst,
+  compileSelectQuery
+} from "../src/domain/query-compiler";
+import type { SelectQueryAst } from "../src/types";
+
+test("buildSelectQueryAst builds a select AST from legacy query request", () => {
+  const ast = buildSelectQueryAst({
+    table: "orders",
+    fields: ["id", "status"],
+    filters: { tenant_id: "t1", status: "PAID" },
+    limit: 50
+  });
+
+  assert.deepEqual(ast, {
+    type: "select",
+    table: { name: "orders" },
+    fields: [{ name: "id" }, { name: "status" }],
+    where: {
+      type: "logical",
+      operator: "and",
+      predicates: [
+        {
+          type: "comparison",
+          left: { name: "tenant_id" },
+          operator: "eq",
+          value: "t1"
+        },
+        {
+          type: "comparison",
+          left: { name: "status" },
+          operator: "eq",
+          value: "PAID"
+        }
+      ]
+    },
+    limit: 50
+  });
+});
+
+test("buildSelectQueryAst maps keyword filter to structured ILIKE OR predicate", () => {
+  const ast = buildSelectQueryAst({
+    table: "orders",
+    fields: ["id"],
+    filters: { keyword: "SO-" }
+  });
+
+  assert.deepEqual(ast.where, {
+    type: "logical",
+    operator: "and",
+    predicates: [
+      {
+        type: "logical",
+        operator: "or",
+        predicates: [
+          {
+            type: "comparison",
+            left: { name: "id" },
+            operator: "ilike",
+            value: "%SO-%"
+          },
+          {
+            type: "comparison",
+            left: { name: "owner" },
+            operator: "ilike",
+            value: "%SO-%"
+          }
+        ]
+      }
+    ]
+  });
+});
 
 test("compileSelectQuery builds parameterized SQL", () => {
   const compiled = compileSelectQuery({
@@ -15,4 +87,135 @@ test("compileSelectQuery builds parameterized SQL", () => {
     'SELECT "id", "status" FROM "orders" WHERE "tenant_id" = $1 AND "status" = $2 LIMIT 50'
   );
   assert.deepEqual(compiled.params, ["t1", "PAID"]);
+});
+
+test("compileSelectQuery keeps SQL and params separated for keyword filters", () => {
+  const compiled = compileSelectQuery({
+    table: "orders",
+    fields: ["id", "owner"],
+    filters: { keyword: "SO-" }
+  });
+
+  assert.equal(
+    compiled.sql,
+    'SELECT "id", "owner" FROM "orders" WHERE ("id" ILIKE $1 OR "owner" ILIKE $2) LIMIT 100'
+  );
+  assert.deepEqual(compiled.params, ["%SO-%", "%SO-%"]);
+});
+
+test("compileSelectAst compiles permission-transformed AST predicates", () => {
+  const ast: SelectQueryAst = {
+    type: "select",
+    table: { name: "orders", alias: "o" },
+    fields: [
+      { name: "id", tableAlias: "o" },
+      { name: "owner", tableAlias: "o" }
+    ],
+    where: {
+      type: "logical",
+      operator: "and",
+      predicates: [
+        {
+          type: "comparison",
+          left: { name: "tenant_id", tableAlias: "o" },
+          operator: "eq",
+          value: "tenant-a"
+        },
+        {
+          type: "logical",
+          operator: "or",
+          predicates: [
+            {
+              type: "comparison",
+              left: { name: "org_id", tableAlias: "o" },
+              operator: "eq",
+              value: "dept-a"
+            },
+            {
+              type: "comparison",
+              left: { name: "org_id", tableAlias: "o" },
+              operator: "eq",
+              value: "dept-b"
+            }
+          ]
+        }
+      ]
+    },
+    limit: 20
+  };
+
+  const compiled = compileSelectAst(ast);
+
+  assert.equal(
+    compiled.sql,
+    'SELECT "o"."id", "o"."owner" FROM "orders" AS "o" WHERE "o"."tenant_id" = $1 AND ("o"."org_id" = $2 OR "o"."org_id" = $3) LIMIT 20'
+  );
+  assert.deepEqual(compiled.params, ["tenant-a", "dept-a", "dept-b"]);
+});
+
+test("compileSelectQuery rejects invalid identifiers", () => {
+  assert.throws(
+    () => compileSelectQuery({ table: "orders;drop", fields: ["id"] }),
+    /Invalid identifier: orders;drop/
+  );
+  assert.throws(
+    () => compileSelectQuery({ table: "orders", fields: ["id;drop"] }),
+    /Invalid identifier: id;drop/
+  );
+  assert.throws(
+    () =>
+      compileSelectAst({
+        type: "select",
+        table: { name: "orders" },
+        fields: [{ name: "id" }],
+        where: {
+          type: "comparison",
+          left: { name: "tenant_id;drop" },
+          operator: "eq",
+          value: "t1"
+        },
+        limit: 10
+      }),
+    /Invalid identifier: tenant_id;drop/
+  );
+});
+
+test("compileSelectQuery rejects empty fields", () => {
+  assert.throws(
+    () => compileSelectQuery({ table: "orders", fields: [] }),
+    /At least one field is required/
+  );
+});
+
+test("compileSelectQuery normalizes limits", () => {
+  assert.equal(
+    compileSelectQuery({ table: "orders", fields: ["id"] }).sql,
+    'SELECT "id" FROM "orders" LIMIT 100'
+  );
+  assert.equal(
+    compileSelectQuery({ table: "orders", fields: ["id"], limit: 0 }).sql,
+    'SELECT "id" FROM "orders" LIMIT 1'
+  );
+  assert.equal(
+    compileSelectQuery({ table: "orders", fields: ["id"], limit: 10.8 }).sql,
+    'SELECT "id" FROM "orders" LIMIT 10'
+  );
+  assert.equal(
+    compileSelectQuery({ table: "orders", fields: ["id"], limit: Number.NaN }).sql,
+    'SELECT "id" FROM "orders" LIMIT 100'
+  );
+});
+
+test("compileSelectAst rejects empty logical predicates", () => {
+  assert.throws(
+    () =>
+      compileSelectAst({
+        type: "select",
+        table: { name: "orders" },
+        fields: [{ name: "id" }],
+        where: { type: "logical", operator: "and", predicates: [] },
+        limit: 10
+      }),
+    /Logical predicate requires at least one child predicate/
+  );
 });


### PR DESCRIPTION
## Summary
- Add AST-first select query contracts in `@zhongmiao/meta-lc-query`.
- Add `buildSelectQueryAst()` and `compileSelectAst()` while keeping `compileSelectQuery(QueryRequest)` compatible for runtime consumers.
- Update query package tests and docs to describe Query as an AST-first compiler, not a datasource executor or orchestration layer.

## Checks
- `pnpm --filter @zhongmiao/meta-lc-query test`
- `pnpm --filter @zhongmiao/meta-lc-runtime test`
- `pnpm --filter @zhongmiao/meta-lc-bff test`
- `pnpm run test:boundaries`
- `pnpm run lint`
- `pnpm query-gate`
- `git diff --check`
- `node scripts/check-changelog-gate.mjs <base-sha> HEAD`

## Risk / Rollback
- Risk is limited to query SQL compilation because runtime and BFF still call the compatible `compileSelectQuery()` entrypoint.
- Rollback is a single revert of this PR; no datasource, permission, or BFF orchestration migration is included.

Closes #87
