### PR TITLE
feat(kernel): add meta definition registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- feat(kernel): add a versioned meta definition registry for view, datasource, and permission policy definitions.
 - feat(permission): add Query AST permission transforms and route runtime query compilation through them.
 - feat(datasource): converge runtime query execution onto the shared datasource adapter contract.
 - fix(boundaries): close Task 1-9 runtime boundary gaps by removing legacy BFF query/mutation orchestration and adding guards against regressions.

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- feat(kernel): 新增覆盖 view、datasource 与 permission policy 定义的版本化 meta definition registry。
 - feat(permission): 新增 Query AST permission transform，并让 runtime query 编译链路先经过权限 AST。
 - feat(datasource): 将 runtime query 执行收敛到共享 datasource adapter 契约。
 - fix(boundaries): 收口 Task 1-9 runtime 边界遗漏，移除旧 BFF query/mutation 编排并新增防回归边界守护。

--- a/packages/bff/CHANGELOG.md
+++ b/packages/bff/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- refactor(meta): read demo view, datasource, and permission definitions from the Kernel-backed registry.
 - test(permission): assert BFF view gateway context flows into runtime Permission AST Transform.
 - refactor(datasource): route BFF runtime view query execution through the datasource package adapter.
 - fix(boundaries): remove legacy `/query` and `/mutation` orchestration surfaces so BFF only acts as a runtime gateway.

--- a/packages/bff/CHANGELOG.zh-CN.md
+++ b/packages/bff/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- refactor(meta): demo view、datasource 与 permission definition 改为从 Kernel-backed registry 读取。
 - test(permission): 验证 BFF view gateway context 会进入 runtime Permission AST Transform。
 - refactor(datasource): BFF runtime view query 执行改为通过 datasource 包 adapter。
 - fix(boundaries): 移除旧 `/query` 与 `/mutation` 编排入口，让 BFF 只作为 runtime gateway。

--- a/packages/bff/README.md
+++ b/packages/bff/README.md
@@ -6,6 +6,8 @@ English | [中文文档](./README_zh.md)
 
 `bff` is the NestJS Gateway boundary package. It keeps protocol entry points, Runtime invocation, domain model, infrastructure integrations, bootstrap logic, and shared contracts in strict layers; it must not own query or mutation orchestration.
 
+BFF reads view definitions from the Kernel-backed meta registry before invoking the Runtime facade; it does not publish metadata or execute registry migrations itself.
+
 ## Source Layout
 
 ```text
@@ -88,6 +90,7 @@ controller -> application -> domain -> infra
 flowchart LR
   Http["HTTP / WS / CLI request"] --> Entry["controller/*"]
   Entry --> App["application services"]
+  App --> Kernel["Kernel meta registry"]
   App --> Infra["infra integration"]
   App --> Response["HTTP response / WS event"]
 ```

--- a/packages/bff/README_zh.md
+++ b/packages/bff/README_zh.md
@@ -6,6 +6,8 @@
 
 `bff` 是 NestJS Gateway 边界包。它用严格分层隔离协议入口、Runtime 调用、领域模型、基础设施集成、启动逻辑和共享契约；不得承载 query / mutation 编排。
 
+BFF 在调用 Runtime facade 前从 Kernel-backed meta registry 读取 view definition；它不发布元数据，也不执行 registry migration。
+
 ## 源码结构
 
 ```text
@@ -88,6 +90,7 @@ controller -> application -> domain -> infra
 flowchart LR
   Http["HTTP / WS / CLI request"] --> Entry["controller/*"]
   Entry --> App["application services"]
+  App --> Kernel["Kernel meta registry"]
   App --> Infra["infra integration"]
   App --> Response["HTTP response / WS event"]
 ```

--- a/packages/bff/package.json
+++ b/packages/bff/package.json
@@ -17,6 +17,7 @@
     "@nestjs/websockets": "^10.4.22",
     "@zhongmiao/meta-lc-contracts": "workspace:*",
     "@zhongmiao/meta-lc-datasource": "workspace:*",
+    "@zhongmiao/meta-lc-kernel": "workspace:*",
     "@zhongmiao/meta-lc-runtime": "workspace:*",
     "pg": "^8.13.1",
     "redis": "^4.7.1",

--- a/packages/bff/src/application/services/aggregation.service.ts
+++ b/packages/bff/src/application/services/aggregation.service.ts
@@ -6,15 +6,16 @@ import type { MetaSummary } from "../types/meta-summary.type";
 export class AggregationService {
   constructor(private readonly registry: MetaRegistryService) {}
 
-  summarizeMeta(): MetaSummary {
-    return this.registry.listKinds().reduce((summary, kind) => {
-      const items = this.registry.list(kind);
+  async summarizeMeta(): Promise<MetaSummary> {
+    const summary = {} as MetaSummary;
+    for (const kind of this.registry.listKinds()) {
+      const items = await this.registry.list(kind);
       summary[kind] = {
         count: items.length,
         updatedAt: newestUpdatedAt(items.map((item) => item.updatedAt))
       };
-      return summary;
-    }, {} as MetaSummary);
+    }
+    return summary;
   }
 }
 

--- a/packages/bff/src/application/services/meta-registry.service.ts
+++ b/packages/bff/src/application/services/meta-registry.service.ts
@@ -1,34 +1,32 @@
 import { Injectable } from "@nestjs/common";
-import type { ViewDefinition } from "@zhongmiao/meta-lc-contracts";
-import { META_REGISTRY_UPDATED_AT, META_REGISTRY_VIEW_FIXTURES } from "../../constants/meta-registry.constants";
+import type {
+  DatasourceDefinition,
+  PermissionPolicy,
+  ViewDefinition
+} from "@zhongmiao/meta-lc-contracts";
+import {
+  InMemoryMetaKernelRepository,
+  MetaKernelService,
+  type MetaDefinitionKind,
+  type MetaDefinitionVersion
+} from "@zhongmiao/meta-lc-kernel";
+import {
+  META_KERNEL_APP_ID,
+  META_KERNEL_DEFINITION_SEEDS,
+  META_REGISTRY_UPDATED_AT
+} from "../../constants/meta-registry.constants";
 import type {
   MetaRegistryItem,
   MetaResourceKind
 } from "../../contracts/types/meta-registry.type";
 
-const FIXTURES: Record<MetaResourceKind, MetaRegistryItem[]> = {
+const STATIC_FIXTURES: Pick<Record<MetaResourceKind, MetaRegistryItem[]>, "tables" | "rules"> = {
   tables: [
     {
       id: "orders",
       name: "Orders",
       updatedAt: META_REGISTRY_UPDATED_AT,
       fields: ["id", "owner", "channel", "priority", "status", "tenant_id", "org_id"]
-    }
-  ],
-  pages: [
-    {
-      id: "orders-workbench",
-      name: "Orders Workbench",
-      updatedAt: META_REGISTRY_UPDATED_AT,
-      route: "/studio/page/orders"
-    }
-  ],
-  datasources: [
-    {
-      id: "orders-query",
-      name: "Orders Query",
-      updatedAt: META_REGISTRY_UPDATED_AT,
-      type: "bff-query"
     }
   ],
   rules: [
@@ -38,33 +36,78 @@ const FIXTURES: Record<MetaResourceKind, MetaRegistryItem[]> = {
       updatedAt: META_REGISTRY_UPDATED_AT,
       trigger: "mutation.succeeded"
     }
-  ],
-  permissions: [
-    {
-      id: "orders-data-scope",
-      name: "Orders Data Scope",
-      updatedAt: META_REGISTRY_UPDATED_AT,
-      scopes: ["SELF", "DEPT", "DEPT_AND_CHILDREN", "CUSTOM_ORG_SET", "TENANT_ALL"]
-    }
   ]
 };
 
 @Injectable()
 export class MetaRegistryService {
-  list(kind: MetaResourceKind): MetaRegistryItem[] {
-    return FIXTURES[kind].map((item) => ({ ...item }));
+  private readonly kernel = new MetaKernelService(
+    new InMemoryMetaKernelRepository({
+      definitions: META_KERNEL_DEFINITION_SEEDS
+    })
+  );
+
+  async list(kind: MetaResourceKind): Promise<MetaRegistryItem[]> {
+    if (kind === "pages") {
+      return this.listKernelDefinitions("view");
+    }
+    if (kind === "datasources") {
+      return this.listKernelDefinitions("datasource");
+    }
+    if (kind === "permissions") {
+      return this.listKernelDefinitions("permissionPolicy");
+    }
+    return STATIC_FIXTURES[kind].map((item) => ({ ...item }));
   }
 
   listKinds(): MetaResourceKind[] {
     return ["tables", "pages", "datasources", "rules", "permissions"];
   }
 
-  getView(name: string): ViewDefinition | null {
-    const view = META_REGISTRY_VIEW_FIXTURES[name];
-    return view ? structuredClone(view) : null;
+  async getView(name: string): Promise<ViewDefinition | null> {
+    const view = await this.kernel.getViewDefinition(META_KERNEL_APP_ID, name);
+    return view ? structuredClone(view.definition) : null;
   }
 
-  listViewNames(): string[] {
-    return Object.keys(META_REGISTRY_VIEW_FIXTURES).sort((left, right) => left.localeCompare(right));
+  async listViewNames(): Promise<string[]> {
+    const views = await this.kernel.listLatestDefinitions(META_KERNEL_APP_ID, "view");
+    return views.map((view) => view.id).sort((left, right) => left.localeCompare(right));
   }
+
+  private async listKernelDefinitions(kind: MetaDefinitionKind): Promise<MetaRegistryItem[]> {
+    const definitions = await this.kernel.listLatestDefinitions(META_KERNEL_APP_ID, kind);
+    return definitions.map((item) => toMetaRegistryItem(item));
+  }
+}
+
+function toMetaRegistryItem(item: MetaDefinitionVersion): MetaRegistryItem {
+  if (item.kind === "view") {
+    const definition = item.definition as ViewDefinition;
+    return {
+      id: item.id,
+      name: definition.name,
+      updatedAt: item.metadata.createdAt,
+      version: item.version
+    };
+  }
+  if (item.kind === "datasource") {
+    const definition = item.definition as DatasourceDefinition;
+    return {
+      id: item.id,
+      name: definition.id,
+      updatedAt: item.metadata.createdAt,
+      type: definition.type,
+      version: item.version
+    };
+  }
+  const definition = item.definition as PermissionPolicy;
+  return {
+    id: item.id,
+    name: definition.id,
+    updatedAt: item.metadata.createdAt,
+    resource: definition.resource,
+    action: definition.action,
+    roles: [...definition.roles],
+    version: item.version
+  };
 }

--- a/packages/bff/src/application/services/temporary-view-adapter.service.ts
+++ b/packages/bff/src/application/services/temporary-view-adapter.service.ts
@@ -19,7 +19,7 @@ export class TemporaryViewAdapter {
   ) {}
 
   async execute(viewName: string, request: ViewApiRequest, requestId: string): Promise<TemporaryViewExecutionResult> {
-    const view = this.lookupView(viewName);
+    const view = await this.lookupView(viewName);
     const runtimeContext = await this.buildRuntimeContext(request, requestId, viewName);
     const runtime = await executeRuntimeView(view, runtimeContext, this.runtimeDependencies.create());
 
@@ -30,8 +30,8 @@ export class TemporaryViewAdapter {
     };
   }
 
-  private lookupView(viewName: string): ViewDefinition {
-    const view = this.registry.getView(viewName);
+  private async lookupView(viewName: string): Promise<ViewDefinition> {
+    const view = await this.registry.getView(viewName);
     if (!view) {
       throw new NotFoundException(`view "${viewName}" not found`);
     }

--- a/packages/bff/src/constants/meta-registry.constants.ts
+++ b/packages/bff/src/constants/meta-registry.constants.ts
@@ -1,6 +1,12 @@
-import type { ViewDefinition } from "@zhongmiao/meta-lc-contracts";
+import type {
+  DatasourceDefinition,
+  PermissionPolicy,
+  ViewDefinition
+} from "@zhongmiao/meta-lc-contracts";
+import type { InMemoryMetaDefinitionSeed } from "@zhongmiao/meta-lc-kernel";
 
 export const META_REGISTRY_UPDATED_AT = "2026-04-20T00:00:00.000Z";
+export const META_KERNEL_APP_ID = "orders-demo-app";
 
 export const META_REGISTRY_VIEW_FIXTURES: Record<string, ViewDefinition> = {
   "orders-workbench": {
@@ -26,3 +32,56 @@ export const META_REGISTRY_VIEW_FIXTURES: Record<string, ViewDefinition> = {
     }
   }
 };
+
+export const META_REGISTRY_DATASOURCE_FIXTURES: Record<string, DatasourceDefinition> = {
+  "orders-query": {
+    id: "orders-query",
+    type: "bff-query",
+    description: "Orders runtime query datasource"
+  }
+};
+
+export const META_REGISTRY_PERMISSION_FIXTURES: Record<string, PermissionPolicy> = {
+  "orders-data-scope": {
+    id: "orders-data-scope",
+    resource: "orders",
+    action: "query",
+    roles: ["SELF", "DEPT", "DEPT_AND_CHILDREN", "CUSTOM_ORG_SET", "TENANT_ALL"]
+  }
+};
+
+export const META_KERNEL_DEFINITION_SEEDS: InMemoryMetaDefinitionSeed[] = [
+  ...Object.entries(META_REGISTRY_VIEW_FIXTURES).map(([id, definition]) => ({
+    appId: META_KERNEL_APP_ID,
+    kind: "view" as const,
+    id,
+    definition,
+    metadata: {
+      author: "system",
+      message: "Seed demo view definition",
+      createdAt: META_REGISTRY_UPDATED_AT
+    }
+  })),
+  ...Object.entries(META_REGISTRY_DATASOURCE_FIXTURES).map(([id, definition]) => ({
+    appId: META_KERNEL_APP_ID,
+    kind: "datasource" as const,
+    id,
+    definition,
+    metadata: {
+      author: "system",
+      message: "Seed demo datasource definition",
+      createdAt: META_REGISTRY_UPDATED_AT
+    }
+  })),
+  ...Object.entries(META_REGISTRY_PERMISSION_FIXTURES).map(([id, definition]) => ({
+    appId: META_KERNEL_APP_ID,
+    kind: "permissionPolicy" as const,
+    id,
+    definition,
+    metadata: {
+      author: "system",
+      message: "Seed demo permission policy",
+      createdAt: META_REGISTRY_UPDATED_AT
+    }
+  }))
+];

--- a/packages/bff/test/meta-gateway.test.ts
+++ b/packages/bff/test/meta-gateway.test.ts
@@ -26,7 +26,7 @@ test("aggregation summary returns resource counts and updated timestamps", async
   const registry = new MetaRegistryService();
   const aggregation = new AggregationService(registry);
 
-  const summary = aggregation.summarizeMeta();
+  const summary = await aggregation.summarizeMeta();
 
   assert.equal(summary.tables.count, 1);
   assert.equal(summary.pages.count, 1);

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- feat(meta-contracts): add datasource and permission policy definition contracts for Kernel meta registry.
 - feat(runtime-contracts): move V2 ViewDefinition, ExecutionPlan, and runtime node contracts into the shared contracts package.
 - fix(api-contracts): stop exporting removed legacy BFF query/mutation API contracts.
 - docs(readme): add bilingual package README and minimal architecture flow.

--- a/packages/contracts/CHANGELOG.zh-CN.md
+++ b/packages/contracts/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- feat(meta-contracts): 新增 Kernel meta registry 使用的 datasource 与 permission policy definition 契约。
 - feat(runtime-contracts): 将 V2 ViewDefinition、ExecutionPlan 与 runtime node 契约迁入共享 contracts 包。
 - fix(api-contracts): 停止导出已移除的旧 BFF query/mutation API 契约。
 - docs(readme): 新增双语子包 README 与最小架构流程图。

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -39,6 +39,21 @@ export interface DataScopeDecision {
   reason: string;
 }
 
+export interface DatasourceDefinition {
+  id: string;
+  type: string;
+  config?: Record<string, unknown>;
+  description?: string;
+}
+
+export interface PermissionPolicy {
+  id: string;
+  resource: string;
+  action: string;
+  roles: string[];
+  scope?: DataScopeType;
+}
+
 export interface DbConfig {
   url?: string;
   host: string;

--- a/packages/contracts/test/smoke.test.ts
+++ b/packages/contracts/test/smoke.test.ts
@@ -4,7 +4,9 @@ import {
   buildRuntimePageTopic,
   createRuntimeManagerExecutedEvent,
   RUNTIME_MANAGER_EXECUTED_EVENT,
+  type DatasourceDefinition,
   type ExecutionPlan,
+  type PermissionPolicy,
   type ViewDefinition,
   type RuntimeManagerExecutedEvent,
   type RuntimeFunctionCallDefinition,
@@ -50,6 +52,26 @@ test("contracts exports V2 view and execution plan contracts", () => {
 
   assert.equal(view.nodes.orders?.type, "query");
   assert.equal(plan.nodes[0]?.id, "orders");
+});
+
+test("contracts exports meta definition registry contracts", () => {
+  const datasource: DatasourceDefinition = {
+    id: "orders-query",
+    type: "postgres",
+    config: {
+      target: "business"
+    }
+  };
+  const policy: PermissionPolicy = {
+    id: "orders-query-policy",
+    resource: "orders",
+    action: "query",
+    roles: ["SALES"],
+    scope: "DEPT"
+  };
+
+  assert.equal(datasource.id, "orders-query");
+  assert.equal(policy.scope, "DEPT");
 });
 
 test("contracts exports runtime dsl types", () => {

--- a/packages/kernel/CHANGELOG.md
+++ b/packages/kernel/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- feat(meta-registry): add versioned view, datasource, and permission policy definition registry APIs.
 - refactor(package-structure): reorganize src into layered domain/application/infra/interface/types/utils directories and update public entrypoints.
 - docs(readme): add bilingual package README and minimal architecture flow.
 - chore(package): adopt the `@zhongmiao/meta-lc-kernel` scoped package identity for release governance.

--- a/packages/kernel/CHANGELOG.zh-CN.md
+++ b/packages/kernel/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- feat(meta-registry): 新增 view、datasource 与 permission policy definition 的版本化 registry API。
 - refactor(package-structure): 将 src 重整为 domain/application/infra/interface/types/utils 分层目录，并同步更新对外入口。
 - docs(readme): 新增双语子包 README 与最小架构流程图。
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-kernel` 正式包名。

--- a/packages/kernel/README.md
+++ b/packages/kernel/README.md
@@ -4,20 +4,21 @@ English | [中文文档](./README_zh.md)
 
 ## Package Role
 
-`kernel` is the structural metadata source for the platform. It owns MetaSchema types, schema validation, snapshot and migration DSL helpers, schema diff, SQL generation, API route manifest generation, permission manifest generation, version publishing, rollback, and migration audit persistence.
+`kernel` is the structural metadata source for the platform. It owns MetaSchema types, schema validation, snapshot and migration DSL helpers, schema diff, SQL generation, API route manifest generation, permission manifest generation, version publishing, rollback, migration audit persistence, and the versioned meta definition registry for views, datasources, and permission policies.
 
 ## Responsibilities
 
 - Define table, field, relation, index, tenant, app, rule, and permission schema types.
 - Validate schemas before they are published.
 - Persist and retrieve versioned schemas through the Postgres repository.
+- Publish, retrieve, and diff versioned view, datasource, and permission policy definitions.
 - Generate schema SQL, migration SQL, API route manifests, and permission manifests.
 - Guard destructive migration statements and record migration audits.
 
 ## Relationship With Other Packages
 
 - `migration` reuses kernel migration compile and safety helpers.
-- `bff` should compose kernel services for meta APIs and migration orchestration.
+- `bff` composes kernel registry services for meta definition lookup and can use kernel services for migration orchestration.
 - `query`, `permission`, and `datasource` must not become kernel dependencies.
 - `platform` may expose kernel-facing capabilities through package composition later, but the runnable BFF remains separate.
 
@@ -28,6 +29,7 @@ flowchart LR
   Schema["MetaSchema"] --> Validate["validateSchema"]
   Validate --> Publish["publishSchema"]
   Publish --> Version["meta_kernel_versions"]
+  Definition["View / Datasource / Policy"] --> Registry["meta definition registry"]
   Version --> Diff["diff / buildMigrationPlan"]
   Diff --> Sql["migration SQL + safety report"]
 ```
@@ -44,3 +46,4 @@ pnpm --filter @zhongmiao/meta-lc-kernel test
 - Kernel is the metadata source of truth and must stay independent from BFF orchestration.
 - DB access here is limited to meta-kernel persistence and migration audit responsibilities.
 - Do not add HTTP, NestJS controller, runtime UI, or business execution logic here.
+- Do not execute runtime plans from meta registry APIs; registry only versions definitions.

--- a/packages/kernel/README_zh.md
+++ b/packages/kernel/README_zh.md
@@ -4,20 +4,21 @@
 
 ## 包定位
 
-`kernel` 是平台结构元数据来源。它负责 MetaSchema 类型、schema 校验、snapshot/migration DSL helper、schema diff、SQL 生成、API route manifest 生成、permission manifest 生成、版本发布、回滚与 migration audit 持久化。
+`kernel` 是平台结构元数据来源。它负责 MetaSchema 类型、schema 校验、snapshot/migration DSL helper、schema diff、SQL 生成、API route manifest 生成、permission manifest 生成、版本发布、回滚、migration audit 持久化，以及 view、datasource、permission policy 的版本化 meta definition registry。
 
 ## 核心职责
 
 - 定义 table、field、relation、index、tenant、app、rule、permission schema 类型。
 - 在发布前校验 schema。
 - 通过 Postgres repository 持久化和读取版本化 schema。
+- 发布、读取和 diff 版本化 view、datasource 与 permission policy definition。
 - 生成 schema SQL、migration SQL、API route manifest 与 permission manifest。
 - 拦截破坏性 migration statement，并记录 migration audit。
 
 ## 与其他包关系
 
 - `migration` 复用 kernel 的 migration compile 与 safety helper。
-- `bff` 应通过编排接入 kernel service，承载 meta API 与 migration orchestration。
+- `bff` 组合 kernel registry service 读取 meta definition，也可后续组合 kernel service 承载 migration orchestration。
 - `query`、`permission`、`datasource` 不能成为 kernel 依赖。
 - `platform` 后续可聚合 kernel 能力，但可运行 BFF 仍保持独立。
 
@@ -28,6 +29,7 @@ flowchart LR
   Schema["MetaSchema"] --> Validate["validateSchema"]
   Validate --> Publish["publishSchema"]
   Publish --> Version["meta_kernel_versions"]
+  Definition["View / Datasource / Policy"] --> Registry["meta definition registry"]
   Version --> Diff["diff / buildMigrationPlan"]
   Diff --> Sql["migration SQL + safety report"]
 ```
@@ -44,3 +46,4 @@ pnpm --filter @zhongmiao/meta-lc-kernel test
 - Kernel 是元数据结构真源，必须独立于 BFF 编排。
 - 这里的 DB access 仅服务 meta-kernel persistence 与 migration audit。
 - 不在这里加入 HTTP、NestJS controller、runtime UI 或业务执行逻辑。
+- meta registry API 不执行 runtime plan；只负责 definition versioning。

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -9,6 +9,7 @@
     "lint": "echo lint:kernel"
   },
   "dependencies": {
+    "@zhongmiao/meta-lc-contracts": "workspace:*",
     "pg": "^8.13.1"
   },
   "devDependencies": {
@@ -16,6 +17,6 @@
     "@types/pg": "^8.11.10",
     "typescript": "^5.7.2"
   },
-  "main": "dist/src/index.js",
-  "types": "dist/src/index.d.ts"
+  "main": "dist/kernel/src/index.js",
+  "types": "dist/kernel/src/index.d.ts"
 }

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -1,2 +1,3 @@
 export * from "./schema-diff";
 export * from "./snapshot-dsl";
+export * from "./meta-definition-registry";

--- a/packages/kernel/src/domain/meta-definition-registry.ts
+++ b/packages/kernel/src/domain/meta-definition-registry.ts
@@ -1,0 +1,136 @@
+import type {
+  DatasourceDefinition,
+  MetaDefinitionByKind,
+  MetaDefinitionDiff,
+  MetaDefinitionKind,
+  PermissionPolicy,
+  ViewDefinition
+} from "../types/shared.types";
+
+export function validateMetaDefinition<K extends MetaDefinitionKind>(
+  kind: K,
+  definition: MetaDefinitionByKind[K]
+): void {
+  if (kind === "view") {
+    validateViewDefinition(definition as ViewDefinition);
+    return;
+  }
+  if (kind === "datasource") {
+    validateDatasourceDefinition(definition as DatasourceDefinition);
+    return;
+  }
+  validatePermissionPolicy(definition as PermissionPolicy);
+}
+
+export function diffMetaDefinitions(input: {
+  appId: string;
+  kind: MetaDefinitionKind;
+  id: string;
+  fromVersion: number;
+  toVersion: number;
+  fromDefinition: unknown;
+  toDefinition: unknown;
+}): MetaDefinitionDiff {
+  return {
+    appId: input.appId,
+    kind: input.kind,
+    id: input.id,
+    fromVersion: input.fromVersion,
+    toVersion: input.toVersion,
+    changedPaths: collectChangedPaths(input.fromDefinition, input.toDefinition)
+  };
+}
+
+function validateViewDefinition(definition: ViewDefinition): void {
+  if (!definition || typeof definition !== "object") {
+    throw new Error("ViewDefinition must be an object.");
+  }
+  if (!definition.name?.trim()) {
+    throw new Error("ViewDefinition.name is required.");
+  }
+  if (!isPlainObject(definition.nodes) || Object.keys(definition.nodes).length === 0) {
+    throw new Error("ViewDefinition.nodes must be a non-empty object.");
+  }
+  if (!isPlainObject(definition.output)) {
+    throw new Error("ViewDefinition.output must be an object.");
+  }
+}
+
+function validateDatasourceDefinition(definition: DatasourceDefinition): void {
+  if (!definition || typeof definition !== "object") {
+    throw new Error("DatasourceDefinition must be an object.");
+  }
+  if (!definition.id?.trim()) {
+    throw new Error("DatasourceDefinition.id is required.");
+  }
+  if (!definition.type?.trim()) {
+    throw new Error(`DatasourceDefinition ${definition.id || "__unknown__"} requires a type.`);
+  }
+}
+
+function validatePermissionPolicy(policy: PermissionPolicy): void {
+  if (!policy || typeof policy !== "object") {
+    throw new Error("PermissionPolicy must be an object.");
+  }
+  if (!policy.id?.trim()) {
+    throw new Error("PermissionPolicy.id is required.");
+  }
+  if (!policy.resource?.trim()) {
+    throw new Error(`PermissionPolicy ${policy.id} requires a resource.`);
+  }
+  if (!policy.action?.trim()) {
+    throw new Error(`PermissionPolicy ${policy.id} requires an action.`);
+  }
+  if (!Array.isArray(policy.roles) || policy.roles.length === 0) {
+    throw new Error(`PermissionPolicy ${policy.id} requires at least one role.`);
+  }
+
+  const roles = new Set<string>();
+  for (const role of policy.roles) {
+    if (!role?.trim()) {
+      throw new Error(`PermissionPolicy ${policy.id} has an empty role.`);
+    }
+    if (roles.has(role)) {
+      throw new Error(`PermissionPolicy ${policy.id} has duplicate role "${role}".`);
+    }
+    roles.add(role);
+  }
+}
+
+function collectChangedPaths(left: unknown, right: unknown, prefix = ""): string[] {
+  if (Object.is(left, right)) {
+    return [];
+  }
+
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right)) {
+      return [prefix || "$"];
+    }
+
+    const paths: string[] = [];
+    const length = Math.max(left.length, right.length);
+    for (let index = 0; index < length; index += 1) {
+      paths.push(...collectChangedPaths(left[index], right[index], appendPath(prefix, String(index))));
+    }
+    return paths.sort();
+  }
+
+  if (isPlainObject(left) && isPlainObject(right)) {
+    const paths: string[] = [];
+    const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
+    for (const key of [...keys].sort()) {
+      paths.push(...collectChangedPaths(left[key], right[key], appendPath(prefix, key)));
+    }
+    return paths.sort();
+  }
+
+  return [prefix || "$"];
+}
+
+function appendPath(prefix: string, segment: string): string {
+  return prefix ? `${prefix}.${segment}` : segment;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/kernel/src/infra/index.ts
+++ b/packages/kernel/src/infra/index.ts
@@ -1,1 +1,2 @@
+export * from "./persistence/in-memory-meta-kernel-repository";
 export * from "./persistence/postgres-meta-kernel-repository";

--- a/packages/kernel/src/infra/persistence/in-memory-meta-kernel-repository.ts
+++ b/packages/kernel/src/infra/persistence/in-memory-meta-kernel-repository.ts
@@ -1,0 +1,151 @@
+import type {
+  MetaDefinitionKind,
+  MetaDefinitionPublishInput,
+  MetaDefinitionVersion,
+  MetaSchema,
+  MetaVersion
+} from "../../types/shared.types";
+
+export interface InMemoryMetaDefinitionSeed<K extends MetaDefinitionKind = MetaDefinitionKind> {
+  appId: string;
+  kind: K;
+  id: string;
+  definition: MetaDefinitionVersion<K>["definition"];
+  version?: number;
+  metadata?: Partial<MetaDefinitionVersion<K>["metadata"]>;
+}
+
+export class InMemoryMetaKernelRepository {
+  private readonly schemaVersions = new Map<string, MetaVersion[]>();
+  private readonly definitionVersions = new Map<string, Array<MetaDefinitionVersion<MetaDefinitionKind>>>();
+
+  constructor(seed: { definitions?: InMemoryMetaDefinitionSeed[] } = {}) {
+    for (const definition of seed.definitions ?? []) {
+      this.seedDefinition(definition);
+    }
+  }
+
+  async init(): Promise<void> {}
+
+  async createVersion(input: {
+    appId: string;
+    schema: MetaSchema;
+    metadata: { author: string; message: string; rollbackFromVersion?: number | null };
+  }): Promise<MetaVersion> {
+    const versions = this.schemaVersions.get(input.appId) ?? [];
+    const version: MetaVersion = {
+      appId: input.appId,
+      version: versions.length ? Math.max(...versions.map((item) => item.version)) + 1 : 1,
+      schema: structuredClone(input.schema),
+      metadata: {
+        author: input.metadata.author,
+        message: input.metadata.message,
+        createdAt: new Date().toISOString(),
+        rollbackFromVersion: input.metadata.rollbackFromVersion ?? null
+      }
+    };
+    versions.push(version);
+    this.schemaVersions.set(input.appId, versions);
+    return structuredClone(version);
+  }
+
+  async getVersion(appId: string, version: number): Promise<MetaVersion | null> {
+    const item = this.schemaVersions.get(appId)?.find((candidate) => candidate.version === version);
+    return item ? structuredClone(item) : null;
+  }
+
+  async executeMigration(): Promise<{ auditCount: number }> {
+    return { auditCount: 0 };
+  }
+
+  async createDefinitionVersion<K extends MetaDefinitionKind>(
+    input: MetaDefinitionPublishInput<K>
+  ): Promise<MetaDefinitionVersion<K>> {
+    const versions = this.getDefinitionVersions(input.appId, input.kind, input.id);
+    const version: MetaDefinitionVersion<K> = {
+      appId: input.appId,
+      kind: input.kind,
+      id: input.id,
+      version: versions.length ? Math.max(...versions.map((item) => item.version)) + 1 : 1,
+      definition: structuredClone(input.definition),
+      metadata: {
+        author: input.metadata.author,
+        message: input.metadata.message,
+        createdAt: new Date().toISOString()
+      }
+    };
+    this.storeDefinition(version);
+    return structuredClone(version);
+  }
+
+  async getLatestDefinitionVersion<K extends MetaDefinitionKind>(
+    appId: string,
+    kind: K,
+    id: string
+  ): Promise<MetaDefinitionVersion<K> | null> {
+    const versions = this.getDefinitionVersions(appId, kind, id);
+    const latest = versions.sort((left, right) => right.version - left.version)[0];
+    return latest ? structuredClone(latest) : null;
+  }
+
+  async getDefinitionVersion<K extends MetaDefinitionKind>(
+    appId: string,
+    kind: K,
+    id: string,
+    version: number
+  ): Promise<MetaDefinitionVersion<K> | null> {
+    const item = this.getDefinitionVersions(appId, kind, id).find((candidate) => candidate.version === version);
+    return item ? structuredClone(item) : null;
+  }
+
+  async listLatestDefinitionVersions<K extends MetaDefinitionKind>(
+    appId: string,
+    kind: K
+  ): Promise<Array<MetaDefinitionVersion<K>>> {
+    const byId = new Map<string, MetaDefinitionVersion<K>>();
+    for (const item of this.definitionVersions.get(appId) ?? []) {
+      if (item.kind !== kind) {
+        continue;
+      }
+      const current = byId.get(item.id);
+      if (!current || item.version > current.version) {
+        byId.set(item.id, item as MetaDefinitionVersion<K>);
+      }
+    }
+
+    return [...byId.values()]
+      .sort((left, right) => left.id.localeCompare(right.id))
+      .map((item) => structuredClone(item));
+  }
+
+  private seedDefinition<K extends MetaDefinitionKind>(seed: InMemoryMetaDefinitionSeed<K>): void {
+    this.storeDefinition({
+      appId: seed.appId,
+      kind: seed.kind,
+      id: seed.id,
+      version: seed.version ?? 1,
+      definition: structuredClone(seed.definition),
+      metadata: {
+        author: seed.metadata?.author ?? "system",
+        message: seed.metadata?.message ?? "Seed definition",
+        createdAt: seed.metadata?.createdAt ?? new Date().toISOString()
+      }
+    });
+  }
+
+  private storeDefinition<K extends MetaDefinitionKind>(version: MetaDefinitionVersion<K>): void {
+    const versions = this.definitionVersions.get(version.appId) ?? [];
+    versions.push(version as MetaDefinitionVersion<MetaDefinitionKind>);
+    this.definitionVersions.set(version.appId, versions);
+  }
+
+  private getDefinitionVersions<K extends MetaDefinitionKind>(
+    appId: string,
+    kind: K,
+    id: string
+  ): Array<MetaDefinitionVersion<K>> {
+    return (this.definitionVersions.get(appId) ?? []).filter(
+      (item): item is MetaDefinitionVersion<K> => item.kind === kind && item.id === id
+    );
+  }
+}

--- a/packages/kernel/src/infra/persistence/postgres-meta-kernel-repository.ts
+++ b/packages/kernel/src/infra/persistence/postgres-meta-kernel-repository.ts
@@ -3,6 +3,9 @@ import { createMigrationSafetyReport, type MigrationGuardOptions } from "../../a
 import { randomUUID } from "node:crypto";
 import type {
   DbConfig,
+  MetaDefinitionKind,
+  MetaDefinitionPublishInput,
+  MetaDefinitionVersion,
   MetaSchema,
   MetaVersion,
   MigrationAuditRecord
@@ -62,6 +65,23 @@ export class PostgresMetaKernelRepository {
     await this.pool.query(`
       CREATE INDEX IF NOT EXISTS idx_meta_kernel_migration_audits_app_created
       ON meta_kernel_migration_audits (app_id, created_at DESC)
+    `);
+    await this.pool.query(`
+      CREATE TABLE IF NOT EXISTS meta_kernel_definition_versions (
+        id BIGSERIAL PRIMARY KEY,
+        app_id TEXT NOT NULL,
+        definition_kind TEXT NOT NULL,
+        definition_id TEXT NOT NULL,
+        version INTEGER NOT NULL,
+        definition_json JSONB NOT NULL,
+        metadata_json JSONB NOT NULL,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        UNIQUE (app_id, definition_kind, definition_id, version)
+      );
+    `);
+    await this.pool.query(`
+      CREATE INDEX IF NOT EXISTS idx_meta_kernel_definition_versions_latest
+      ON meta_kernel_definition_versions (app_id, definition_kind, definition_id, version DESC)
     `);
   }
 
@@ -132,6 +152,101 @@ export class PostgresMetaKernelRepository {
       [input.appId, nextVersion, JSON.stringify(input.schema), JSON.stringify(metadata)]
     );
     return mapRow(result.rows[0]);
+  }
+
+  async getLatestDefinitionVersion<K extends MetaDefinitionKind>(
+    appId: string,
+    kind: K,
+    id: string
+  ): Promise<MetaDefinitionVersion<K> | null> {
+    const result = await this.pool.query(
+      `SELECT app_id, definition_kind, definition_id, version, definition_json, metadata_json
+       FROM meta_kernel_definition_versions
+       WHERE app_id = $1 AND definition_kind = $2 AND definition_id = $3
+       ORDER BY version DESC
+       LIMIT 1`,
+      [appId, kind, id]
+    );
+
+    if (result.rows.length === 0) {
+      return null;
+    }
+    return mapDefinitionRow<K>(result.rows[0]);
+  }
+
+  async getDefinitionVersion<K extends MetaDefinitionKind>(
+    appId: string,
+    kind: K,
+    id: string,
+    version: number
+  ): Promise<MetaDefinitionVersion<K> | null> {
+    const result = await this.pool.query(
+      `SELECT app_id, definition_kind, definition_id, version, definition_json, metadata_json
+       FROM meta_kernel_definition_versions
+       WHERE app_id = $1 AND definition_kind = $2 AND definition_id = $3 AND version = $4
+       LIMIT 1`,
+      [appId, kind, id, version]
+    );
+
+    if (result.rows.length === 0) {
+      return null;
+    }
+    return mapDefinitionRow<K>(result.rows[0]);
+  }
+
+  async listLatestDefinitionVersions<K extends MetaDefinitionKind>(
+    appId: string,
+    kind: K
+  ): Promise<Array<MetaDefinitionVersion<K>>> {
+    const result = await this.pool.query(
+      `SELECT DISTINCT ON (definition_id)
+        app_id,
+        definition_kind,
+        definition_id,
+        version,
+        definition_json,
+        metadata_json
+       FROM meta_kernel_definition_versions
+       WHERE app_id = $1 AND definition_kind = $2
+       ORDER BY definition_id ASC, version DESC`,
+      [appId, kind]
+    );
+
+    return result.rows.map(mapDefinitionRow<K>);
+  }
+
+  async createDefinitionVersion<K extends MetaDefinitionKind>(
+    input: MetaDefinitionPublishInput<K>
+  ): Promise<MetaDefinitionVersion<K>> {
+    const latest = await this.getLatestDefinitionVersion(input.appId, input.kind, input.id);
+    const nextVersion = latest ? latest.version + 1 : 1;
+    const metadata = {
+      author: input.metadata.author,
+      message: input.metadata.message,
+      createdAt: new Date().toISOString()
+    };
+
+    const result = await this.pool.query(
+      `INSERT INTO meta_kernel_definition_versions (
+        app_id,
+        definition_kind,
+        definition_id,
+        version,
+        definition_json,
+        metadata_json
+      )
+       VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb)
+       RETURNING app_id, definition_kind, definition_id, version, definition_json, metadata_json`,
+      [
+        input.appId,
+        input.kind,
+        input.id,
+        nextVersion,
+        JSON.stringify(input.definition),
+        JSON.stringify(metadata)
+      ]
+    );
+    return mapDefinitionRow<K>(result.rows[0]);
   }
 
   async executeMigration(
@@ -281,6 +396,24 @@ function mapRow(row: {
     appId: row.app_id,
     version: row.version,
     schema: row.schema_json,
+    metadata: row.metadata_json
+  };
+}
+
+function mapDefinitionRow<K extends MetaDefinitionKind>(row: {
+  app_id: string;
+  definition_kind: K;
+  definition_id: string;
+  version: number;
+  definition_json: MetaDefinitionVersion<K>["definition"];
+  metadata_json: MetaDefinitionVersion<K>["metadata"];
+}): MetaDefinitionVersion<K> {
+  return {
+    appId: row.app_id,
+    kind: row.definition_kind,
+    id: row.definition_id,
+    version: row.version,
+    definition: row.definition_json,
     metadata: row.metadata_json
   };
 }

--- a/packages/kernel/src/interface/meta-kernel-service.ts
+++ b/packages/kernel/src/interface/meta-kernel-service.ts
@@ -2,15 +2,30 @@ import { validateSchema } from "../types/contracts";
 import { createMigrationSafetyReport } from "../application/migration-safety";
 import { PostgresMetaKernelRepository } from "../infra/persistence/postgres-meta-kernel-repository";
 import type {
+  DatasourceDefinition,
+  MetaDefinitionDiff,
+  MetaDefinitionKind,
+  MetaDefinitionPublishInput,
+  MetaDefinitionVersion,
   MetaSchema,
   MetaVersion,
-  MigrationExecutionOptions
+  MigrationExecutionOptions,
+  PermissionPolicy,
+  ViewDefinition
 } from "../types/shared.types";
 import { diffSchemas, generateMigrationSql, type SchemaDiff } from "../domain/schema-diff";
+import { diffMetaDefinitions, validateMetaDefinition } from "../domain/meta-definition-registry";
 
 type KernelRepository = Pick<
   PostgresMetaKernelRepository,
-  "init" | "createVersion" | "getVersion" | "executeMigration"
+  | "init"
+  | "createVersion"
+  | "getVersion"
+  | "executeMigration"
+  | "createDefinitionVersion"
+  | "getDefinitionVersion"
+  | "getLatestDefinitionVersion"
+  | "listLatestDefinitionVersions"
 >;
 
 export interface MigrationExecutionResult {
@@ -43,6 +58,126 @@ export class MetaKernelService {
         author: input.author,
         message: input.message
       }
+    });
+  }
+
+  async publishViewDefinition(input: {
+    appId: string;
+    id?: string;
+    definition: ViewDefinition;
+    author: string;
+    message: string;
+  }): Promise<MetaDefinitionVersion<"view">> {
+    return this.publishDefinition({
+      appId: input.appId,
+      kind: "view",
+      id: input.id ?? input.definition.name,
+      definition: input.definition,
+      metadata: {
+        author: input.author,
+        message: input.message
+      }
+    });
+  }
+
+  async getViewDefinition(
+    appId: string,
+    id: string,
+    version?: number
+  ): Promise<MetaDefinitionVersion<"view"> | null> {
+    return this.getDefinition(appId, "view", id, version);
+  }
+
+  async publishDatasourceDefinition(input: {
+    appId: string;
+    definition: DatasourceDefinition;
+    author: string;
+    message: string;
+  }): Promise<MetaDefinitionVersion<"datasource">> {
+    return this.publishDefinition({
+      appId: input.appId,
+      kind: "datasource",
+      id: input.definition.id,
+      definition: input.definition,
+      metadata: {
+        author: input.author,
+        message: input.message
+      }
+    });
+  }
+
+  async getDatasourceDefinition(
+    appId: string,
+    id: string,
+    version?: number
+  ): Promise<MetaDefinitionVersion<"datasource"> | null> {
+    return this.getDefinition(appId, "datasource", id, version);
+  }
+
+  async publishPermissionPolicy(input: {
+    appId: string;
+    definition: PermissionPolicy;
+    author: string;
+    message: string;
+  }): Promise<MetaDefinitionVersion<"permissionPolicy">> {
+    return this.publishDefinition({
+      appId: input.appId,
+      kind: "permissionPolicy",
+      id: input.definition.id,
+      definition: input.definition,
+      metadata: {
+        author: input.author,
+        message: input.message
+      }
+    });
+  }
+
+  async getPermissionPolicy(
+    appId: string,
+    id: string,
+    version?: number
+  ): Promise<MetaDefinitionVersion<"permissionPolicy"> | null> {
+    return this.getDefinition(appId, "permissionPolicy", id, version);
+  }
+
+  async listLatestDefinitions<K extends MetaDefinitionKind>(
+    appId: string,
+    kind: K
+  ): Promise<Array<MetaDefinitionVersion<K>>> {
+    return this.repository.listLatestDefinitionVersions(appId, kind);
+  }
+
+  async diffDefinition(input: {
+    appId: string;
+    kind: MetaDefinitionKind;
+    id: string;
+    fromVersion: number;
+    toVersion: number;
+  }): Promise<MetaDefinitionDiff> {
+    const from = await this.repository.getDefinitionVersion(
+      input.appId,
+      input.kind,
+      input.id,
+      input.fromVersion
+    );
+    const to = await this.repository.getDefinitionVersion(
+      input.appId,
+      input.kind,
+      input.id,
+      input.toVersion
+    );
+    if (!from || !to) {
+      throw new Error("Cannot diff definition: one of the versions does not exist.");
+    }
+
+    return diffMetaDefinitions({
+      appId: input.appId,
+      kind: input.kind,
+      id: input.id,
+      fromVersion: input.fromVersion,
+      toVersion: input.toVersion,
+      fromDefinition: from.definition,
+      toDefinition: to.definition
     });
   }
 
@@ -142,5 +277,24 @@ export class MetaKernelService {
     }
 
     return results;
+  }
+
+  private async publishDefinition<K extends MetaDefinitionKind>(
+    input: MetaDefinitionPublishInput<K>
+  ): Promise<MetaDefinitionVersion<K>> {
+    validateMetaDefinition(input.kind, input.definition);
+    return this.repository.createDefinitionVersion(input);
+  }
+
+  private async getDefinition<K extends MetaDefinitionKind>(
+    appId: string,
+    kind: K,
+    id: string,
+    version?: number
+  ): Promise<MetaDefinitionVersion<K> | null> {
+    if (version === undefined) {
+      return this.repository.getLatestDefinitionVersion(appId, kind, id);
+    }
+    return this.repository.getDefinitionVersion(appId, kind, id, version);
   }
 }

--- a/packages/kernel/src/types/shared.types.ts
+++ b/packages/kernel/src/types/shared.types.ts
@@ -1,3 +1,9 @@
+import type {
+  DatasourceDefinition,
+  PermissionPolicy,
+  ViewDefinition
+} from "@zhongmiao/meta-lc-contracts";
+
 export type Primitive = string | number | boolean | null;
 
 export interface MetaField {
@@ -198,3 +204,55 @@ export interface MigrationAuditRecord {
   durationMs: number;
   requestId: string;
 }
+
+export type MetaDefinitionKind = "view" | "datasource" | "permissionPolicy";
+
+export interface MetaDefinitionByKind {
+  view: ViewDefinition;
+  datasource: DatasourceDefinition;
+  permissionPolicy: PermissionPolicy;
+}
+
+export interface MetaDefinitionVersionMetadata {
+  author: string;
+  message: string;
+  createdAt: string;
+}
+
+export interface MetaDefinitionVersion<K extends MetaDefinitionKind = MetaDefinitionKind> {
+  appId: string;
+  kind: K;
+  id: string;
+  version: number;
+  definition: MetaDefinitionByKind[K];
+  metadata: MetaDefinitionVersionMetadata;
+}
+
+export interface MetaDefinitionPublishInput<K extends MetaDefinitionKind = MetaDefinitionKind> {
+  appId: string;
+  kind: K;
+  id: string;
+  definition: MetaDefinitionByKind[K];
+  metadata: {
+    author: string;
+    message: string;
+  };
+}
+
+export interface MetaDefinitionDiff {
+  appId: string;
+  kind: MetaDefinitionKind;
+  id: string;
+  fromVersion: number;
+  toVersion: number;
+  changedPaths: string[];
+}
+
+export type LatestMetaDefinitionVersion<K extends MetaDefinitionKind = MetaDefinitionKind> =
+  MetaDefinitionVersion<K>;
+
+export type {
+  DatasourceDefinition,
+  PermissionPolicy,
+  ViewDefinition
+} from "@zhongmiao/meta-lc-contracts";

--- a/packages/kernel/test/meta-kernel-service.test.ts
+++ b/packages/kernel/test/meta-kernel-service.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { MetaKernelService } from "../src/interface/meta-kernel-service";
+import { InMemoryMetaKernelRepository, MetaKernelService } from "../src";
 import type { MetaVersion } from "../src/types";
 
 function createVersion(version: number, schema: MetaVersion["schema"]): MetaVersion {
@@ -34,7 +34,8 @@ test("buildMigrationPlan returns SQL statements between versions", async () => {
       throw new Error("not used in test");
     },
     getVersion: async (_appId: string, version: number) => versions.get(version) ?? null,
-    executeMigration: async (_statements: string[]) => ({ auditCount: 0 })
+    executeMigration: async (_statements: string[]) => ({ auditCount: 0 }),
+    ...definitionRepositoryStubs()
   };
 
   const service = new MetaKernelService(repository);
@@ -73,7 +74,8 @@ test("replayFromVersion executes migrations sequentially", async () => {
     executeMigration: async (statements: string[]) => {
       executed.push(statements);
       return { auditCount: statements.length };
-    }
+    },
+    ...definitionRepositoryStubs()
   };
 
   const service = new MetaKernelService(repository);
@@ -114,7 +116,8 @@ test("migrateToVersion passes guard options to repository", async () => {
       optionsSeen.push(options);
       contextSeen.push(context);
       return { auditCount: 1 };
-    }
+    },
+    ...definitionRepositoryStubs()
   };
 
   const service = new MetaKernelService(repository);
@@ -137,3 +140,168 @@ test("migrateToVersion passes guard options to repository", async () => {
     requestId: "req-1"
   });
 });
+
+test("publishes and fetches versioned view definitions", async () => {
+  const service = new MetaKernelService(new InMemoryMetaKernelRepository());
+  const first = await service.publishViewDefinition({
+    appId: "demo-app",
+    definition: createOrdersView(["id"]),
+    author: "tester",
+    message: "Publish orders view"
+  });
+  const second = await service.publishViewDefinition({
+    appId: "demo-app",
+    definition: createOrdersView(["id", "owner"]),
+    author: "tester",
+    message: "Add owner field"
+  });
+
+  assert.equal(first.version, 1);
+  assert.equal(second.version, 2);
+  assert.equal(second.id, "orders-workbench");
+  assert.deepEqual((await service.getViewDefinition("demo-app", "orders-workbench", 1))?.definition, first.definition);
+  assert.deepEqual((await service.getViewDefinition("demo-app", "orders-workbench"))?.definition, second.definition);
+});
+
+test("diffDefinition returns stable changed paths for view versions", async () => {
+  const service = new MetaKernelService(new InMemoryMetaKernelRepository());
+  await service.publishViewDefinition({
+    appId: "demo-app",
+    definition: createOrdersView(["id"]),
+    author: "tester",
+    message: "Publish orders view"
+  });
+  await service.publishViewDefinition({
+    appId: "demo-app",
+    definition: createOrdersView(["id", "owner"]),
+    author: "tester",
+    message: "Add owner field"
+  });
+
+  const diff = await service.diffDefinition({
+    appId: "demo-app",
+    kind: "view",
+    id: "orders-workbench",
+    fromVersion: 1,
+    toVersion: 2
+  });
+
+  assert.deepEqual(diff.changedPaths, ["nodes.orders.fields.1"]);
+});
+
+test("publishes and fetches datasource definitions", async () => {
+  const service = new MetaKernelService(new InMemoryMetaKernelRepository());
+  const published = await service.publishDatasourceDefinition({
+    appId: "demo-app",
+    definition: {
+      id: "orders-query",
+      type: "postgres",
+      config: { target: "business" }
+    },
+    author: "tester",
+    message: "Publish datasource"
+  });
+
+  assert.equal(published.version, 1);
+  assert.deepEqual(await service.getDatasourceDefinition("demo-app", "orders-query"), published);
+});
+
+test("rejects invalid datasource definitions", async () => {
+  const service = new MetaKernelService(new InMemoryMetaKernelRepository());
+
+  await assert.rejects(
+    () =>
+      service.publishDatasourceDefinition({
+        appId: "demo-app",
+        definition: {
+          id: "orders-query",
+          type: ""
+        },
+        author: "tester",
+        message: "Invalid datasource"
+      }),
+    /requires a type/
+  );
+});
+
+test("publishes and fetches permission policies", async () => {
+  const service = new MetaKernelService(new InMemoryMetaKernelRepository());
+  const published = await service.publishPermissionPolicy({
+    appId: "demo-app",
+    definition: {
+      id: "orders-query-policy",
+      resource: "orders",
+      action: "query",
+      roles: ["SALES"],
+      scope: "DEPT"
+    },
+    author: "tester",
+    message: "Publish permission policy"
+  });
+
+  assert.equal(published.version, 1);
+  assert.deepEqual(await service.getPermissionPolicy("demo-app", "orders-query-policy"), published);
+});
+
+test("rejects invalid permission policies", async () => {
+  const service = new MetaKernelService(new InMemoryMetaKernelRepository());
+
+  await assert.rejects(
+    () =>
+      service.publishPermissionPolicy({
+        appId: "demo-app",
+        definition: {
+          id: "orders-query-policy",
+          resource: "orders",
+          action: "query",
+          roles: ["SALES", "SALES"]
+        },
+        author: "tester",
+        message: "Invalid permission policy"
+      }),
+    /duplicate role "SALES"/
+  );
+
+  await assert.rejects(
+    () =>
+      service.publishPermissionPolicy({
+        appId: "demo-app",
+        definition: {
+          id: "orders-query-policy",
+          resource: "orders",
+          action: "query",
+          roles: [""]
+        },
+        author: "tester",
+        message: "Invalid permission policy"
+      }),
+    /empty role/
+  );
+});
+
+function createOrdersView(fields: string[]) {
+  return {
+    name: "orders-workbench",
+    nodes: {
+      orders: {
+        type: "query" as const,
+        table: "orders",
+        fields
+      }
+    },
+    output: {
+      rows: "{{orders.rows}}"
+    }
+  };
+}
+
+function definitionRepositoryStubs() {
+  return {
+    createDefinitionVersion: async () => {
+      throw new Error("not used in test");
+    },
+    getDefinitionVersion: async () => null,
+    getLatestDefinitionVersion: async () => null,
+    listLatestDefinitionVersions: async () => []
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ importers:
       '@zhongmiao/meta-lc-datasource':
         specifier: workspace:*
         version: link:../datasource
+      '@zhongmiao/meta-lc-kernel':
+        specifier: workspace:*
+        version: link:../kernel
       '@zhongmiao/meta-lc-runtime':
         specifier: workspace:*
         version: link:../runtime
@@ -132,6 +135,9 @@ importers:
 
   packages/kernel:
     dependencies:
+      '@zhongmiao/meta-lc-contracts':
+        specifier: workspace:*
+        version: link:../contracts
       pg:
         specifier: ^8.13.1
         version: 8.20.0


### PR DESCRIPTION
## Summary
- Add shared datasource and permission policy definition contracts.
- Add Kernel versioned meta definition registry APIs for views, datasources, and permission policies.
- Route BFF demo view/datasource/permission lookup through a Kernel-backed in-memory registry without adding publish HTTP APIs or runtime execution changes.

Closes #90

## Checks
- pnpm --filter @zhongmiao/meta-lc-contracts test
- pnpm --filter @zhongmiao/meta-lc-kernel test
- pnpm --filter @zhongmiao/meta-lc-bff test
- pnpm --filter @zhongmiao/meta-lc-runtime test
- pnpm run test:boundaries
- pnpm run lint
- pnpm query-gate
- pnpm -r build
- git diff --check
- node scripts/check-changelog-gate.mjs $(git merge-base origin/main HEAD) HEAD

## Risk / Rollback
- Risk: BFF meta listing and view lookup now use async Kernel-backed registry reads; existing tests cover view execution and meta summary/listing.
- Rollback: revert this PR to restore the previous in-memory BFF fixture registry while leaving Runtime and Data paths unchanged.