### PR TITLE
feat(permission): add query AST transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- feat(permission): add Query AST permission transforms and route runtime query compilation through them.
 - feat(datasource): converge runtime query execution onto the shared datasource adapter contract.
 - fix(boundaries): close Task 1-9 runtime boundary gaps by removing legacy BFF query/mutation orchestration and adding guards against regressions.
 - feat(runtime): add a high-level runtime view executor facade for BFF gateway integration.

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- feat(permission): 新增 Query AST permission transform，并让 runtime query 编译链路先经过权限 AST。
 - feat(datasource): 将 runtime query 执行收敛到共享 datasource adapter 契约。
 - fix(boundaries): 收口 Task 1-9 runtime 边界遗漏，移除旧 BFF query/mutation 编排并新增防回归边界守护。
 - feat(runtime): 新增面向 BFF gateway 集成的高层 runtime view executor facade。

--- a/packages/bff/CHANGELOG.md
+++ b/packages/bff/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- test(permission): assert BFF view gateway context flows into runtime Permission AST Transform.
 - refactor(datasource): route BFF runtime view query execution through the datasource package adapter.
 - fix(boundaries): remove legacy `/query` and `/mutation` orchestration surfaces so BFF only acts as a runtime gateway.
 - test(gateway): retarget the e2e gate from removed legacy query/mutation endpoints to `POST /view/:name`.

--- a/packages/bff/CHANGELOG.zh-CN.md
+++ b/packages/bff/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- test(permission): 验证 BFF view gateway context 会进入 runtime Permission AST Transform。
 - refactor(datasource): BFF runtime view query 执行改为通过 datasource 包 adapter。
 - fix(boundaries): 移除旧 `/query` 与 `/mutation` 编排入口，让 BFF 只作为 runtime gateway。
 - test(gateway): e2e gate 从已移除的旧 query/mutation 入口改为验证 `POST /view/:name`。

--- a/packages/bff/test/temporary-view-adapter.test.ts
+++ b/packages/bff/test/temporary-view-adapter.test.ts
@@ -14,7 +14,7 @@ test("temporary view adapter executes runtime view and propagates context into t
         assert.deepEqual(input, {
           tenantId: "tenant-a",
           userId: "user-a",
-          roles: ["USER"]
+          roles: ["MANAGER"]
         });
         return {
           tenantId: input.tenantId,
@@ -69,7 +69,7 @@ test("temporary view adapter executes runtime view and propagates context into t
     {
       tenantId: "tenant-a",
       userId: "user-a",
-      roles: ["USER"],
+      roles: ["MANAGER"],
       input: {
         owner: "Ada",
         limit: 2
@@ -86,8 +86,8 @@ test("temporary view adapter executes runtime view and propagates context into t
   assert.deepEqual(queryCalls, [
     {
       kind: "query",
-      sql: 'SELECT "id", "owner", "channel", "priority", "status" FROM "orders" WHERE "tenant_id" = $1 AND "owner" = $2 AND "created_by" = $3 LIMIT 2',
-      params: ["tenant-a", "Ada", "user-a"]
+      sql: 'SELECT "id", "owner", "channel", "priority", "status" FROM "orders" WHERE ("tenant_id" = $1 AND "owner" = $2 AND "created_by" = $3) AND ("tenant_id" = $4 AND ("org_id" IN ($5) OR ("org_id" IS NULL AND "created_by" = $6))) LIMIT 2',
+      params: ["tenant-a", "Ada", "user-a", "tenant-a", "dept-a", "user-a"]
     }
   ]);
   assert.deepEqual(result.runtime.viewModel, {

--- a/packages/permission/CHANGELOG.md
+++ b/packages/permission/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- feat(permission-ast): add Query AST transforms for tenant, self, and organization data scopes.
 - refactor(package-structure): reorganize src into layered domain/application/infra/interface/types/utils directories and update public entrypoints.
 - docs(readme): add bilingual package README and minimal architecture flow.
 - chore(package): adopt the `@zhongmiao/meta-lc-permission` scoped package identity for release governance.

--- a/packages/permission/CHANGELOG.zh-CN.md
+++ b/packages/permission/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- feat(permission-ast): 新增覆盖 tenant、self 与组织数据域的 Query AST transform。
 - refactor(package-structure): 将 src 重整为 domain/application/infra/interface/types/utils 分层目录，并同步更新对外入口。
 - docs(readme): 新增双语子包 README 与最小架构流程图。
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-permission` 正式包名。

--- a/packages/permission/README.md
+++ b/packages/permission/README.md
@@ -4,18 +4,20 @@ English | [中文文档](./README_zh.md)
 
 ## Package Role
 
-`permission` evaluates role and organization data-scope policies. It produces permission decisions that BFF and query orchestration can use to restrict data access.
+`permission` evaluates role and organization data-scope policies and transforms query AST before SQL compilation. It does not inject SQL strings or execute datasources.
 
 ## Responsibilities
 
 - Model role data policies and organization scope context.
 - Resolve data scopes such as `SELF`, `DEPT`, `DEPT_AND_CHILDREN`, `CUSTOM_ORG_SET`, and `TENANT_ALL`.
 - Return decisions with allowed organization ids, fallback flags, and reason text.
+- Transform `SelectQueryAst` with tenant, self, and org-scope predicates before the query compiler renders SQL.
 
 ## Relationship With Other Packages
 
-- `bff` loads user/org/policy context and calls permission evaluation.
-- `query` consumes the resulting constraints through BFF orchestration.
+- `bff` loads user/org/policy context and passes it into runtime execution.
+- `runtime` calls the permission transform before invoking the query compiler.
+- `query` compiles permission-transformed AST into SQL and params.
 - `contracts` contains shared data-scope DTOs used at API boundaries.
 - `audit` can record allow/deny outcomes through BFF integration.
 
@@ -25,7 +27,8 @@ English | [中文文档](./README_zh.md)
 flowchart LR
   Context["OrgScopeContext"] --> Engine["PermissionEngine"]
   Engine --> Decision["DataScopeDecision"]
-  Decision --> Query["BFF query / mutation guard"]
+  Decision --> Transform["Permission AST Transform"]
+  Transform --> Query["Query AST Compiler"]
   Query --> Audit["audit outcome"]
 ```
 
@@ -40,3 +43,4 @@ pnpm --filter @zhongmiao/meta-lc-permission test
 
 - Keep policy evaluation deterministic.
 - Do not fetch users, roles, or organization data directly from this package; BFF integration supplies context.
+- Do not concatenate SQL clauses here; permissions must flow through AST predicates.

--- a/packages/permission/README_zh.md
+++ b/packages/permission/README_zh.md
@@ -4,18 +4,20 @@
 
 ## 包定位
 
-`permission` 负责评估角色与组织数据域策略，产出 BFF 与 query orchestration 可用于限制数据访问的 permission decision。
+`permission` 负责评估角色与组织数据域策略，并在 SQL 编译前转换 query AST。它不拼接 SQL 字符串，也不执行 datasource。
 
 ## 核心职责
 
 - 建模 role data policy 与 organization scope context。
 - 解析 `SELF`、`DEPT`、`DEPT_AND_CHILDREN`、`CUSTOM_ORG_SET`、`TENANT_ALL` 等数据域。
 - 返回 allowed organization ids、fallback flags 与 reason text。
+- 在 query compiler 渲染 SQL 前，为 `SelectQueryAst` 加入 tenant、self 与 org-scope predicates。
 
 ## 与其他包关系
 
-- `bff` 加载 user/org/policy context 后调用 permission evaluation。
-- `query` 通过 BFF 编排消费权限约束。
+- `bff` 加载 user/org/policy context 后传入 runtime execution。
+- `runtime` 在调用 query compiler 前执行 permission transform。
+- `query` 将 permission-transformed AST 编译为 SQL 与 params。
 - `contracts` 包含 API 边界共享的数据域 DTO。
 - `audit` 可通过 BFF integration 记录 allow/deny 结果。
 
@@ -25,7 +27,8 @@
 flowchart LR
   Context["OrgScopeContext"] --> Engine["PermissionEngine"]
   Engine --> Decision["DataScopeDecision"]
-  Decision --> Query["BFF query / mutation guard"]
+  Decision --> Transform["Permission AST Transform"]
+  Transform --> Query["Query AST Compiler"]
   Query --> Audit["audit outcome"]
 ```
 
@@ -40,3 +43,4 @@ pnpm --filter @zhongmiao/meta-lc-permission test
 
 - 保持 policy evaluation 确定性。
 - 不在此包中直接读取 users、roles 或 organization data；上下文由 BFF integration 提供。
+- 不在此包拼接 SQL clause；权限必须通过 AST predicate 流转。

--- a/packages/permission/package.json
+++ b/packages/permission/package.json
@@ -8,10 +8,14 @@
     "test": "npm run build && node --test \"dist/**/test/*.test.js\"",
     "lint": "echo lint:permission"
   },
+  "dependencies": {
+    "@zhongmiao/meta-lc-contracts": "workspace:*",
+    "@zhongmiao/meta-lc-query": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^22.10.2",
     "typescript": "^5.7.2"
   },
-  "main": "dist/src/index.js",
-  "types": "dist/src/index.d.ts"
+  "main": "dist/permission/src/index.js",
+  "types": "dist/permission/src/index.d.ts"
 }

--- a/packages/permission/src/domain/index.ts
+++ b/packages/permission/src/domain/index.ts
@@ -1,1 +1,2 @@
 export * from "./permission-engine";
+export * from "./permission-ast-transform";

--- a/packages/permission/src/domain/permission-ast-transform.ts
+++ b/packages/permission/src/domain/permission-ast-transform.ts
@@ -1,0 +1,137 @@
+import type { QueryFieldRef, QueryPredicate, SelectQueryAst } from "@zhongmiao/meta-lc-query";
+import type {
+  DataScopeDecision,
+  OrgScopeContext,
+  PermissionContext
+} from "../types/shared.types";
+import { resolveDataScope } from "./permission-engine";
+
+export interface PermissionAstTransformContext extends PermissionContext {
+  orgScope?: OrgScopeContext;
+  dataScopeDecision?: DataScopeDecision;
+}
+
+export function transformSelectQueryAstWithPermission(
+  ast: SelectQueryAst,
+  context: PermissionAstTransformContext
+): SelectQueryAst {
+  const permissionPredicate = buildPermissionPredicate(ast, context);
+
+  return {
+    ...ast,
+    fields: ast.fields.map((field) => ({ ...field })),
+    table: { ...ast.table },
+    where: mergeWhere(ast.where, permissionPredicate)
+  };
+}
+
+function buildPermissionPredicate(
+  ast: SelectQueryAst,
+  context: PermissionAstTransformContext
+): QueryPredicate {
+  const decision = context.dataScopeDecision ?? resolveDataScope(context.orgScope ?? createOrgScopeContext(context));
+  const tableAlias = ast.table.alias;
+
+  if (decision.tenantAll) {
+    return tenantPredicate(context.tenantId, tableAlias);
+  }
+
+  if (decision.scope === "SELF") {
+    return andPredicate([
+      tenantPredicate(context.tenantId, tableAlias),
+      comparisonPredicate("created_by", context.userId, tableAlias)
+    ]);
+  }
+
+  if (!decision.allowedOrgIds.length) {
+    return literalPredicate(false);
+  }
+
+  const orgScopePredicate = inPredicate("org_id", decision.allowedOrgIds, tableAlias);
+  if (!decision.legacyFallbackToCreatedBy) {
+    return andPredicate([tenantPredicate(context.tenantId, tableAlias), orgScopePredicate]);
+  }
+
+  return andPredicate([
+    tenantPredicate(context.tenantId, tableAlias),
+    {
+      type: "logical",
+      operator: "or",
+      predicates: [
+        orgScopePredicate,
+        andPredicate([
+          {
+            type: "is_null",
+            left: fieldRef("org_id", tableAlias)
+          },
+          comparisonPredicate("created_by", context.userId, tableAlias)
+        ])
+      ]
+    }
+  ]);
+}
+
+function createOrgScopeContext(context: PermissionContext): OrgScopeContext {
+  return {
+    tenantId: context.tenantId,
+    userId: context.userId,
+    roles: [...context.roles],
+    userOrgIds: [],
+    rolePolicies: [],
+    orgNodes: []
+  };
+}
+
+function mergeWhere(existing: QueryPredicate | undefined, permission: QueryPredicate): QueryPredicate {
+  if (!existing) {
+    return permission;
+  }
+  return andPredicate([existing, permission]);
+}
+
+function tenantPredicate(tenantId: string, tableAlias: string | undefined): QueryPredicate {
+  return comparisonPredicate("tenant_id", tenantId, tableAlias);
+}
+
+function comparisonPredicate(
+  field: string,
+  value: string,
+  tableAlias: string | undefined
+): QueryPredicate {
+  return {
+    type: "comparison",
+    left: fieldRef(field, tableAlias),
+    operator: "eq",
+    value
+  };
+}
+
+function inPredicate(field: string, values: string[], tableAlias: string | undefined): QueryPredicate {
+  return {
+    type: "in",
+    left: fieldRef(field, tableAlias),
+    values: [...values]
+  };
+}
+
+function literalPredicate(value: boolean): QueryPredicate {
+  return {
+    type: "literal",
+    value
+  };
+}
+
+function andPredicate(predicates: QueryPredicate[]): QueryPredicate {
+  return {
+    type: "logical",
+    operator: "and",
+    predicates
+  };
+}
+
+function fieldRef(name: string, tableAlias: string | undefined): QueryFieldRef {
+  return {
+    name,
+    ...(tableAlias ? { tableAlias } : {})
+  };
+}

--- a/packages/permission/src/domain/permission-engine.ts
+++ b/packages/permission/src/domain/permission-engine.ts
@@ -123,6 +123,10 @@ export function resolveDataScope(context: OrgScopeContext): DataScopeDecision {
   };
 }
 
+/**
+ * @deprecated Runtime query permissions should use transformSelectQueryAstWithPermission()
+ * and let the query compiler render SQL from AST.
+ */
 export function buildDataScopeFilter(decision: DataScopeDecision, context: PermissionContext): PermissionFilter {
   if (decision.tenantAll) {
     return {
@@ -191,6 +195,10 @@ export function canAccessOrg(
   };
 }
 
+/**
+ * @deprecated Runtime query permissions should use transformSelectQueryAstWithPermission()
+ * and let the query compiler render SQL from AST.
+ */
 export function buildRowLevelFilter(context: PermissionContext): PermissionFilter {
   return buildDataScopeFilter(
     {
@@ -204,6 +212,10 @@ export function buildRowLevelFilter(context: PermissionContext): PermissionFilte
   );
 }
 
+/**
+ * @deprecated SQL clause injection is retained only for legacy callers. Runtime
+ * query execution must use Permission AST Transform instead.
+ */
 export function injectPermissionClause(baseSql: string, filter: PermissionFilter): string {
   if (filter.clause === "1=1") {
     return baseSql;

--- a/packages/permission/src/types/shared.types.ts
+++ b/packages/permission/src/types/shared.types.ts
@@ -1,3 +1,11 @@
+export type {
+  DataScopeDecision,
+  DataScopeType,
+  OrgNode,
+  OrgScopeContext,
+  RoleDataPolicy
+} from "@zhongmiao/meta-lc-contracts";
+
 export interface PermissionContext {
   tenantId: string;
   userId: string;
@@ -7,43 +15,4 @@ export interface PermissionContext {
 export interface PermissionFilter {
   clause: string;
   params: Array<string | number | boolean | string[]>;
-}
-
-export type DataScopeType =
-  | "SELF"
-  | "DEPT"
-  | "DEPT_AND_CHILDREN"
-  | "CUSTOM_ORG_SET"
-  | "TENANT_ALL";
-
-export interface RoleDataPolicy {
-  role: string;
-  scope: DataScopeType;
-  customOrgIds?: string[];
-}
-
-export interface OrgNode {
-  id: string;
-  tenantId: string;
-  parentId: string | null;
-  path: string;
-  name: string;
-  type: string;
-}
-
-export interface OrgScopeContext {
-  tenantId: string;
-  userId: string;
-  roles: string[];
-  userOrgIds: string[];
-  rolePolicies: RoleDataPolicy[];
-  orgNodes: OrgNode[];
-}
-
-export interface DataScopeDecision {
-  scope: DataScopeType;
-  allowedOrgIds: string[];
-  tenantAll: boolean;
-  legacyFallbackToCreatedBy: boolean;
-  reason: string;
 }

--- a/packages/permission/test/permission-engine.test.ts
+++ b/packages/permission/test/permission-engine.test.ts
@@ -1,12 +1,14 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { compileSelectAst, type SelectQueryAst } from "@zhongmiao/meta-lc-query";
 import {
   buildDataScopeFilter,
   buildRowLevelFilter,
   canAccessOrg,
   injectPermissionClause,
-  resolveDataScope
-} from "../src/domain/permission-engine";
+  resolveDataScope,
+  transformSelectQueryAstWithPermission
+} from "../src/domain";
 
 test("non-admin defaults to SELF scope", () => {
   const filter = buildRowLevelFilter({
@@ -143,3 +145,147 @@ test("injectPermissionClause appends filter to SQL with WHERE", () => {
   });
   assert.equal(sql, "SELECT * FROM orders WHERE status = $1 AND tenant_id = $2");
 });
+
+test("transformSelectQueryAstWithPermission adds tenant filter for tenant-wide admins", () => {
+  const transformed = transformSelectQueryAstWithPermission(createOrdersAst(), {
+    tenantId: "tenant-a",
+    userId: "admin-1",
+    roles: ["SUPER_ADMIN"]
+  });
+
+  assert.deepEqual(transformed.where, {
+    type: "comparison",
+    left: { name: "tenant_id" },
+    operator: "eq",
+    value: "tenant-a"
+  });
+});
+
+test("transformSelectQueryAstWithPermission adds SELF scope filters", () => {
+  const transformed = transformSelectQueryAstWithPermission(createOrdersAst({ status: true }), {
+    tenantId: "tenant-a",
+    userId: "user-1",
+    roles: ["USER"]
+  });
+
+  const compiled = compileSelectAst(transformed);
+
+  assert.equal(
+    compiled.sql,
+    'SELECT "id", "owner" FROM "orders" WHERE "status" = $1 AND ("tenant_id" = $2 AND "created_by" = $3) LIMIT 100'
+  );
+  assert.deepEqual(compiled.params, ["active", "tenant-a", "user-1"]);
+});
+
+test("transformSelectQueryAstWithPermission adds org scope with legacy owner fallback", () => {
+  const transformed = transformSelectQueryAstWithPermission(createOrdersAst(), {
+    tenantId: "tenant-a",
+    userId: "manager-1",
+    roles: ["MANAGER"],
+    dataScopeDecision: {
+      scope: "DEPT_AND_CHILDREN",
+      allowedOrgIds: ["dept-a", "dept-a-sub"],
+      tenantAll: false,
+      legacyFallbackToCreatedBy: true,
+      reason: "scope:DEPT_AND_CHILDREN"
+    }
+  });
+
+  const compiled = compileSelectAst(transformed);
+
+  assert.equal(
+    compiled.sql,
+    'SELECT "id", "owner" FROM "orders" WHERE "tenant_id" = $1 AND ("org_id" IN ($2, $3) OR ("org_id" IS NULL AND "created_by" = $4)) LIMIT 100'
+  );
+  assert.deepEqual(compiled.params, ["tenant-a", "dept-a", "dept-a-sub", "manager-1"]);
+});
+
+test("transformSelectQueryAstWithPermission supports custom org scope without SQL clause output", () => {
+  const transformed = transformSelectQueryAstWithPermission(createOrdersAst(), {
+    tenantId: "tenant-a",
+    userId: "custom-user",
+    roles: ["CUSTOM_SUPPORT"],
+    dataScopeDecision: {
+      scope: "CUSTOM_ORG_SET",
+      allowedOrgIds: ["dept-b"],
+      tenantAll: false,
+      legacyFallbackToCreatedBy: false,
+      reason: "scope:CUSTOM_ORG_SET"
+    }
+  });
+
+  assert.equal(JSON.stringify(transformed).includes("clause"), false);
+  assert.equal(JSON.stringify(transformed).includes(" WHERE "), false);
+  assert.equal(
+    compileSelectAst(transformed).sql,
+    'SELECT "id", "owner" FROM "orders" WHERE "tenant_id" = $1 AND "org_id" IN ($2) LIMIT 100'
+  );
+});
+
+test("transformSelectQueryAstWithPermission preserves table aliases in permission predicates", () => {
+  const transformed = transformSelectQueryAstWithPermission(
+    {
+      type: "select",
+      table: { name: "orders", alias: "o" },
+      fields: [
+        { name: "id", tableAlias: "o" },
+        { name: "owner", tableAlias: "o" }
+      ],
+      limit: 25
+    },
+    {
+      tenantId: "tenant-a",
+      userId: "manager-1",
+      roles: ["MANAGER"],
+      dataScopeDecision: {
+        scope: "DEPT",
+        allowedOrgIds: ["dept-a"],
+        tenantAll: false,
+        legacyFallbackToCreatedBy: true,
+        reason: "scope:DEPT"
+      }
+    }
+  );
+
+  assert.equal(
+    compileSelectAst(transformed).sql,
+    'SELECT "o"."id", "o"."owner" FROM "orders" AS "o" WHERE "o"."tenant_id" = $1 AND ("o"."org_id" IN ($2) OR ("o"."org_id" IS NULL AND "o"."created_by" = $3)) LIMIT 25'
+  );
+});
+
+test("transformSelectQueryAstWithPermission denies empty org scope", () => {
+  const transformed = transformSelectQueryAstWithPermission(createOrdersAst(), {
+    tenantId: "tenant-a",
+    userId: "manager-1",
+    roles: ["MANAGER"],
+    dataScopeDecision: {
+      scope: "DEPT",
+      allowedOrgIds: [],
+      tenantAll: false,
+      legacyFallbackToCreatedBy: true,
+      reason: "scope:DEPT"
+    }
+  });
+
+  assert.deepEqual(transformed.where, { type: "literal", value: false });
+  assert.equal(compileSelectAst(transformed).sql, 'SELECT "id", "owner" FROM "orders" WHERE FALSE LIMIT 100');
+});
+
+function createOrdersAst(options: { status?: boolean } = {}): SelectQueryAst {
+  return {
+    type: "select",
+    table: { name: "orders" },
+    fields: [{ name: "id" }, { name: "owner" }],
+    ...(options.status
+      ? {
+          where: {
+            type: "comparison",
+            left: { name: "status" },
+            operator: "eq",
+            value: "active"
+          } as const
+        }
+      : {}),
+    limit: 100
+  };
+}

--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- feat(query-ast): support permission predicate shapes such as `IN`, `IS NULL`, and boolean literals.
 - feat(query-ast): add AST-first select query builder and SQL compiler while keeping the legacy request entrypoint.
 - refactor(package-structure): reorganize src into layered domain/application/infra/interface/types/utils directories and update public entrypoints.
 - docs(readme): add bilingual package README and minimal architecture flow.

--- a/packages/query/CHANGELOG.zh-CN.md
+++ b/packages/query/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- feat(query-ast): 支持 `IN`、`IS NULL` 与 boolean literal 等权限 predicate 形状。
 - feat(query-ast): 新增 AST-first select query builder 与 SQL compiler，同时保留旧 request 入口兼容。
 - refactor(package-structure): 将 src 重整为 domain/application/infra/interface/types/utils 分层目录，并同步更新对外入口。
 - docs(readme): 新增双语子包 README 与最小架构流程图。

--- a/packages/query/README.md
+++ b/packages/query/README.md
@@ -16,7 +16,7 @@ English | [中文文档](./README_zh.md)
 ## Relationship With Other Packages
 
 - `runtime` calls query compilation through its query compiler adapter before datasource execution.
-- `permission` can later transform query AST before final SQL compilation.
+- `permission` transforms query AST before final SQL compilation.
 - `datasource` executes compiled SQL; `query` does not depend on `datasource`.
 - `contracts` provides V2 query node shapes that runtime adapts into query compiler input.
 
@@ -26,7 +26,8 @@ English | [中文文档](./README_zh.md)
 flowchart LR
   Request["QueryRequest compatibility input"] --> AstBuilder["Query AST Builder"]
   AstBuilder --> Ast["SelectQueryAst"]
-  Ast --> Compiler["AST SQL Compiler"]
+  Ast --> Permission["Permission AST Transform"]
+  Permission --> Compiler["AST SQL Compiler"]
   Compiler --> Sql["SQL + params"]
   Sql --> Executor["Datasource adapter"]
 ```
@@ -42,4 +43,4 @@ pnpm --filter @zhongmiao/meta-lc-query test
 
 - Do not open DB connections here.
 - Do not add runtime orchestration or BFF page request semantics here.
-- Keep permission policy resolution outside this package; consume AST predicates or later permission-transformed AST.
+- Keep permission policy resolution outside this package; consume permission-transformed AST predicates.

--- a/packages/query/README_zh.md
+++ b/packages/query/README_zh.md
@@ -16,7 +16,7 @@
 ## 与其他包关系
 
 - `runtime` 通过 query compiler adapter 在 datasource 执行前调用 query compiler。
-- `permission` 后续可以在最终 SQL 编译前 transform query AST。
+- `permission` 在最终 SQL 编译前 transform query AST。
 - `datasource` 执行编译后的 SQL；`query` 不依赖 `datasource`。
 - `contracts` 提供 V2 query node 形状，由 runtime 适配为 compiler input。
 
@@ -26,7 +26,8 @@
 flowchart LR
   Request["QueryRequest 兼容输入"] --> AstBuilder["Query AST Builder"]
   AstBuilder --> Ast["SelectQueryAst"]
-  Ast --> Compiler["AST SQL Compiler"]
+  Ast --> Permission["Permission AST Transform"]
+  Permission --> Compiler["AST SQL Compiler"]
   Compiler --> Sql["SQL + params"]
   Sql --> Executor["Datasource adapter"]
 ```
@@ -42,4 +43,4 @@ pnpm --filter @zhongmiao/meta-lc-query test
 
 - 不在这里打开数据库连接。
 - 不在这里新增 runtime orchestration 或 BFF 页面请求语义。
-- 权限策略解析留在包外；本包消费 AST predicates 或后续 permission-transformed AST。
+- 权限策略解析留在包外；本包消费 permission-transformed AST predicates。

--- a/packages/query/src/domain/query-compiler.ts
+++ b/packages/query/src/domain/query-compiler.ts
@@ -2,6 +2,9 @@ import type {
   CompiledQuery,
   QueryComparisonPredicate,
   QueryFieldRef,
+  QueryInPredicate,
+  QueryIsNullPredicate,
+  QueryLiteralPredicate,
   QueryLogicalPredicate,
   QueryPredicate,
   QueryRequest,
@@ -118,6 +121,15 @@ function compilePredicate(predicate: QueryPredicate, params: QueryScalarValue[],
   if (predicate.type === "comparison") {
     return compileComparisonPredicate(predicate, params);
   }
+  if (predicate.type === "in") {
+    return compileInPredicate(predicate, params);
+  }
+  if (predicate.type === "is_null") {
+    return compileIsNullPredicate(predicate);
+  }
+  if (predicate.type === "literal") {
+    return compileLiteralPredicate(predicate);
+  }
   return compileLogicalPredicate(predicate, params, isRoot);
 }
 
@@ -125,6 +137,26 @@ function compileComparisonPredicate(predicate: QueryComparisonPredicate, params:
   params.push(predicate.value);
   const operator = predicate.operator === "ilike" ? "ILIKE" : "=";
   return `${compileFieldRef(predicate.left)} ${operator} $${params.length}`;
+}
+
+function compileInPredicate(predicate: QueryInPredicate, params: QueryScalarValue[]): string {
+  if (!predicate.values.length) {
+    return "FALSE";
+  }
+
+  const placeholders = predicate.values.map((value) => {
+    params.push(value);
+    return `$${params.length}`;
+  });
+  return `${compileFieldRef(predicate.left)} IN (${placeholders.join(", ")})`;
+}
+
+function compileIsNullPredicate(predicate: QueryIsNullPredicate): string {
+  return `${compileFieldRef(predicate.left)} IS NULL`;
+}
+
+function compileLiteralPredicate(predicate: QueryLiteralPredicate): string {
+  return predicate.value ? "TRUE" : "FALSE";
 }
 
 function compileLogicalPredicate(

--- a/packages/query/src/types/shared.types.ts
+++ b/packages/query/src/types/shared.types.ts
@@ -35,13 +35,34 @@ export interface QueryComparisonPredicate {
   value: QueryScalarValue;
 }
 
+export interface QueryInPredicate {
+  type: "in";
+  left: QueryFieldRef;
+  values: QueryScalarValue[];
+}
+
+export interface QueryIsNullPredicate {
+  type: "is_null";
+  left: QueryFieldRef;
+}
+
+export interface QueryLiteralPredicate {
+  type: "literal";
+  value: boolean;
+}
+
 export interface QueryLogicalPredicate {
   type: "logical";
   operator: "and" | "or";
   predicates: QueryPredicate[];
 }
 
-export type QueryPredicate = QueryComparisonPredicate | QueryLogicalPredicate;
+export type QueryPredicate =
+  | QueryComparisonPredicate
+  | QueryInPredicate
+  | QueryIsNullPredicate
+  | QueryLiteralPredicate
+  | QueryLogicalPredicate;
 
 export interface SelectQueryAst {
   type: "select";

--- a/packages/query/test/query-compiler.test.ts
+++ b/packages/query/test/query-compiler.test.ts
@@ -153,6 +153,65 @@ test("compileSelectAst compiles permission-transformed AST predicates", () => {
   assert.deepEqual(compiled.params, ["tenant-a", "dept-a", "dept-b"]);
 });
 
+test("compileSelectAst compiles permission predicate shapes", () => {
+  const ast: SelectQueryAst = {
+    type: "select",
+    table: { name: "orders", alias: "o" },
+    fields: [{ name: "id", tableAlias: "o" }],
+    where: {
+      type: "logical",
+      operator: "and",
+      predicates: [
+        {
+          type: "in",
+          left: { name: "org_id", tableAlias: "o" },
+          values: ["dept-a", "dept-b"]
+        },
+        {
+          type: "logical",
+          operator: "or",
+          predicates: [
+            {
+              type: "is_null",
+              left: { name: "deleted_at", tableAlias: "o" }
+            },
+            {
+              type: "literal",
+              value: false
+            }
+          ]
+        }
+      ]
+    },
+    limit: 20
+  };
+
+  const compiled = compileSelectAst(ast);
+
+  assert.equal(
+    compiled.sql,
+    'SELECT "o"."id" FROM "orders" AS "o" WHERE "o"."org_id" IN ($1, $2) AND ("o"."deleted_at" IS NULL OR FALSE) LIMIT 20'
+  );
+  assert.deepEqual(compiled.params, ["dept-a", "dept-b"]);
+});
+
+test("compileSelectAst compiles empty IN as deny-all predicate", () => {
+  const compiled = compileSelectAst({
+    type: "select",
+    table: { name: "orders" },
+    fields: [{ name: "id" }],
+    where: {
+      type: "in",
+      left: { name: "org_id" },
+      values: []
+    },
+    limit: 10
+  });
+
+  assert.equal(compiled.sql, 'SELECT "id" FROM "orders" WHERE FALSE LIMIT 10');
+  assert.deepEqual(compiled.params, []);
+});
+
 test("compileSelectQuery rejects invalid identifiers", () => {
   assert.throws(
     () => compileSelectQuery({ table: "orders;drop", fields: ["id"] }),

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- feat(permission): route query nodes through Permission AST Transform before SQL compilation.
 - refactor(datasource): execute query nodes through the shared datasource adapter contract.
 - feat(runtime): add a high-level runtime view executor facade that compiles and executes ViewDefinition through RuntimeExecutor.
 - refactor(contracts): re-export V2 view and execution plan contracts from the shared contracts package.

--- a/packages/runtime/CHANGELOG.zh-CN.md
+++ b/packages/runtime/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- feat(permission): query node 在 SQL 编译前接入 Permission AST Transform。
 - refactor(datasource): query node 改为通过共享 datasource adapter 契约执行。
 - feat(runtime): 新增高层 runtime view executor facade，通过 RuntimeExecutor 编译并执行 ViewDefinition。
 - refactor(contracts): 从共享 contracts 包转导 V2 view 与 execution plan 契约。

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -19,7 +19,7 @@ English | [中文文档](./README_zh.md)
 - Depends on `contracts` for shared runtime event and page topic contracts.
 - BFF websocket code can publish runtime events compatible with these contracts.
 - Frontend runtime adapters consume the package contract without direct database or business API access.
-- Query nodes compile through `query` and execute through the shared `datasource` adapter contract.
+- Query nodes build AST through `query`, apply `permission` AST transforms, compile SQL, and execute through the shared `datasource` adapter contract.
 - BFF wires concrete datasource adapters; runtime does not read DB config or access physical data directly.
 
 ## Minimal Flow
@@ -44,3 +44,4 @@ pnpm --filter @zhongmiao/meta-lc-runtime test
 
 - Runtime orchestration must not embed business-specific backend logic.
 - Runtime consumers must still access data through BFF contracts.
+- Runtime query execution must not inject SQL permission clauses; it calls the permission AST transform before SQL compilation.

--- a/packages/runtime/README_zh.md
+++ b/packages/runtime/README_zh.md
@@ -19,7 +19,7 @@
 - 依赖 `contracts` 获取共享 runtime event 与 page topic contract。
 - BFF websocket code 可以发布与这些 contract 兼容的 runtime event。
 - 前端 runtime adapter 消费本包 contract，但不直连数据库或业务 API。
-- Query node 通过 `query` 编译，并通过共享 `datasource` adapter 契约执行。
+- Query node 通过 `query` 构建 AST，经过 `permission` AST transform 后编译 SQL，并通过共享 `datasource` adapter 契约执行。
 - BFF 负责装配具体 datasource adapter；runtime 不读取 DB config，也不直接访问物理数据。
 
 ## 最小闭环
@@ -44,3 +44,4 @@ pnpm --filter @zhongmiao/meta-lc-runtime test
 
 - Runtime orchestration 不能内嵌业务专用后端逻辑。
 - Runtime consumer 的数据访问仍必须经过 BFF contract。
+- Runtime query execution 不能注入 SQL permission clause；必须在 SQL 编译前调用 permission AST transform。

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@zhongmiao/meta-lc-contracts": "workspace:*",
     "@zhongmiao/meta-lc-datasource": "workspace:*",
+    "@zhongmiao/meta-lc-permission": "workspace:*",
     "@zhongmiao/meta-lc-query": "workspace:*"
   },
   "devDependencies": {

--- a/packages/runtime/src/application/executor/query-executor.ts
+++ b/packages/runtime/src/application/executor/query-executor.ts
@@ -1,5 +1,7 @@
 import type { QueryResultRow } from "@zhongmiao/meta-lc-datasource";
 import type { CompiledQuery, QueryRequest } from "@zhongmiao/meta-lc-query";
+import type { OrgScopeContext } from "@zhongmiao/meta-lc-contracts";
+import type { PermissionAstTransformContext } from "@zhongmiao/meta-lc-permission";
 import { resolveExpression } from "../../domain/dsl/expression";
 import {
   QueryExecutorError,
@@ -10,12 +12,15 @@ import {
 } from "../../types";
 import {
   createQueryCompilerAdapter,
+  createQueryPermissionAdapter,
   type QueryCompilerAdapter,
-  type QueryDatasourceAdapter
+  type QueryDatasourceAdapter,
+  type QueryPermissionAdapter
 } from "../../infra/adapter/query.adapter";
 
 export interface QueryExecutorDependencies {
   compiler?: QueryCompilerAdapter;
+  permission?: QueryPermissionAdapter;
   datasource: QueryDatasourceAdapter;
 }
 
@@ -32,12 +37,15 @@ export async function executeQueryNode(
   dependencies: QueryExecutorDependencies
 ): Promise<QueryResultRow[]> {
   const compiler = dependencies.compiler ?? createQueryCompilerAdapter();
+  const permission = dependencies.permission ?? createQueryPermissionAdapter();
   const resolvedNode = resolveExpression(node as unknown as ViewExpression, new QueryExpressionStateSource(state, context)) as ResolvedQueryNodeDefinition;
   const request = buildQueryRequest(resolvedNode);
 
   let compiled: CompiledQuery;
   try {
-    compiled = compiler.compile(request);
+    const ast = compiler.buildAst(request);
+    const transformedAst = permission.transform(ast, buildPermissionContext(context));
+    compiled = compiler.compileAst(transformedAst);
   } catch (error) {
     throw new QueryExecutorError(
       `Failed to compile query node "${String(resolvedNode.type ?? node.type)}" for table "${request.table}". ${
@@ -64,6 +72,57 @@ export async function executeQueryNode(
       error
     );
   }
+}
+
+function buildPermissionContext(context: RuntimeContext): PermissionAstTransformContext {
+  const auth = isPlainObject(context.auth) ? context.auth : {};
+  const tenantId = readContextString(context.tenantId ?? auth.tenantId, "tenantId");
+  const userId = readContextString(context.userId ?? auth.userId, "userId");
+  const roles = readContextStringArray(context.roles ?? auth.roles, "roles");
+  const orgScope = readOrgScopeContext(context.orgScope);
+
+  return {
+    tenantId,
+    userId,
+    roles,
+    ...(orgScope ? { orgScope } : {})
+  };
+}
+
+function readContextString(value: unknown, key: string): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new QueryExecutorError(`Runtime context is missing a valid permission "${key}" value.`, "validation");
+  }
+  return value.trim();
+}
+
+function readContextStringArray(value: unknown, key: string): string[] {
+  if (!Array.isArray(value)) {
+    throw new QueryExecutorError(`Runtime context permission "${key}" must be an array.`, "validation");
+  }
+  return value.map((item) => readContextString(item, key));
+}
+
+function readOrgScopeContext(value: unknown): OrgScopeContext | undefined {
+  if (!isPlainObject(value)) {
+    return undefined;
+  }
+
+  const tenantId = readContextString(value.tenantId, "orgScope.tenantId");
+  const userId = readContextString(value.userId, "orgScope.userId");
+  const roles = readContextStringArray(value.roles, "orgScope.roles");
+  const userOrgIds = readContextStringArray(value.userOrgIds, "orgScope.userOrgIds");
+  const rolePolicies = Array.isArray(value.rolePolicies) ? value.rolePolicies : [];
+  const orgNodes = Array.isArray(value.orgNodes) ? value.orgNodes : [];
+
+  return {
+    tenantId,
+    userId,
+    roles,
+    userOrgIds,
+    rolePolicies: rolePolicies as OrgScopeContext["rolePolicies"],
+    orgNodes: orgNodes as OrgScopeContext["orgNodes"]
+  };
 }
 
 function buildQueryRequest(node: ResolvedQueryNodeDefinition): QueryRequest {

--- a/packages/runtime/src/application/executor/runtime-view-executor.ts
+++ b/packages/runtime/src/application/executor/runtime-view-executor.ts
@@ -15,13 +15,15 @@ import type {
 } from "../../types";
 import type {
   QueryCompilerAdapter,
-  QueryDatasourceAdapter
+  QueryDatasourceAdapter,
+  QueryPermissionAdapter
 } from "../../infra/adapter/query.adapter";
 import type { MutationDatasourceAdapter } from "../../infra/adapter/mutation.adapter";
 import { compileViewDefinition } from "../compiler/view-compiler";
 
 export interface RuntimeViewExecutorDependencies {
   queryCompiler?: QueryCompilerAdapter;
+  queryPermission?: QueryPermissionAdapter;
   queryDatasource: QueryDatasourceAdapter;
   mutationDatasource: MutationDatasourceAdapter;
   merge?: MergeExecutorDependencies;
@@ -45,6 +47,7 @@ function createRuntimeViewExecutors(
     query: (node, state, context) =>
       executeQueryNode(node, state, context, {
         ...(dependencies.queryCompiler ? { compiler: dependencies.queryCompiler } : {}),
+        ...(dependencies.queryPermission ? { permission: dependencies.queryPermission } : {}),
         datasource: dependencies.queryDatasource
       }),
     mutation: (node, state, context) =>

--- a/packages/runtime/src/infra/adapter/query.adapter.ts
+++ b/packages/runtime/src/infra/adapter/query.adapter.ts
@@ -1,15 +1,28 @@
 import {
+  buildSelectQueryAst,
+  compileSelectAst,
   compileSelectQuery,
   type CompiledQuery,
-  type QueryRequest
+  type QueryRequest,
+  type SelectQueryAst
 } from "@zhongmiao/meta-lc-query";
+import {
+  transformSelectQueryAstWithPermission,
+  type PermissionAstTransformContext
+} from "@zhongmiao/meta-lc-permission";
 import type {
   DatasourceAdapter,
   DatasourceExecutionResult
 } from "@zhongmiao/meta-lc-datasource";
 
 export interface QueryCompilerAdapter {
+  buildAst(request: QueryRequest): SelectQueryAst;
+  compileAst(ast: SelectQueryAst): CompiledQuery;
   compile(request: QueryRequest): CompiledQuery;
+}
+
+export interface QueryPermissionAdapter {
+  transform(ast: SelectQueryAst, context: PermissionAstTransformContext): SelectQueryAst;
 }
 
 export interface QueryDatasourceAdapter extends DatasourceAdapter {}
@@ -18,7 +31,18 @@ export function createQueryCompilerAdapter(
   compile: (request: QueryRequest) => CompiledQuery = compileSelectQuery
 ): QueryCompilerAdapter {
   return {
+    buildAst: buildSelectQueryAst,
+    compileAst: compileSelectAst,
     compile
+  };
+}
+
+export function createQueryPermissionAdapter(
+  transform: (ast: SelectQueryAst, context: PermissionAstTransformContext) => SelectQueryAst =
+    transformSelectQueryAstWithPermission
+): QueryPermissionAdapter {
+  return {
+    transform
   };
 }
 

--- a/packages/runtime/test/query-executor.test.ts
+++ b/packages/runtime/test/query-executor.test.ts
@@ -1,6 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import type { QueryRequest } from "@zhongmiao/meta-lc-query";
+import {
+  buildSelectQueryAst,
+  compileSelectAst,
+  type QueryRequest,
+  type SelectQueryAst
+} from "@zhongmiao/meta-lc-query";
 import { createQueryCompilerAdapter, executeQueryNode, QueryExecutorError, type QueryNodeDefinition, type RuntimeContext, type RuntimeStateStore } from "../src";
 
 const runtimeState: RuntimeStateStore = {
@@ -13,6 +18,9 @@ const runtimeState: RuntimeStateStore = {
 };
 
 const runtimeContext: RuntimeContext = {
+  tenantId: "tenant-a",
+  userId: "user-1",
+  roles: ["USER"],
   params: {
     limit: 7
   }
@@ -33,16 +41,43 @@ function createQueryNode(): QueryNodeDefinition {
 
 test("executeQueryNode resolves expressions before compiling and querying", async () => {
   const compileCalls: QueryRequest[] = [];
+  const permissionCalls: Array<{ ast: SelectQueryAst; tenantId: string }> = [];
+  const compileAstCalls: SelectQueryAst[] = [];
   const executeCalls: Array<{ kind: string; sql: string; params: unknown[] }> = [];
 
   const rows = [{ id: "row-1", owner: "user-1" }];
   const result = await executeQueryNode(createQueryNode(), runtimeState, runtimeContext, {
     compiler: {
-      compile(request) {
+      buildAst(request) {
         compileCalls.push(request);
+        return buildSelectQueryAst(request);
+      },
+      compileAst(ast) {
+        compileAstCalls.push(ast);
+        return compileSelectAst(ast);
+      },
+      compile() {
+        throw new Error("legacy compile should not be called");
+      }
+    },
+    permission: {
+      transform(ast, context) {
+        permissionCalls.push({ ast, tenantId: context.tenantId });
         return {
-          sql: 'SELECT "id", "owner" FROM "users" WHERE "owner" = $1 AND "status" = $2 LIMIT 7',
-          params: ["user-1", "active"]
+          ...ast,
+          where: {
+            type: "logical",
+            operator: "and",
+            predicates: [
+              ...(ast.where ? [ast.where] : []),
+              {
+                type: "comparison",
+                left: { name: "tenant_id" },
+                operator: "eq",
+                value: context.tenantId
+              }
+            ]
+          }
         };
       }
     },
@@ -79,10 +114,13 @@ test("executeQueryNode resolves expressions before compiling and querying", asyn
   assert.deepEqual(executeCalls, [
     {
       kind: "query",
-      sql: 'SELECT "id", "owner" FROM "users" WHERE "owner" = $1 AND "status" = $2 LIMIT 7',
-      params: ["user-1", "active"]
+      sql: 'SELECT "id", "owner" FROM "users" WHERE ("owner" = $1 AND "status" = $2) AND "tenant_id" = $3 LIMIT 7',
+      params: ["user-1", "active", "tenant-a"]
     }
   ]);
+  assert.equal(permissionCalls.length, 1);
+  assert.equal(permissionCalls[0]?.tenantId, "tenant-a");
+  assert.equal(compileAstCalls.length, 1);
   assert.deepEqual(result, rows);
 });
 
@@ -91,8 +129,14 @@ test("executeQueryNode wraps query compilation errors with traceable stage infor
     () =>
       executeQueryNode(createQueryNode(), runtimeState, runtimeContext, {
         compiler: {
-          compile() {
+          buildAst() {
             throw new Error("invalid query request");
+          },
+          compileAst() {
+            throw new Error("should not compile ast");
+          },
+          compile() {
+            throw new Error("legacy compile should not be called");
           }
         },
         datasource: {
@@ -107,6 +151,31 @@ test("executeQueryNode wraps query compilation errors with traceable stage infor
       assert.equal(error.cause instanceof Error, true);
       assert.match(error.message, /Failed to compile query node/);
       assert.match(error.message, /invalid query request/);
+      return true;
+    }
+  );
+});
+
+test("executeQueryNode wraps permission transform errors as compile errors", async () => {
+  await assert.rejects(
+    () =>
+      executeQueryNode(createQueryNode(), runtimeState, runtimeContext, {
+        compiler: createQueryCompilerAdapter(),
+        permission: {
+          transform() {
+            throw new Error("permission transform failed");
+          }
+        },
+        datasource: {
+          async execute() {
+            throw new Error("should not be called");
+          }
+        }
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof QueryExecutorError);
+      assert.equal(error.stage, "compile");
+      assert.match(error.message, /permission transform failed/);
       return true;
     }
   );

--- a/packages/runtime/test/runtime-view-executor.test.ts
+++ b/packages/runtime/test/runtime-view-executor.test.ts
@@ -25,6 +25,9 @@ test("executeRuntimeView compiles a view and executes through the runtime entryp
   const result = await executeRuntimeView(
     view,
     {
+      tenantId: "tenant-a",
+      userId: "user-1",
+      roles: ["USER"],
       input: {
         tenantId: "tenant-a"
       }
@@ -58,8 +61,8 @@ test("executeRuntimeView compiles a view and executes through the runtime entryp
   assert.deepEqual(queryCalls, [
     {
       kind: "query",
-      sql: 'SELECT "id", "owner" FROM "orders" WHERE "tenant_id" = $1 LIMIT 100',
-      params: ["tenant-a"]
+      sql: 'SELECT "id", "owner" FROM "orders" WHERE ("tenant_id" = $1) AND ("tenant_id" = $2 AND "created_by" = $3) LIMIT 100',
+      params: ["tenant-a", "tenant-a", "user-1"]
     }
   ]);
   assert.deepEqual(result.viewModel, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,13 @@ importers:
         version: 5.9.3
 
   packages/permission:
+    dependencies:
+      '@zhongmiao/meta-lc-contracts':
+        specifier: workspace:*
+        version: link:../contracts
+      '@zhongmiao/meta-lc-query':
+        specifier: workspace:*
+        version: link:../query
     devDependencies:
       '@types/node':
         specifier: ^22.10.2
@@ -203,6 +210,9 @@ importers:
       '@zhongmiao/meta-lc-datasource':
         specifier: workspace:*
         version: link:../datasource
+      '@zhongmiao/meta-lc-permission':
+        specifier: workspace:*
+        version: link:../permission
       '@zhongmiao/meta-lc-query':
         specifier: workspace:*
         version: link:../query


### PR DESCRIPTION
## Summary
- Add Permission AST Transform for tenant, self, and org-scope query constraints.
- Route runtime query execution through QueryRequest -> QueryAst -> Permission AST Transform -> SQL compiler -> datasource adapter.
- Extend query AST compiler with permission predicate shapes without adding datasource or kernel registry behavior.

Closes #89

## Checks
- pnpm --filter @zhongmiao/meta-lc-permission test
- pnpm --filter @zhongmiao/meta-lc-query test
- pnpm --filter @zhongmiao/meta-lc-runtime test
- pnpm --filter @zhongmiao/meta-lc-bff test
- pnpm run test:boundaries
- pnpm run lint
- pnpm query-gate
- pnpm -r build
- git diff --check
- node scripts/check-changelog-gate.mjs $(git merge-base origin/main HEAD) HEAD

## Risk / Rollback
- Risk: runtime query execution now requires permission context; BFF already supplies tenant/user/roles and orgScope.
- Rollback: revert this PR to return runtime query execution to direct QueryRequest compilation while keeping datasource adapter behavior unchanged.