### PR TITLE
feat(audit): add runtime observability events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- feat(audit): add non-blocking runtime observability events and BFF persistence wiring for plan, node, permission, and datasource execution.
 - feat(kernel): add a versioned meta definition registry for view, datasource, and permission policy definitions.
 - feat(permission): add Query AST permission transforms and route runtime query compilation through them.
 - feat(datasource): converge runtime query execution onto the shared datasource adapter contract.

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- feat(audit): 新增非阻塞 runtime observability event，并在 BFF 持久化 plan、node、permission、datasource execution 事件。
 - feat(kernel): 新增覆盖 view、datasource 与 permission policy 定义的版本化 meta definition registry。
 - feat(permission): 新增 Query AST permission transform，并让 runtime query 编译链路先经过权限 AST。
 - feat(datasource): 将 runtime query 执行收敛到共享 datasource adapter 契约。

--- a/packages/audit/CHANGELOG.md
+++ b/packages/audit/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- feat(observability): add non-blocking runtime audit event contracts for plan, node, permission, and datasource execution.
 - refactor(package-structure): reorganize src into layered domain/application/infra/interface/types/utils directories and update public entrypoints.
 - docs(readme): add bilingual package README and minimal architecture flow.
 - chore(package): adopt the `@zhongmiao/meta-lc-audit` scoped package identity for release governance.

--- a/packages/audit/CHANGELOG.zh-CN.md
+++ b/packages/audit/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- feat(observability): 新增面向 plan、node、permission、datasource execution 的非阻塞 runtime audit event contract。
 - refactor(package-structure): 将 src 重整为 domain/application/infra/interface/types/utils 分层目录，并同步更新对外入口。
 - docs(readme): 新增双语子包 README 与最小架构流程图。
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-audit` 正式包名。

--- a/packages/audit/README.md
+++ b/packages/audit/README.md
@@ -4,19 +4,21 @@ English | [中文文档](./README_zh.md)
 
 ## Package Role
 
-`audit` defines audit log shapes and a pluggable audit service/sink contract for query, mutation, migration, and access events.
+`audit` defines audit log shapes and a pluggable audit service/sink contract for query, mutation, migration, access, and runtime observability events.
 
 ## Responsibilities
 
 - Define audit log interfaces for mutation, migration, and access events.
 - Reuse `QueryAuditLog` from `contracts`.
 - Provide `AuditService` with an injectable sink.
+- Provide non-blocking runtime observability event contracts for plan, node, permission, and datasource execution.
 - Default to a no-op sink when no persistence implementation is supplied.
 
 ## Relationship With Other Packages
 
 - Depends on `contracts` for query audit log shape.
 - BFF can call audit service or equivalent integration after query/mutation outcomes.
+- Runtime can emit observability events through an optional `RuntimeAuditObserver`; observer failures must not affect execution semantics.
 - Migration orchestration can report migration audit records through this contract.
 - Persistence details belong to the sink implementation or BFF integration layer.
 
@@ -24,7 +26,7 @@ English | [中文文档](./README_zh.md)
 
 ```mermaid
 flowchart LR
-  Event["query / mutation / migration / access outcome"] --> Service["AuditService"]
+  Event["query / mutation / migration / access / runtime outcome"] --> Service["AuditService"]
   Service --> Sink["AuditSink"]
   Sink --> AuditDb[("audit_db or external sink")]
 ```
@@ -39,4 +41,5 @@ pnpm --filter @zhongmiao/meta-lc-audit test
 ## Boundary Notes
 
 - Keep audit persistence pluggable through `AuditSink`.
+- Keep runtime observability optional and non-blocking.
 - Do not couple this package to NestJS controllers or concrete BFF request handling.

--- a/packages/audit/README_zh.md
+++ b/packages/audit/README_zh.md
@@ -4,19 +4,21 @@
 
 ## 包定位
 
-`audit` 定义 query、mutation、migration、access 事件的 audit log 形状，以及可插拔的 audit service/sink contract。
+`audit` 定义 query、mutation、migration、access 与 runtime observability 事件的 audit log 形状，以及可插拔的 audit service/sink contract。
 
 ## 核心职责
 
 - 定义 mutation、migration、access audit log interface。
 - 复用 `contracts` 中的 `QueryAuditLog`。
 - 提供可注入 sink 的 `AuditService`。
+- 提供面向 plan、node、permission、datasource execution 的非阻塞 runtime observability event contract。
 - 未提供 persistence implementation 时默认使用 no-op sink。
 
 ## 与其他包关系
 
 - 依赖 `contracts` 获取 query audit log 形状。
 - BFF 可在 query/mutation 结果后调用 audit service 或等价 integration。
+- Runtime 可通过可选 `RuntimeAuditObserver` 发出 observability event；observer 失败不得影响执行语义。
 - Migration orchestration 可通过此 contract 上报 migration audit record。
 - 持久化细节属于 sink implementation 或 BFF integration layer。
 
@@ -24,7 +26,7 @@
 
 ```mermaid
 flowchart LR
-  Event["query / mutation / migration / access outcome"] --> Service["AuditService"]
+  Event["query / mutation / migration / access / runtime outcome"] --> Service["AuditService"]
   Service --> Sink["AuditSink"]
   Sink --> AuditDb[("audit_db or external sink")]
 ```
@@ -39,4 +41,5 @@ pnpm --filter @zhongmiao/meta-lc-audit test
 ## 边界约束
 
 - 通过 `AuditSink` 保持 audit persistence 可插拔。
+- runtime observability 必须保持可选、非阻塞。
 - 不把本包耦合到 NestJS controller 或具体 BFF request handling。

--- a/packages/audit/src/application/record-audit.usecase.ts
+++ b/packages/audit/src/application/record-audit.usecase.ts
@@ -3,7 +3,8 @@ import type {
   AccessAuditLog,
   AuditSink,
   MigrationAuditLog,
-  MutationAuditLog
+  MutationAuditLog,
+  RuntimeAuditEvent
 } from "../domain/audit.entity";
 
 export interface AuditDbConfig {
@@ -16,6 +17,7 @@ function createNoopAuditSink(): AuditSink {
     async logMutation(): Promise<void> {},
     async logMigration(): Promise<void> {},
     async logAccess(): Promise<void> {},
+    async recordRuntimeEvent(): Promise<void> {},
     async close(): Promise<void> {}
   };
 }
@@ -41,6 +43,14 @@ export class AuditService {
 
   async logAccess(log: AccessAuditLog): Promise<void> {
     await this.sink.logAccess(log);
+  }
+
+  async recordRuntimeEvent(event: RuntimeAuditEvent): Promise<void> {
+    try {
+      await this.sink.recordRuntimeEvent?.(event);
+    } catch {
+      // Audit must never become a runtime dependency.
+    }
   }
 
   async close(): Promise<void> {

--- a/packages/audit/src/domain/audit.entity.ts
+++ b/packages/audit/src/domain/audit.entity.ts
@@ -1,5 +1,92 @@
 import type { QueryAuditLog } from "@zhongmiao/meta-lc-contracts";
 
+export type RuntimeAuditEventType =
+  | "runtime.plan.started"
+  | "runtime.plan.finished"
+  | "runtime.node.succeeded"
+  | "runtime.node.failed"
+  | "runtime.permission.decision"
+  | "runtime.datasource.succeeded"
+  | "runtime.datasource.failed";
+
+export type RuntimeAuditEventStatus = "started" | "success" | "failure" | "allow" | "deny";
+
+export interface RuntimeAuditEventBase {
+  type: RuntimeAuditEventType;
+  requestId: string;
+  planId: string;
+  timestamp: string;
+  viewName?: string;
+  nodeId?: string;
+  nodeType?: string;
+  tenantId?: string;
+  userId?: string;
+  durationMs?: number;
+  status: RuntimeAuditEventStatus;
+  errorMessage?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface RuntimePlanStartedAuditEvent extends RuntimeAuditEventBase {
+  type: "runtime.plan.started";
+  status: "started";
+}
+
+export interface RuntimePlanFinishedAuditEvent extends RuntimeAuditEventBase {
+  type: "runtime.plan.finished";
+  status: "success" | "failure";
+}
+
+export interface RuntimeNodeSucceededAuditEvent extends RuntimeAuditEventBase {
+  type: "runtime.node.succeeded";
+  status: "success";
+  nodeId: string;
+  nodeType: string;
+}
+
+export interface RuntimeNodeFailedAuditEvent extends RuntimeAuditEventBase {
+  type: "runtime.node.failed";
+  status: "failure";
+  nodeId: string;
+  nodeType: string;
+}
+
+export interface RuntimePermissionDecisionAuditEvent extends RuntimeAuditEventBase {
+  type: "runtime.permission.decision";
+  status: "allow" | "deny";
+  nodeId?: string;
+  nodeType?: string;
+}
+
+export interface RuntimeDatasourceSucceededAuditEvent extends RuntimeAuditEventBase {
+  type: "runtime.datasource.succeeded";
+  status: "success";
+  nodeId?: string;
+  nodeType?: string;
+}
+
+export interface RuntimeDatasourceFailedAuditEvent extends RuntimeAuditEventBase {
+  type: "runtime.datasource.failed";
+  status: "failure";
+  nodeId?: string;
+  nodeType?: string;
+}
+
+export type RuntimeAuditEvent =
+  | RuntimePlanStartedAuditEvent
+  | RuntimePlanFinishedAuditEvent
+  | RuntimeNodeSucceededAuditEvent
+  | RuntimeNodeFailedAuditEvent
+  | RuntimePermissionDecisionAuditEvent
+  | RuntimeDatasourceSucceededAuditEvent
+  | RuntimeDatasourceFailedAuditEvent;
+
+export interface RuntimeAuditObserver {
+  recordRuntimeEvent(event: RuntimeAuditEvent): void | Promise<void>;
+}
+
+export interface RuntimeAuditSink extends RuntimeAuditObserver {}
+
 export interface MutationAuditLog {
   requestId: string;
   tenantId: string;
@@ -37,5 +124,6 @@ export interface AuditSink {
   logMutation(log: MutationAuditLog): Promise<void>;
   logMigration(log: MigrationAuditLog): Promise<void>;
   logAccess(log: AccessAuditLog): Promise<void>;
+  recordRuntimeEvent?(event: RuntimeAuditEvent): Promise<void>;
   close?(): Promise<void>;
 }

--- a/packages/audit/test/smoke.test.ts
+++ b/packages/audit/test/smoke.test.ts
@@ -1,7 +1,93 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { AuditService } from "../src";
+import { AuditService, type RuntimeAuditEvent } from "../src";
 
 test("audit service class exists", () => {
   assert.equal(typeof AuditService, "function");
+});
+
+test("AuditService records runtime observability events through the sink", async () => {
+  const events: RuntimeAuditEvent[] = [];
+  const service = new AuditService({}, {
+    async logQuery() {},
+    async logMutation() {},
+    async logMigration() {},
+    async logAccess() {},
+    async recordRuntimeEvent(event) {
+      events.push(event);
+    }
+  });
+
+  await service.recordRuntimeEvent({
+    type: "runtime.plan.started",
+    requestId: "req-1",
+    planId: "req-1",
+    timestamp: "2026-04-24T00:00:00.000Z",
+    status: "started",
+    viewName: "orders-workbench"
+  });
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0]?.type, "runtime.plan.started");
+});
+
+test("AuditService degrades when runtime event sink throws", async () => {
+  const service = new AuditService({}, {
+    async logQuery() {},
+    async logMutation() {},
+    async logMigration() {},
+    async logAccess() {},
+    async recordRuntimeEvent() {
+      throw new Error("audit db unavailable");
+    }
+  });
+
+  await assert.doesNotReject(() =>
+    service.recordRuntimeEvent({
+      type: "runtime.node.failed",
+      requestId: "req-2",
+      planId: "req-2",
+      timestamp: "2026-04-24T00:00:00.000Z",
+      nodeId: "orders",
+      nodeType: "query",
+      status: "failure",
+      errorMessage: "boom"
+    })
+  );
+});
+
+test("AuditService keeps legacy query and mutation APIs available", async () => {
+  const calls: string[] = [];
+  const service = new AuditService({}, {
+    async logQuery() {
+      calls.push("query");
+    },
+    async logMutation() {
+      calls.push("mutation");
+    },
+    async logMigration() {},
+    async logAccess() {}
+  });
+
+  await service.logQuery({
+    requestId: "req-3",
+    tenantId: "tenant-a",
+    userId: "user-a",
+    queryDsl: "{}",
+    finalSql: "select 1",
+    durationMs: 1,
+    resultCount: 1,
+    status: "success"
+  });
+  await service.logMutation({
+    requestId: "req-4",
+    tenantId: "tenant-a",
+    userId: "user-a",
+    table: "orders",
+    action: "create",
+    payload: "{}",
+    status: "success"
+  });
+
+  assert.deepEqual(calls, ["query", "mutation"]);
 });

--- a/packages/bff/CHANGELOG.md
+++ b/packages/bff/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- feat(observability): persist runtime audit events through a BFF infra observer without blocking view execution.
 - refactor(meta): read demo view, datasource, and permission definitions from the Kernel-backed registry.
 - test(permission): assert BFF view gateway context flows into runtime Permission AST Transform.
 - refactor(datasource): route BFF runtime view query execution through the datasource package adapter.

--- a/packages/bff/CHANGELOG.zh-CN.md
+++ b/packages/bff/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- feat(observability): 通过 BFF infra observer 持久化 runtime audit event，且不阻塞 view execution。
 - refactor(meta): demo view、datasource 与 permission definition 改为从 Kernel-backed registry 读取。
 - test(permission): 验证 BFF view gateway context 会进入 runtime Permission AST Transform。
 - refactor(datasource): BFF runtime view query 执行改为通过 datasource 包 adapter。

--- a/packages/bff/README.md
+++ b/packages/bff/README.md
@@ -8,6 +8,8 @@ English | [中文文档](./README_zh.md)
 
 BFF reads view definitions from the Kernel-backed meta registry before invoking the Runtime facade; it does not publish metadata or execute registry migrations itself.
 
+BFF also wires a runtime audit observer into the Runtime facade and persists observability events as an infrastructure concern; audit failures are logged and degraded without blocking page execution.
+
 ## Source Layout
 
 ```text
@@ -91,7 +93,9 @@ flowchart LR
   Http["HTTP / WS / CLI request"] --> Entry["controller/*"]
   Entry --> App["application services"]
   App --> Kernel["Kernel meta registry"]
+  App --> Runtime["Runtime facade"]
   App --> Infra["infra integration"]
+  Runtime --> Audit["runtime audit observer"]
   App --> Response["HTTP response / WS event"]
 ```
 
@@ -108,5 +112,6 @@ pnpm --filter @zhongmiao/meta-lc-bff start
 - WebSocket is an entry protocol layer, not infra and not application orchestration.
 - Direct DB driver use must stay inside approved edge files and pass `pnpm test:boundaries`.
 - Runtime UI and kernel source-of-truth logic must not be moved into BFF.
+- Runtime audit persistence is an infra integration and must not become request orchestration.
 - Do not restore legacy `/query` or `/mutation` endpoints; page data requests must use `POST /view/:name`.
 - Do not add `application/orchestrator/**`; BFF is only a Gateway invoking Runtime.

--- a/packages/bff/README_zh.md
+++ b/packages/bff/README_zh.md
@@ -8,6 +8,8 @@
 
 BFF 在调用 Runtime facade 前从 Kernel-backed meta registry 读取 view definition；它不发布元数据，也不执行 registry migration。
 
+BFF 还会把 runtime audit observer 注入 Runtime facade，并把 observability event 作为 infra 职责持久化；audit 失败只记录并降级，不阻塞页面执行。
+
 ## 源码结构
 
 ```text
@@ -91,7 +93,9 @@ flowchart LR
   Http["HTTP / WS / CLI request"] --> Entry["controller/*"]
   Entry --> App["application services"]
   App --> Kernel["Kernel meta registry"]
+  App --> Runtime["Runtime facade"]
   App --> Infra["infra integration"]
+  Runtime --> Audit["runtime audit observer"]
   App --> Response["HTTP response / WS event"]
 ```
 
@@ -108,5 +112,6 @@ pnpm --filter @zhongmiao/meta-lc-bff start
 - WebSocket 是入口协议层，不属于 infra，也不承载 application orchestration。
 - direct DB driver use 必须保留在允许的 edge files 内，并通过 `pnpm test:boundaries`。
 - 不把 runtime UI 或 kernel 的结构真源逻辑搬进 BFF。
+- Runtime audit persistence 属于 infra integration，不得变成 request orchestration。
 - 禁止恢复 `/query`、`/mutation` 旧入口；页面级数据请求必须走 `POST /view/:name`。
 - 禁止新增 `application/orchestrator/**`；BFF 只能作为 Gateway 调用 Runtime。

--- a/packages/bff/package.json
+++ b/packages/bff/package.json
@@ -15,6 +15,7 @@
     "@nestjs/platform-express": "^10.4.22",
     "@nestjs/platform-socket.io": "^10.4.22",
     "@nestjs/websockets": "^10.4.22",
+    "@zhongmiao/meta-lc-audit": "workspace:*",
     "@zhongmiao/meta-lc-contracts": "workspace:*",
     "@zhongmiao/meta-lc-datasource": "workspace:*",
     "@zhongmiao/meta-lc-kernel": "workspace:*",

--- a/packages/bff/src/bootstrap/app.module.ts
+++ b/packages/bff/src/bootstrap/app.module.ts
@@ -31,6 +31,7 @@ import { RuntimeWsGateway } from "../controller/ws/runtime/ws.gateway";
 import { AuditPersistenceService } from "../infra/integration/audit.service";
 import { OrgScopeService } from "../infra/integration/org-scope.service";
 import { PostgresQueryExecutorService } from "../infra/integration/postgres-query.service";
+import { RuntimeAuditObserverService } from "../infra/integration/runtime-audit-observer.service";
 import { RuntimeViewDependenciesService } from "../infra/integration/runtime-view-dependencies.service";
 
 @Module({
@@ -43,6 +44,7 @@ import { RuntimeViewDependenciesService } from "../infra/integration/runtime-vie
     MetaQueryService,
     MetaRegistryService,
     PostgresQueryExecutorService,
+    RuntimeAuditObserverService,
     RuntimeViewDependenciesService,
     OrgScopeService,
     AuditPersistenceService,

--- a/packages/bff/src/infra/integration/audit.service.ts
+++ b/packages/bff/src/infra/integration/audit.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from "@nestjs/common";
+import type { RuntimeAuditEvent } from "@zhongmiao/meta-lc-audit";
 import { Pool } from "pg";
 import { loadDbTargets } from "../../config/config";
 import type {
@@ -149,6 +150,18 @@ export class AuditPersistenceService implements OnModuleInit, OnModuleDestroy {
       )
     `);
     await this.pool.query(`
+      CREATE TABLE IF NOT EXISTS runtime_audit_events (
+        id BIGSERIAL PRIMARY KEY,
+        request_id TEXT NOT NULL,
+        plan_id TEXT NOT NULL,
+        node_id TEXT NULL,
+        event_type TEXT NOT NULL,
+        status TEXT NOT NULL,
+        payload JSONB NOT NULL,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    `);
+    await this.pool.query(`
       CREATE INDEX IF NOT EXISTS idx_bff_query_audit_logs_request_id
       ON bff_query_audit_logs (request_id)
     `);
@@ -159,6 +172,22 @@ export class AuditPersistenceService implements OnModuleInit, OnModuleDestroy {
     await this.pool.query(`
       CREATE INDEX IF NOT EXISTS idx_query_logs_request_id
       ON query_logs (request_id)
+    `);
+    await this.pool.query(`
+      CREATE INDEX IF NOT EXISTS idx_runtime_audit_events_request_id
+      ON runtime_audit_events (request_id)
+    `);
+    await this.pool.query(`
+      CREATE INDEX IF NOT EXISTS idx_runtime_audit_events_plan_id
+      ON runtime_audit_events (plan_id)
+    `);
+    await this.pool.query(`
+      CREATE INDEX IF NOT EXISTS idx_runtime_audit_events_node_id
+      ON runtime_audit_events (node_id)
+    `);
+    await this.pool.query(`
+      CREATE INDEX IF NOT EXISTS idx_runtime_audit_events_event_type
+      ON runtime_audit_events (event_type)
     `);
   }
 
@@ -270,6 +299,33 @@ export class AuditPersistenceService implements OnModuleInit, OnModuleDestroy {
     } catch (error) {
       this.logger.warn(
         `persist mutation audit failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  async persistRuntimeEvent(event: RuntimeAuditEvent): Promise<void> {
+    try {
+      await this.pool.query(
+        `INSERT INTO runtime_audit_events (
+          request_id,
+          plan_id,
+          node_id,
+          event_type,
+          status,
+          payload
+        ) VALUES ($1, $2, $3, $4, $5, $6::jsonb)`,
+        [
+          event.requestId,
+          event.planId,
+          event.nodeId ?? null,
+          event.type,
+          event.status,
+          JSON.stringify(event)
+        ]
+      );
+    } catch (error) {
+      this.logger.warn(
+        `persist runtime audit event failed: ${error instanceof Error ? error.message : String(error)}`
       );
     }
   }

--- a/packages/bff/src/infra/integration/runtime-audit-observer.service.ts
+++ b/packages/bff/src/infra/integration/runtime-audit-observer.service.ts
@@ -1,0 +1,23 @@
+import { Injectable, Logger } from "@nestjs/common";
+import type {
+  RuntimeAuditEvent,
+  RuntimeAuditObserver
+} from "@zhongmiao/meta-lc-audit";
+import { AuditPersistenceService } from "./audit.service";
+
+@Injectable()
+export class RuntimeAuditObserverService implements RuntimeAuditObserver {
+  private readonly logger = new Logger("RuntimeAuditObserver");
+
+  constructor(private readonly auditPersistence: AuditPersistenceService) {}
+
+  async recordRuntimeEvent(event: RuntimeAuditEvent): Promise<void> {
+    try {
+      await this.auditPersistence.persistRuntimeEvent(event);
+    } catch (error) {
+      this.logger.warn(
+        `runtime audit observer failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+}

--- a/packages/bff/src/infra/integration/runtime-view-dependencies.service.ts
+++ b/packages/bff/src/infra/integration/runtime-view-dependencies.service.ts
@@ -5,14 +5,19 @@ import type {
   RuntimeViewExecutorDependencies
 } from "@zhongmiao/meta-lc-runtime";
 import { PostgresQueryExecutorService } from "./postgres-query.service";
+import { RuntimeAuditObserverService } from "./runtime-audit-observer.service";
 
 @Injectable()
 export class RuntimeViewDependenciesService {
-  constructor(private readonly queryExecutor: PostgresQueryExecutorService) {}
+  constructor(
+    private readonly queryExecutor: PostgresQueryExecutorService,
+    private readonly auditObserver: RuntimeAuditObserverService
+  ) {}
 
   create(): RuntimeViewExecutorDependencies {
     const queryExecutor = this.queryExecutor;
     return {
+      auditObserver: this.auditObserver,
       queryDatasource: {
         async execute(request) {
           return queryExecutor.execute(request);

--- a/packages/bff/test/audit-log.test.ts
+++ b/packages/bff/test/audit-log.test.ts
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { AuditLogService } from "../src/application/services/audit-log.service";
+import { RuntimeAuditObserverService } from "../src/infra/integration/runtime-audit-observer.service";
 
 test("logQuerySuccess degrades when persistence throws", async () => {
   const service = new AuditLogService({
@@ -39,6 +40,25 @@ test("logQueryFailure degrades when persistence throws", async () => {
       queryDsl: '{"table":"orders"}',
       durationMs: 12,
       error: "bad request"
+    });
+  });
+});
+
+test("runtime audit observer degrades when persistence throws", async () => {
+  const service = new RuntimeAuditObserverService({
+    persistRuntimeEvent: async () => {
+      throw new Error("db unavailable");
+    }
+  } as never);
+
+  await assert.doesNotReject(async () => {
+    await service.recordRuntimeEvent({
+      type: "runtime.plan.finished",
+      requestId: "req-runtime-1",
+      planId: "req-runtime-1",
+      timestamp: "2026-04-24T00:00:00.000Z",
+      status: "failure",
+      errorMessage: "boom"
     });
   });
 });

--- a/packages/bff/test/runtime-view-dependencies.test.ts
+++ b/packages/bff/test/runtime-view-dependencies.test.ts
@@ -1,0 +1,14 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { RuntimeViewDependenciesService } from "../src/infra/integration/runtime-view-dependencies.service";
+
+test("runtime view dependencies inject runtime audit observer", () => {
+  const auditObserver = {
+    recordRuntimeEvent() {}
+  };
+  const service = new RuntimeViewDependenciesService({} as never, auditObserver as never);
+
+  const deps = service.create();
+
+  assert.equal(deps.auditObserver, auditObserver);
+});

--- a/packages/bff/test/temporary-view-adapter.test.ts
+++ b/packages/bff/test/temporary-view-adapter.test.ts
@@ -1,11 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { NotFoundException } from "@nestjs/common";
+import type { RuntimeAuditEvent } from "@zhongmiao/meta-lc-audit";
 import { TemporaryViewAdapter } from "../src/application/services/temporary-view-adapter.service";
 import { MetaRegistryService } from "../src/application/services/meta-registry.service";
 
 test("temporary view adapter executes runtime view and propagates context into the query node", async () => {
   const queryCalls: Array<{ kind: string; sql: string; params: unknown[] }> = [];
+  const auditEvents: RuntimeAuditEvent[] = [];
   const registry = new MetaRegistryService();
   const adapter = new TemporaryViewAdapter(
     registry,
@@ -29,6 +31,11 @@ test("temporary view adapter executes runtime view and propagates context into t
     {
       create() {
         return {
+          auditObserver: {
+            recordRuntimeEvent(event: RuntimeAuditEvent) {
+              auditEvents.push(event);
+            }
+          },
           queryDatasource: {
             async execute(request: { kind: "query"; sql: string; params?: unknown[] }) {
               queryCalls.push({
@@ -83,6 +90,20 @@ test("temporary view adapter executes runtime view and propagates context into t
 
   assert.equal(result.requestId, "req-view-1");
   assert.equal(result.viewName, "orders-workbench");
+  assert.deepEqual(
+    auditEvents.map((event) => event.type),
+    [
+      "runtime.plan.started",
+      "runtime.permission.decision",
+      "runtime.datasource.succeeded",
+      "runtime.node.succeeded",
+      "runtime.plan.finished"
+    ]
+  );
+  assert.deepEqual(
+    auditEvents.map((event) => event.requestId),
+    ["req-view-1", "req-view-1", "req-view-1", "req-view-1", "req-view-1"]
+  );
   assert.deepEqual(queryCalls, [
     {
       kind: "query",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- feat(observability): emit optional non-blocking runtime audit events for plan, node, permission, and datasource boundaries.
 - feat(permission): route query nodes through Permission AST Transform before SQL compilation.
 - refactor(datasource): execute query nodes through the shared datasource adapter contract.
 - feat(runtime): add a high-level runtime view executor facade that compiles and executes ViewDefinition through RuntimeExecutor.

--- a/packages/runtime/CHANGELOG.zh-CN.md
+++ b/packages/runtime/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- feat(observability): 在 plan、node、permission、datasource 边界发出可选、非阻塞 runtime audit event。
 - feat(permission): query node 在 SQL 编译前接入 Permission AST Transform。
 - refactor(datasource): query node 改为通过共享 datasource adapter 契约执行。
 - feat(runtime): 新增高层 runtime view executor facade，通过 RuntimeExecutor 编译并执行 ViewDefinition。

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -21,6 +21,7 @@ English | [中文文档](./README_zh.md)
 - Frontend runtime adapters consume the package contract without direct database or business API access.
 - Query nodes build AST through `query`, apply `permission` AST transforms, compile SQL, and execute through the shared `datasource` adapter contract.
 - BFF wires concrete datasource adapters; runtime does not read DB config or access physical data directly.
+- Runtime can emit optional audit observability events for plan, node, permission, and datasource boundaries without changing execution semantics.
 
 ## Minimal Flow
 
@@ -45,3 +46,4 @@ pnpm --filter @zhongmiao/meta-lc-runtime test
 - Runtime orchestration must not embed business-specific backend logic.
 - Runtime consumers must still access data through BFF contracts.
 - Runtime query execution must not inject SQL permission clauses; it calls the permission AST transform before SQL compilation.
+- Runtime audit observers are optional and non-blocking; observer failures must not affect plan execution.

--- a/packages/runtime/README_zh.md
+++ b/packages/runtime/README_zh.md
@@ -21,6 +21,7 @@
 - 前端 runtime adapter 消费本包 contract，但不直连数据库或业务 API。
 - Query node 通过 `query` 构建 AST，经过 `permission` AST transform 后编译 SQL，并通过共享 `datasource` adapter 契约执行。
 - BFF 负责装配具体 datasource adapter；runtime 不读取 DB config，也不直接访问物理数据。
+- Runtime 可以在 plan、node、permission、datasource 边界发出可选 audit observability event，但不改变执行语义。
 
 ## 最小闭环
 
@@ -45,3 +46,4 @@ pnpm --filter @zhongmiao/meta-lc-runtime test
 - Runtime orchestration 不能内嵌业务专用后端逻辑。
 - Runtime consumer 的数据访问仍必须经过 BFF contract。
 - Runtime query execution 不能注入 SQL permission clause；必须在 SQL 编译前调用 permission AST transform。
+- Runtime audit observer 必须保持可选、非阻塞；observer 失败不得影响 plan execution。

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@zhongmiao/meta-lc-contracts": "workspace:*",
+    "@zhongmiao/meta-lc-audit": "workspace:*",
     "@zhongmiao/meta-lc-datasource": "workspace:*",
     "@zhongmiao/meta-lc-permission": "workspace:*",
     "@zhongmiao/meta-lc-query": "workspace:*"

--- a/packages/runtime/src/application/executor/node-executor.ts
+++ b/packages/runtime/src/application/executor/node-executor.ts
@@ -12,10 +12,16 @@ import {
 
 export type NodeExecutionResult = unknown;
 
+export interface NodeExecutionMetadata {
+  nodeId: string;
+  nodeType: ExecutionNode["type"];
+}
+
 export type NodeTypeExecutor<TNode extends NodeDefinition = NodeDefinition> = (
   node: TNode,
   state: RuntimeStateStore,
-  context: RuntimeContext
+  context: RuntimeContext,
+  metadata?: NodeExecutionMetadata
 ) => NodeExecutionResult | Promise<NodeExecutionResult>;
 
 export interface NodeExecutorDependencies {
@@ -33,13 +39,25 @@ export async function executeNode(
 ): Promise<NodeExecutionResult> {
   switch (node.type) {
     case "query":
-      return runExecutor("query", executors.query, node.definition as QueryNodeDefinition, state, context);
+      return runExecutor("query", executors.query, node.definition as QueryNodeDefinition, state, context, {
+        nodeId: node.id,
+        nodeType: node.type
+      });
     case "mutation":
-      return runExecutor("mutation", executors.mutation, node.definition as MutationNodeDefinition, state, context);
+      return runExecutor("mutation", executors.mutation, node.definition as MutationNodeDefinition, state, context, {
+        nodeId: node.id,
+        nodeType: node.type
+      });
     case "merge":
-      return runExecutor("merge", executors.merge, node.definition as MergeNodeDefinition, state, context);
+      return runExecutor("merge", executors.merge, node.definition as MergeNodeDefinition, state, context, {
+        nodeId: node.id,
+        nodeType: node.type
+      });
     case "transform":
-      return runExecutor("transform", executors.transform, node.definition as TransformNodeDefinition, state, context);
+      return runExecutor("transform", executors.transform, node.definition as TransformNodeDefinition, state, context, {
+        nodeId: node.id,
+        nodeType: node.type
+      });
     default:
       throw new NodeExecutorError(`Unsupported node type "${String(node.type)}".`);
   }
@@ -50,11 +68,12 @@ async function runExecutor<TNode extends NodeDefinition>(
   executor: NodeTypeExecutor<TNode> | undefined,
   node: TNode,
   state: RuntimeStateStore,
-  context: RuntimeContext
+  context: RuntimeContext,
+  metadata: NodeExecutionMetadata
 ): Promise<NodeExecutionResult> {
   if (typeof executor !== "function") {
     throw new NodeExecutorError(`Missing node executor for "${kind}".`);
   }
 
-  return executor(node, state, context);
+  return executor(node, state, context, metadata);
 }

--- a/packages/runtime/src/application/executor/query-executor.ts
+++ b/packages/runtime/src/application/executor/query-executor.ts
@@ -1,7 +1,8 @@
 import type { QueryResultRow } from "@zhongmiao/meta-lc-datasource";
-import type { CompiledQuery, QueryRequest } from "@zhongmiao/meta-lc-query";
+import type { CompiledQuery, QueryRequest, SelectQueryAst } from "@zhongmiao/meta-lc-query";
 import type { OrgScopeContext } from "@zhongmiao/meta-lc-contracts";
 import type { PermissionAstTransformContext } from "@zhongmiao/meta-lc-permission";
+import type { RuntimeAuditObserver } from "@zhongmiao/meta-lc-audit";
 import { resolveExpression } from "../../domain/dsl/expression";
 import {
   QueryExecutorError,
@@ -17,11 +18,23 @@ import {
   type QueryDatasourceAdapter,
   type QueryPermissionAdapter
 } from "../../infra/adapter/query.adapter";
+import {
+  createRuntimeAuditDispatchContext,
+  emitRuntimeAuditEvent,
+  getErrorMessage
+} from "./runtime-audit";
+
+export interface QueryAuditDependencies {
+  observer?: RuntimeAuditObserver;
+  nodeId?: string;
+  nodeType?: string;
+}
 
 export interface QueryExecutorDependencies {
   compiler?: QueryCompilerAdapter;
   permission?: QueryPermissionAdapter;
   datasource: QueryDatasourceAdapter;
+  audit?: QueryAuditDependencies;
 }
 
 export interface QueryExecutionResult {
@@ -38,13 +51,41 @@ export async function executeQueryNode(
 ): Promise<QueryResultRow[]> {
   const compiler = dependencies.compiler ?? createQueryCompilerAdapter();
   const permission = dependencies.permission ?? createQueryPermissionAdapter();
+  const auditContext = createRuntimeAuditDispatchContext(context, dependencies.audit?.observer);
   const resolvedNode = resolveExpression(node as unknown as ViewExpression, new QueryExpressionStateSource(state, context)) as ResolvedQueryNodeDefinition;
   const request = buildQueryRequest(resolvedNode);
+  const nodeId = dependencies.audit?.nodeId;
+  const nodeType = dependencies.audit?.nodeType ?? node.type;
 
   let compiled: CompiledQuery;
   try {
     const ast = compiler.buildAst(request);
-    const transformedAst = permission.transform(ast, buildPermissionContext(context));
+    let transformedAst: SelectQueryAst;
+    try {
+      transformedAst = permission.transform(ast, buildPermissionContext(context));
+      emitRuntimeAuditEvent(auditContext, {
+        type: "runtime.permission.decision",
+        status: "allow",
+        nodeId,
+        nodeType,
+        metadata: {
+          table: request.table,
+          fields: request.fields
+        }
+      });
+    } catch (error) {
+      emitRuntimeAuditEvent(auditContext, {
+        type: "runtime.permission.decision",
+        status: "deny",
+        nodeId,
+        nodeType,
+        errorMessage: getErrorMessage(error),
+        metadata: {
+          table: request.table
+        }
+      });
+      throw error;
+    }
     compiled = compiler.compileAst(transformedAst);
   } catch (error) {
     throw new QueryExecutorError(
@@ -56,14 +97,39 @@ export async function executeQueryNode(
     );
   }
 
+  const datasourceStartedAt = Date.now();
   try {
     const result = await dependencies.datasource.execute({
       kind: "query",
       sql: compiled.sql,
       params: compiled.params
     });
+    emitRuntimeAuditEvent(auditContext, {
+      type: "runtime.datasource.succeeded",
+      status: "success",
+      nodeId,
+      nodeType,
+      durationMs: result.metadata.durationMs,
+      metadata: {
+        kind: result.metadata.kind,
+        rowCount: result.rowCount,
+        table: request.table
+      }
+    });
     return result.rows;
   } catch (error) {
+    emitRuntimeAuditEvent(auditContext, {
+      type: "runtime.datasource.failed",
+      status: "failure",
+      nodeId,
+      nodeType,
+      durationMs: Date.now() - datasourceStartedAt,
+      errorMessage: getErrorMessage(error),
+      metadata: {
+        kind: "query",
+        table: request.table
+      }
+    });
     throw new QueryExecutorError(
       `Failed to execute query node "${String(resolvedNode.type ?? node.type)}" for table "${request.table}". ${
         getErrorMessage(error)
@@ -196,10 +262,6 @@ function readOptionalFiniteNumber(value: unknown): number | undefined {
     throw new QueryExecutorError('Query node "limit" must resolve to a finite number.', "validation");
   }
   return value;
-}
-
-function getErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }
 
 function getNestedValue(source: Record<string, unknown>, path: string): unknown {

--- a/packages/runtime/src/application/executor/runtime-audit.ts
+++ b/packages/runtime/src/application/executor/runtime-audit.ts
@@ -1,0 +1,98 @@
+import type {
+  RuntimeAuditEvent,
+  RuntimeAuditObserver
+} from "@zhongmiao/meta-lc-audit";
+import type { ExecutionPlan, RuntimeContext } from "../../types";
+
+export interface RuntimeAuditDispatchContext {
+  observer?: RuntimeAuditObserver;
+  requestId: string;
+  planId: string;
+  viewName?: string;
+  tenantId?: string;
+  userId?: string;
+}
+
+export type RuntimeAuditEventInput = Omit<
+  RuntimeAuditEvent,
+  "requestId" | "planId" | "timestamp" | "viewName" | "tenantId" | "userId"
+>;
+
+export function createRuntimeAuditDispatchContext(
+  context: RuntimeContext,
+  observer?: RuntimeAuditObserver,
+  plan?: ExecutionPlan
+): RuntimeAuditDispatchContext {
+  const requestId = readContextString(context.requestId) ?? readContextString(readNestedContext(context, "requestId"));
+  const planId = readContextString(context.planId) ?? requestId ?? createFallbackPlanId(plan);
+
+  return {
+    observer,
+    requestId: requestId ?? planId,
+    planId,
+    viewName: readContextString(context.viewName) ?? readContextString(readNestedContext(context, "viewName")),
+    tenantId: readContextString(context.tenantId) ?? readContextString(readNestedContext(context, "tenantId")),
+    userId: readContextString(context.userId) ?? readContextString(readNestedContext(context, "userId"))
+  };
+}
+
+export function emitRuntimeAuditEvent(
+  context: RuntimeAuditDispatchContext | undefined,
+  input: RuntimeAuditEventInput
+): void {
+  if (!context?.observer) {
+    return;
+  }
+
+  const event = {
+    ...input,
+    requestId: context.requestId,
+    planId: context.planId,
+    timestamp: new Date().toISOString(),
+    viewName: context.viewName,
+    tenantId: context.tenantId,
+    userId: context.userId
+  } as RuntimeAuditEvent;
+
+  try {
+    const result = context.observer.recordRuntimeEvent(event);
+    if (isPromiseLike(result)) {
+      void result.catch(() => undefined);
+    }
+  } catch {
+    // Observability must never alter runtime execution.
+  }
+}
+
+export function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function createFallbackPlanId(plan?: ExecutionPlan): string {
+  if (!plan) {
+    return "runtime-plan";
+  }
+
+  const nodeIds = plan.nodes.map((node) => node.id).sort((left, right) => left.localeCompare(right));
+  return `runtime-plan:${nodeIds.join(",") || "empty"}`;
+}
+
+function readNestedContext(context: RuntimeContext, key: string): unknown {
+  const nested = context.context;
+  if (!isRecordLike(nested)) {
+    return undefined;
+  }
+  return nested[key];
+}
+
+function readContextString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function isRecordLike(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> & { catch(onRejected: () => void): unknown } {
+  return isRecordLike(value) && typeof value.catch === "function";
+}

--- a/packages/runtime/src/application/executor/runtime-executor.ts
+++ b/packages/runtime/src/application/executor/runtime-executor.ts
@@ -3,6 +3,12 @@ import { resolveExpression } from "../../domain/dsl/expression";
 import { resolveExecutionOrder } from "../../domain/graph/dep-resolver";
 import { executeNode, type NodeExecutorDependencies } from "./node-executor";
 import {
+  createRuntimeAuditDispatchContext,
+  emitRuntimeAuditEvent,
+  getErrorMessage,
+  type RuntimeAuditDispatchContext
+} from "./runtime-audit";
+import {
   type ExecutionNode,
   type ExecutionPlan,
   RuntimeExecutionError,
@@ -14,9 +20,11 @@ import {
   type RuntimeValueNodeResult,
   type RuntimeContext
 } from "../../types";
+import type { RuntimeAuditObserver } from "@zhongmiao/meta-lc-audit";
 
 export interface RuntimeExecutorDependencies {
   executors: NodeExecutorDependencies;
+  auditObserver?: RuntimeAuditObserver;
 }
 
 export class RuntimeExecutor {
@@ -24,6 +32,48 @@ export class RuntimeExecutor {
     plan: ExecutionPlan,
     context: RuntimeContext,
     deps: RuntimeExecutorDependencies
+  ): Promise<RuntimeExecutionResult> {
+    const auditContext = createRuntimeAuditDispatchContext(context, deps.auditObserver, plan);
+    const startedAt = Date.now();
+    emitRuntimeAuditEvent(auditContext, {
+      type: "runtime.plan.started",
+      status: "started",
+      metadata: {
+        nodeCount: plan.nodes.length
+      }
+    });
+
+    try {
+      const result = await this.executeInternal(plan, context, deps, auditContext);
+      emitRuntimeAuditEvent(auditContext, {
+        type: "runtime.plan.finished",
+        status: "success",
+        durationMs: Date.now() - startedAt,
+        metadata: {
+          layerCount: result.layers.length,
+          nodeCount: plan.nodes.length
+        }
+      });
+      return result;
+    } catch (error) {
+      emitRuntimeAuditEvent(auditContext, {
+        type: "runtime.plan.finished",
+        status: "failure",
+        durationMs: Date.now() - startedAt,
+        errorMessage: getErrorMessage(error),
+        metadata: {
+          nodeCount: plan.nodes.length
+        }
+      });
+      throw error;
+    }
+  }
+
+  private async executeInternal(
+    plan: ExecutionPlan,
+    context: RuntimeContext,
+    deps: RuntimeExecutorDependencies,
+    auditContext: RuntimeAuditDispatchContext
   ): Promise<RuntimeExecutionResult> {
     const nodeById = buildNodeLookup(plan.nodes);
     validatePlanCoverage(plan, nodeById);
@@ -54,22 +104,39 @@ export class RuntimeExecutor {
             );
           }
 
+          const nodeStartedAt = Date.now();
           try {
             const result = await executeNode(node, layerState, context, deps.executors);
+            const normalized = normalizeNodeResult(node, result, nodeId);
+            emitRuntimeAuditEvent(auditContext, {
+              type: "runtime.node.succeeded",
+              status: "success",
+              nodeId,
+              nodeType: node.type,
+              durationMs: Date.now() - nodeStartedAt
+            });
             return {
               node,
               nodeId,
-              result
+              result: normalized
             };
           } catch (error) {
+            emitRuntimeAuditEvent(auditContext, {
+              type: "runtime.node.failed",
+              status: "failure",
+              nodeId,
+              nodeType: node.type,
+              durationMs: Date.now() - nodeStartedAt,
+              errorMessage: getErrorMessage(error)
+            });
             throw wrapRuntimeExecutionError("execute", error, node);
           }
         })
       );
 
       const committedLayerResults: Record<string, RuntimeNodeResult> = {};
-      for (const { node, nodeId, result } of layerResults) {
-        const normalized = normalizeNodeResult(node, result, nodeId);
+      for (const { nodeId, result } of layerResults) {
+        const normalized = result;
         committedLayerResults[nodeId] = cloneValue(normalized);
         nodeResults[nodeId] = cloneValue(normalized);
       }
@@ -258,10 +325,6 @@ function wrapRuntimeExecutionError(
 
 function cloneValue<T>(value: T): T {
   return structuredClone(value);
-}
-
-function getErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/packages/runtime/src/application/executor/runtime-view-executor.ts
+++ b/packages/runtime/src/application/executor/runtime-view-executor.ts
@@ -6,6 +6,7 @@ import {
 import { executeMutationNode } from "./mutation-executor";
 import { executeQueryNode } from "./query-executor";
 import type { RuntimeExecutorDependencies } from "./runtime-executor";
+import type { RuntimeAuditObserver } from "@zhongmiao/meta-lc-audit";
 import { executeSubmitPlan, type SubmitExecutionResult } from "./submit-executor";
 import type {
   RuntimeContext,
@@ -27,6 +28,7 @@ export interface RuntimeViewExecutorDependencies {
   queryDatasource: QueryDatasourceAdapter;
   mutationDatasource: MutationDatasourceAdapter;
   merge?: MergeExecutorDependencies;
+  auditObserver?: RuntimeAuditObserver;
 }
 
 export async function executeRuntimeView(
@@ -36,7 +38,8 @@ export async function executeRuntimeView(
 ): Promise<SubmitExecutionResult> {
   const plan = compileViewDefinition(view);
   return executeSubmitPlan(plan, context, {
-    executors: createRuntimeViewExecutors(dependencies)
+    executors: createRuntimeViewExecutors(dependencies),
+    ...(dependencies.auditObserver ? { auditObserver: dependencies.auditObserver } : {})
   });
 }
 
@@ -44,11 +47,20 @@ function createRuntimeViewExecutors(
   dependencies: RuntimeViewExecutorDependencies
 ): RuntimeExecutorDependencies["executors"] {
   return {
-    query: (node, state, context) =>
+    query: (node, state, context, metadata) =>
       executeQueryNode(node, state, context, {
         ...(dependencies.queryCompiler ? { compiler: dependencies.queryCompiler } : {}),
         ...(dependencies.queryPermission ? { permission: dependencies.queryPermission } : {}),
-        datasource: dependencies.queryDatasource
+        datasource: dependencies.queryDatasource,
+        ...(dependencies.auditObserver
+          ? {
+              audit: {
+                observer: dependencies.auditObserver,
+                nodeId: metadata?.nodeId,
+                nodeType: metadata?.nodeType
+              }
+            }
+          : {})
       }),
     mutation: (node, state, context) =>
       executeMutationNode(node, state, context, {

--- a/packages/runtime/src/application/index.ts
+++ b/packages/runtime/src/application/index.ts
@@ -4,6 +4,7 @@ export * from "./executor/merge-executor";
 export * from "./executor/mutation-executor";
 export * from "./executor/node-executor";
 export * from "./executor/query-executor";
+export * from "./executor/runtime-audit";
 export * from "./executor/runtime-view-executor";
 export * from "./executor/submit-executor";
 export * from "./executor/runtime-executor";

--- a/packages/runtime/src/types/shared.types.ts
+++ b/packages/runtime/src/types/shared.types.ts
@@ -28,6 +28,10 @@ import type {
   RuntimeTemplateDependency
 } from "@zhongmiao/meta-lc-contracts";
 import type { QueryResultRow } from "@zhongmiao/meta-lc-datasource";
+export type {
+  RuntimeAuditEvent,
+  RuntimeAuditObserver
+} from "@zhongmiao/meta-lc-audit";
 
 export type {
   ExecutionNode,

--- a/packages/runtime/test/query-executor.test.ts
+++ b/packages/runtime/test/query-executor.test.ts
@@ -7,6 +7,7 @@ import {
   type SelectQueryAst
 } from "@zhongmiao/meta-lc-query";
 import { createQueryCompilerAdapter, executeQueryNode, QueryExecutorError, type QueryNodeDefinition, type RuntimeContext, type RuntimeStateStore } from "../src";
+import type { RuntimeAuditEvent } from "../src";
 
 const runtimeState: RuntimeStateStore = {
   get(path: string): unknown {
@@ -122,6 +123,101 @@ test("executeQueryNode resolves expressions before compiling and querying", asyn
   assert.equal(permissionCalls[0]?.tenantId, "tenant-a");
   assert.equal(compileAstCalls.length, 1);
   assert.deepEqual(result, rows);
+});
+
+test("executeQueryNode emits permission and datasource observability events", async () => {
+  const events: RuntimeAuditEvent[] = [];
+  const rows = [{ id: "row-1", owner: "user-1" }];
+
+  const result = await executeQueryNode(createQueryNode(), runtimeState, {
+    ...runtimeContext,
+    requestId: "req-query-1",
+    planId: "plan-query-1",
+    viewName: "orders-workbench"
+  }, {
+    compiler: createQueryCompilerAdapter(),
+    datasource: {
+      async execute(request) {
+        return {
+          rows,
+          rowCount: rows.length,
+          metadata: {
+            kind: request.kind,
+            durationMs: 3
+          }
+        };
+      }
+    },
+    audit: {
+      observer: {
+        recordRuntimeEvent(event) {
+          events.push(event);
+        }
+      },
+      nodeId: "orders",
+      nodeType: "query"
+    }
+  });
+
+  assert.deepEqual(result, rows);
+  assert.deepEqual(
+    events.map((event) => event.type),
+    [
+      "runtime.permission.decision",
+      "runtime.datasource.succeeded"
+    ]
+  );
+  assert.equal(events[0]?.requestId, "req-query-1");
+  assert.equal(events[0]?.planId, "plan-query-1");
+  assert.equal(events[0]?.nodeId, "orders");
+  assert.equal(events[0]?.status, "allow");
+  assert.equal(events[1]?.status, "success");
+  assert.equal(events[1]?.metadata?.rowCount, 1);
+});
+
+test("executeQueryNode emits datasource failure events while preserving execute errors", async () => {
+  const events: RuntimeAuditEvent[] = [];
+
+  await assert.rejects(
+    () =>
+      executeQueryNode(createQueryNode(), runtimeState, {
+        ...runtimeContext,
+        requestId: "req-query-2"
+      }, {
+        compiler: createQueryCompilerAdapter(),
+        datasource: {
+          async execute() {
+            throw new Error("database offline");
+          }
+        },
+        audit: {
+          observer: {
+            recordRuntimeEvent(event) {
+              events.push(event);
+            }
+          },
+          nodeId: "orders",
+          nodeType: "query"
+        }
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof QueryExecutorError);
+      assert.equal(error.stage, "execute");
+      return true;
+    }
+  );
+
+  assert.deepEqual(
+    events.map((event) => event.type),
+    [
+      "runtime.permission.decision",
+      "runtime.datasource.failed"
+    ]
+  );
+  assert.equal(events[1]?.requestId, "req-query-2");
+  assert.equal(events[1]?.planId, "req-query-2");
+  assert.equal(events[1]?.nodeId, "orders");
+  assert.match(events[1]?.errorMessage ?? "", /database offline/);
 });
 
 test("executeQueryNode wraps query compilation errors with traceable stage information", async () => {

--- a/packages/runtime/test/runtime-executor.test.ts
+++ b/packages/runtime/test/runtime-executor.test.ts
@@ -4,6 +4,7 @@ import {
   executeMergeNode,
   RuntimeExecutionError,
   RuntimeExecutor,
+  type RuntimeAuditEvent,
   type ExecutionNode,
   type ExecutionPlan,
   type NodeExecutorDependencies,
@@ -141,6 +142,138 @@ test("RuntimeExecutor executes a single query plan and resolves output against t
   (result.state.orders as { row: { id: string } }).row.id = "mutated";
   assert.deepEqual(result.viewModel, snapshot.viewModel);
   assert.deepEqual(result.nodeResults, snapshot.nodeResults);
+});
+
+test("RuntimeExecutor emits plan and node observability events", async () => {
+  const events: RuntimeAuditEvent[] = [];
+  const plan = createPlan(
+    [createQueryNode("orders", "orders")],
+    {
+      orders: []
+    },
+    {
+      rows: "{{orders.rows}}"
+    }
+  );
+
+  await executor.execute(
+    plan,
+    {
+      ...runtimeContext,
+      requestId: "req-runtime-1",
+      planId: "plan-runtime-1",
+      viewName: "orders-workbench",
+      tenantId: "tenant-a",
+      userId: "user-a"
+    },
+    {
+      auditObserver: {
+        recordRuntimeEvent(event) {
+          events.push(event);
+        }
+      },
+      executors: createExecutors({
+        query: async () => [{ id: "order-1" }]
+      })
+    }
+  );
+
+  assert.deepEqual(
+    events.map((event) => event.type),
+    [
+      "runtime.plan.started",
+      "runtime.node.succeeded",
+      "runtime.plan.finished"
+    ]
+  );
+  assert.deepEqual(
+    events.map((event) => event.requestId),
+    ["req-runtime-1", "req-runtime-1", "req-runtime-1"]
+  );
+  assert.equal(events[1]?.nodeId, "orders");
+  assert.equal(events[1]?.nodeType, "query");
+  assert.equal(events[2]?.planId, "plan-runtime-1");
+});
+
+test("RuntimeExecutor emits node failure events with correlation and preserves the runtime error", async () => {
+  const events: RuntimeAuditEvent[] = [];
+  const plan = createPlan(
+    [createQueryNode("orders", "orders")],
+    {
+      orders: []
+    },
+    {
+      rows: "{{orders.rows}}"
+    }
+  );
+
+  await assert.rejects(
+    () =>
+      executor.execute(
+        plan,
+        {
+          ...runtimeContext,
+          requestId: "req-runtime-2"
+        },
+        {
+          auditObserver: {
+            recordRuntimeEvent(event) {
+              events.push(event);
+            }
+          },
+          executors: createExecutors({
+            query: async () => {
+              throw new Error("node exploded");
+            }
+          })
+        }
+      ),
+    (error: unknown) => {
+      assert.ok(error instanceof RuntimeExecutionError);
+      assert.equal(error.nodeId, "orders");
+      return true;
+    }
+  );
+
+  assert.deepEqual(
+    events.map((event) => event.type),
+    [
+      "runtime.plan.started",
+      "runtime.node.failed",
+      "runtime.plan.finished"
+    ]
+  );
+  assert.equal(events[1]?.requestId, "req-runtime-2");
+  assert.equal(events[1]?.planId, "req-runtime-2");
+  assert.equal(events[1]?.nodeId, "orders");
+  assert.match(events[1]?.errorMessage ?? "", /node exploded/);
+});
+
+test("RuntimeExecutor ignores observer failures", async () => {
+  const plan = createPlan(
+    [createQueryNode("orders", "orders")],
+    {
+      orders: []
+    },
+    {
+      rows: "{{orders.rows}}"
+    }
+  );
+
+  const result = await executor.execute(plan, runtimeContext, {
+    auditObserver: {
+      recordRuntimeEvent() {
+        throw new Error("observer unavailable");
+      }
+    },
+    executors: createExecutors({
+      query: async () => [{ id: "order-1" }]
+    })
+  });
+
+  assert.deepEqual(result.viewModel, {
+    rows: [{ id: "order-1" }]
+  });
 });
 
 test("RuntimeExecutor commits a layer atomically when one sibling fails", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
       '@nestjs/websockets':
         specifier: ^10.4.22
         version: 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@nestjs/platform-socket.io@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@zhongmiao/meta-lc-audit':
+        specifier: workspace:*
+        version: link:../audit
       '@zhongmiao/meta-lc-contracts':
         specifier: workspace:*
         version: link:../contracts
@@ -210,6 +213,9 @@ importers:
 
   packages/runtime:
     dependencies:
+      '@zhongmiao/meta-lc-audit':
+        specifier: workspace:*
+        version: link:../audit
       '@zhongmiao/meta-lc-contracts':
         specifier: workspace:*
         version: link:../contracts


### PR DESCRIPTION
## Summary
- Add runtime audit observability contracts for plan, node, permission, and datasource execution events.
- Wire RuntimeExecutor and query execution to emit optional non-blocking observer events without changing execution semantics.
- Persist runtime audit events from the BFF infra boundary into `runtime_audit_events` with request/plan/node/event indexes.

## Checks
- `pnpm --filter @zhongmiao/meta-lc-audit test`
- `pnpm --filter @zhongmiao/meta-lc-runtime test`
- `pnpm --filter @zhongmiao/meta-lc-bff test`
- `pnpm --filter @zhongmiao/meta-lc-datasource test`
- `pnpm run test:boundaries`
- `pnpm run lint`
- `pnpm query-gate`
- `pnpm -r build`
- `git diff --check`
- `node scripts/check-changelog-gate.mjs origin/main HEAD`

## Risk / Rollback
- Risk is limited to optional observability hooks and BFF audit persistence; the runtime observer path is fire-and-forget and catches failures.
- Rollback by reverting this PR; core runtime, permission, and datasource execution semantics remain unchanged.

Closes #91
