### PR TITLE
fix(ci): build workspace dependencies before package tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- fix(ci): build workspace dependencies before package-local tests so clean CI runners can resolve package entrypoints.
 - chore(boundaries): lock final dependency gates with Nx module-boundary tags, full-workspace ESLint, and hard checks that prevent kernel/query/datasource/audit workspace dependencies.
 - chore(boundaries): seal the final seven-package topology with stricter BFF gateway layout, runtime entry naming, datasource demo adapter names, and dependency gates.
 - refactor(boundaries): lock the final runtime gateway topology by removing BFF data wiring, moving execution dependencies into runtime, and forbidding kernel-to-runtime dependency drift.

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- fix(ci): 在 package-local test 前先构建 workspace 依赖，确保 clean CI runner 能解析各包入口。
 - chore(boundaries): 通过 Nx module-boundary tags、全仓 ESLint 与硬边界检查锁死最终依赖规则，防止 kernel/query/datasource/audit 引入 workspace 依赖。
 - chore(boundaries): 通过更严格的 BFF gateway 目录、runtime 入口命名、datasource demo adapter 命名与依赖守护，封板最终七包拓扑。
 - refactor(boundaries): 锁定最终 runtime gateway topology，移除 BFF 数据装配，把执行依赖迁入 runtime，并禁止 kernel 反向依赖 runtime。

--- a/apps/bff-server/package.json
+++ b/apps/bff-server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "start": "sh -c 'if [ -f ../../.env ]; then exec node --env-file=../../.env dist/apps/bff-server/src/main.js; else exec node dist/apps/bff-server/src/main.js; fi'",
-    "test": "npm run build && node --test \"dist/**/test/*.test.js\"",
+    "test": "pnpm --filter @zhongmiao/meta-lc-bff-server... build && node --test \"dist/**/test/*.test.js\"",
     "test:query-gate": "bash ../../infra/scripts/e2e-query-isolation.sh",
     "lint": "echo lint:bff-server"
   },

--- a/packages/bff/CHANGELOG.md
+++ b/packages/bff/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- fix(ci): build BFF workspace dependencies before package-local tests on clean runners.
 - chore(boundaries): add final Nx layer tags and lock BFF dependency gates to runtime/kernel only.
 - chore(boundaries): seal the gateway-only layout by removing mapper/repository/interface remnants, adding gateway-only config, and tightening dependency guards.
 - refactor(boundaries): remove BFF contracts and data execution dependencies so view controllers only call the runtime gateway facade.

--- a/packages/bff/CHANGELOG.zh-CN.md
+++ b/packages/bff/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- fix(ci): 在 clean runner 的 BFF package-local test 前先构建 workspace 依赖。
 - chore(boundaries): 新增最终 Nx layer tags，并将 BFF 依赖守护锁定为只能依赖 runtime/kernel。
 - chore(boundaries): 删除 mapper/repository/interface 残留，新增 gateway-only config，并收紧依赖守护，封板 BFF gateway-only 目录。
 - refactor(boundaries): 删除 BFF contracts 与数据执行依赖，让 view controller 只调用 runtime gateway facade。

--- a/packages/bff/package.json
+++ b/packages/bff/package.json
@@ -5,7 +5,7 @@
   "type": "commonjs",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "pnpm --filter @zhongmiao/meta-lc-runtime build && npm run build && node --test \"dist/**/test/*.test.js\"",
+    "test": "pnpm --filter @zhongmiao/meta-lc-bff... build && node --test \"dist/**/test/*.test.js\"",
     "lint": "eslint \"src/**/*.ts\" --config ../../eslint.config.mjs",
     "start": "sh -c 'if [ -f ../../.env ]; then exec node --env-file=../../.env dist/bff/src/bootstrap/main.js; else exec node dist/bff/src/bootstrap/main.js; fi'"
   },

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -16,8 +16,8 @@
     "@types/pg": "^8.11.10",
     "typescript": "^5.7.2"
   },
-  "main": "dist/kernel/src/index.js",
-  "types": "dist/kernel/src/index.d.ts",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
   "nx": {
     "tags": ["layer:kernel"]
   }

--- a/packages/permission/CHANGELOG.md
+++ b/packages/permission/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- fix(ci): build query before permission package-local tests on clean runners.
 - chore(boundaries): add final Nx layer tags and lock permission so it can depend on query only.
 - refactor(contracts): own org and data-scope DTO contracts directly.
 - feat(permission-ast): add Query AST transforms for tenant, self, and organization data scopes.

--- a/packages/permission/CHANGELOG.zh-CN.md
+++ b/packages/permission/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- fix(ci): 在 clean runner 的 permission package-local test 前先构建 query。
 - chore(boundaries): 新增最终 Nx layer tags，并将 permission 锁定为只能依赖 query。
 - refactor(contracts): 由 permission 直接拥有组织与数据域 DTO contract。
 - feat(permission-ast): 新增覆盖 tenant、self 与组织数据域的 Query AST transform。

--- a/packages/permission/package.json
+++ b/packages/permission/package.json
@@ -5,7 +5,7 @@
   "type": "commonjs",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "npm run build && node --test \"dist/**/test/*.test.js\"",
+    "test": "pnpm --filter @zhongmiao/meta-lc-permission... build && node --test \"dist/**/test/*.test.js\"",
     "lint": "echo lint:permission"
   },
   "dependencies": {

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- fix(ci): build runtime workspace dependencies before package-local tests on clean runners.
 - chore(boundaries): add final Nx layer tags and keep runtime as the only package allowed to depend on kernel/query/permission/datasource/audit together.
 - chore(boundaries): rename runtime manager-event tests to interaction-event tests and document RuntimeExecutor as the only bottom execution entry with view/interaction facades above it.
 - refactor(boundaries): remove the manager-adapter export and make the runtime gateway facade own view lookup plus execution dependency wiring.

--- a/packages/runtime/CHANGELOG.zh-CN.md
+++ b/packages/runtime/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- fix(ci): 在 clean runner 的 runtime package-local test 前先构建 workspace 依赖。
 - chore(boundaries): 新增最终 Nx layer tags，并保持 runtime 是唯一允许同时依赖 kernel/query/permission/datasource/audit 的执行包。
 - chore(boundaries): 将 runtime manager-event 测试命名改为 interaction-event，并明确 RuntimeExecutor 是唯一底层执行入口，view/interaction 位于 facade 层。
 - refactor(boundaries): 移除 manager-adapter 导出，并让 runtime gateway facade 接管 view lookup 与执行依赖装配。

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -5,7 +5,7 @@
   "type": "commonjs",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "npm run build && node --test \"dist/**/test/*.test.js\"",
+    "test": "pnpm --filter @zhongmiao/meta-lc-runtime... build && node --test \"dist/**/test/*.test.js\"",
     "lint": "echo lint:runtime"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Fix the clean-runner CI failure from PR #125 by correcting the kernel package entrypoint after removing its workspace dependency.
- Build workspace dependencies before package-local tests for runtime, permission, BFF, and bff-server.

## Checks
- `rm -rf packages/*/dist apps/bff-server/dist && pnpm --filter @zhongmiao/meta-lc-runtime test`
- `pnpm --filter @zhongmiao/meta-lc-permission test`
- `pnpm --filter @zhongmiao/meta-lc-bff test`
- `pnpm run test:boundaries`
- `pnpm run lint:boundaries`
- `pnpm run lint`
- `pnpm -r build`
- `pnpm -r test`
- `pnpm query-gate`
- `git diff --check`
- `pnpm run changelog:gate -- origin/main HEAD`

## Risk / Rollback
- Risk is limited to test scripts and kernel package entrypoint metadata.
- Roll back by reverting this PR if package-local tests need a different CI composition.

Follow-up for #125 / #124.
