### PR TITLE
docs(kernel): update task 17 changelog

### DIFF
--- a/packages/kernel/CHANGELOG.md
+++ b/packages/kernel/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- refactor(meta): own the demo meta registry seeds used by runtime gateway view lookup.
 - refactor(contracts): own ViewDefinition and node structure contracts directly while staying independent from runtime.
 - refactor(contracts): own datasource, permission policy, view, and node structure contracts directly.
 - feat(meta-registry): add versioned view, datasource, and permission policy definition registry APIs.

--- a/packages/kernel/CHANGELOG.zh-CN.md
+++ b/packages/kernel/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- refactor(meta): 由 kernel 拥有 runtime gateway view lookup 使用的 demo meta registry seed。
 - refactor(contracts): 由 kernel 直接拥有 ViewDefinition 与 node 结构契约，并保持不依赖 runtime。
 - refactor(contracts): 由 kernel 直接拥有 datasource、permission policy、view 与 node 结构契约。
 - feat(meta-registry): 新增 view、datasource 与 permission policy definition 的版本化 registry API。


### PR DESCRIPTION
## Summary
- Adds the missing kernel changelog entries for the Task 17 meta registry seed ownership change.
- This is a follow-up to #120 / #119 to satisfy the CI changelog gate on main.

## Checks
- pnpm run changelog:gate -- origin/main HEAD
- pnpm --filter @zhongmiao/meta-lc-kernel test
- git diff --check

## Risk / Rollback
- Documentation-only changelog update; rollback by reverting this PR if needed.

Follow-up for #119.