### PR TITLE
fix(ci): add kernel changelog for entrypoint fix

### DIFF
--- a/packages/kernel/CHANGELOG.md
+++ b/packages/kernel/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- fix(package): align the kernel package main/types entrypoints with the dependency-free clean build output.
 - chore(boundaries): own `DataScopeType` as a local structural literal and remove the permission package dependency so kernel has no workspace dependencies.
 - refactor(meta): own the demo meta registry seeds used by runtime gateway view lookup.
 - refactor(contracts): own ViewDefinition and node structure contracts directly while staying independent from runtime.

--- a/packages/kernel/CHANGELOG.zh-CN.md
+++ b/packages/kernel/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- fix(package): 将 kernel package main/types 入口对齐到无 workspace 依赖后的 clean build 输出路径。
 - chore(boundaries): 将 `DataScopeType` 作为本地结构字面量持有，移除 permission 包依赖，确保 kernel 不依赖任何 workspace package。
 - refactor(meta): 由 kernel 拥有 runtime gateway view lookup 使用的 demo meta registry seed。
 - refactor(contracts): 由 kernel 直接拥有 ViewDefinition 与 node 结构契约，并保持不依赖 runtime。


### PR DESCRIPTION
## Summary
- Add the missing kernel package changelog entries required by CI for the kernel package entrypoint fix in #126.

## Checks
- `pnpm run changelog:gate -- origin/main HEAD`
- `pnpm run lint:boundaries`
- `git diff --check`

## Risk / Rollback
- Documentation/changelog-only fix; rollback risk is negligible.

Follow-up for #126 / #125 / #124.
