### PR TITLE
docs(readme): sync architecture flow boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- docs(readme): sync the final architecture flow, package relationship notes, and compiler/execution boundary wording.
 - fix(ci): build workspace dependencies before package-local tests so clean CI runners can resolve package entrypoints.
 - chore(boundaries): lock final dependency gates with Nx module-boundary tags, full-workspace ESLint, and hard checks that prevent kernel/query/datasource/audit workspace dependencies.
 - chore(boundaries): seal the final seven-package topology with stricter BFF gateway layout, runtime entry naming, datasource demo adapter names, and dependency gates.

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- docs(readme): 同步最终架构协作流、子包上下游关系与编译/执行边界口径。
 - fix(ci): 在 package-local test 前先构建 workspace 依赖，确保 clean CI runner 能解析各包入口。
 - chore(boundaries): 通过 Nx module-boundary tags、全仓 ESLint 与硬边界检查锁死最终依赖规则，防止 kernel/query/datasource/audit 引入 workspace 依赖。
 - chore(boundaries): 通过更严格的 BFF gateway 目录、runtime 入口命名、datasource demo adapter 命名与依赖守护，封板最终七包拓扑。

--- a/README.md
+++ b/README.md
@@ -6,22 +6,44 @@ This workspace combines reusable platform libraries under `packages/*` with a ru
 
 English | [中文文档](./README_zh.md)
 
-## Architecture
+## Architecture Flow
 
 The platform keeps the frontend and runtime behind the BFF. Metadata flows through the Meta Kernel and `meta_db`; business data flows through runtime, query, permission, and datasource execution against `business_db`; audit records belong to `audit_db`.
 
+This diagram shows runtime execution handoff, not package import dependencies. `Permission --> Query` means permission transforms query AST / type contracts and must not execute SQL. `Query --> Datasource` means runtime hands compiled SQL/request output to datasource execution; `query` still must not depend on `datasource`.
+
 ```mermaid
 flowchart LR
-  Client["Runtime / Client"] --> BFF["packages/bff<br/>Gateway only"]
-  BFF --> Runtime["packages/runtime<br/>Execution engine"]
-  BFF --> Kernel["packages/kernel<br/>Structure source of truth"]
-  Runtime --> Query["packages/query<br/>AST -> SQL"]
-  Runtime --> Permission["packages/permission<br/>AST transform + data scope"]
-  Runtime --> Datasource["packages/datasource<br/>Datasource adapter"]
-  Runtime --> Audit["packages/audit<br/>Observability events"]
-  Kernel --> MetaDb[("meta_db")]
-  Datasource --> BusinessDb[("business_db")]
-  Audit --> AuditDb[("audit_db")]
+  Client["Runtime / Client<br/>Renderer / Designer / Consumer"]
+  BFFServer["apps/bff-server<br/>NestJS bootstrap"]
+  BFF["packages/bff<br/>Gateway only<br/>HTTP / WS / request-id / error mapping"]
+  Runtime["packages/runtime<br/>Execution engine<br/>View facade / RuntimeExecutor / DAG / State"]
+  Kernel["packages/kernel<br/>Structure source of truth<br/>Meta registry / ViewDefinition / Schema / Version"]
+  Query["packages/query<br/>Query compiler<br/>AST to SQL"]
+  Permission["packages/permission<br/>Permission engine<br/>AST transform + data scope"]
+  Datasource["packages/datasource<br/>Datasource adapter<br/>Postgres / mutation / org-scope adapters"]
+  Audit["packages/audit<br/>Observability events<br/>Runtime audit sink"]
+  InfraScripts["infra/scripts<br/>migrate.ts / seed.ts"]
+  MetaDb[("meta_db")]
+  BusinessDb[("business_db")]
+  AuditDb[("audit_db")]
+  Client --> BFFServer
+  BFFServer --> BFF
+  BFF --> Runtime
+  BFF --> Kernel
+  Runtime --> Kernel
+  Runtime --> Permission
+  Runtime --> Query
+  Runtime --> Datasource
+  Runtime --> Audit
+  Permission -->|"AST transform / query types"| Query
+  Query -->|"compiled request"| Datasource
+  Kernel --> MetaDb
+  Datasource --> BusinessDb
+  Audit --> AuditDb
+  InfraScripts --> MetaDb
+  InfraScripts --> BusinessDb
+  InfraScripts --> AuditDb
 ```
 
 ## Package Index
@@ -30,7 +52,7 @@ flowchart LR
 | --- | --- | --- |
 | `packages/runtime` | RuntimeExecutor execution engine, DAG/state execution contracts, runtime gateway facade, and WS event contracts. | [English](./packages/runtime/README.md) \| [中文文档](./packages/runtime/README_zh.md) |
 | `packages/kernel` | Structural metadata contracts, MetaSchema validation, definition registry, diff, and migration SQL helpers. | [English](./packages/kernel/README.md) \| [中文文档](./packages/kernel/README_zh.md) |
-| `packages/query` | Query DSL to SQL compilation. | [English](./packages/query/README.md) \| [中文文档](./packages/query/README_zh.md) |
+| `packages/query` | Query AST / DSL to SQL compilation. | [English](./packages/query/README.md) \| [中文文档](./packages/query/README_zh.md) |
 | `packages/permission` | RBAC and organization data-scope decisions. | [English](./packages/permission/README.md) \| [中文文档](./packages/permission/README_zh.md) |
 | `packages/datasource` | Postgres datasource configuration and execution adapter. | [English](./packages/datasource/README.md) \| [中文文档](./packages/datasource/README_zh.md) |
 | `packages/audit` | Audit contracts and optional non-blocking runtime observability sinks. | [English](./packages/audit/README.md) \| [中文文档](./packages/audit/README_zh.md) |
@@ -47,6 +69,12 @@ flowchart LR
 - `query` compiles AST to SQL and must not depend on `datasource`, `runtime`, or `permission`.
 - `bff` remains a gateway and must not own runtime orchestration, datasource wiring, permission decisions, audit wiring, or DB access.
 - Deep cross-package imports are forbidden; import through package entrypoints.
+
+### Compiler / Execution Boundaries
+
+- `packages/query`: owns Query AST -> SQL compile; must not execute SQL; must not depend on datasource.
+- `packages/datasource`: owns physical execution; receives compiled request / SQL command; must not compile Query AST; must not depend on query / permission / runtime.
+- `packages/permission`: owns AST transform only; may use type-only imports from query AST/types if needed; must not value-import the query compiler; must not compile SQL; must not execute datasource.
 
 ## Runtime Entries
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -6,22 +6,44 @@
 
 [English](./README.md) | 中文文档
 
-## 总体架构
+## 架构协作流
 
 平台约束是所有前端与 runtime 数据访问必须经过 BFF。元数据通过 Meta Kernel 进入 `meta_db`；业务查询与变更通过 runtime、query、permission、datasource 访问 `business_db`；审计记录进入 `audit_db`。
 
+下图表达 runtime 执行交接关系，不是 package import 依赖图。`Permission --> Query` 表示 permission transform 作用于 query AST / query type contract，且 permission 不执行 SQL。`Query --> Datasource` 表示 runtime 将 query 编译后的 SQL/request 产物交给 datasource 执行；`query` 仍然禁止依赖 `datasource`。
+
 ```mermaid
 flowchart LR
-  Client["Runtime / Client"] --> BFF["packages/bff<br/>Gateway only"]
-  BFF --> Runtime["packages/runtime<br/>执行引擎"]
-  BFF --> Kernel["packages/kernel<br/>结构真源"]
-  Runtime --> Query["packages/query<br/>AST -> SQL"]
-  Runtime --> Permission["packages/permission<br/>AST transform + 数据域"]
-  Runtime --> Datasource["packages/datasource<br/>Datasource adapter"]
-  Runtime --> Audit["packages/audit<br/>观测事件"]
-  Kernel --> MetaDb[("meta_db")]
-  Datasource --> BusinessDb[("business_db")]
-  Audit --> AuditDb[("audit_db")]
+  Client["Runtime / Client<br/>Renderer / Designer / Consumer"]
+  BFFServer["apps/bff-server<br/>NestJS bootstrap"]
+  BFF["packages/bff<br/>Gateway only<br/>HTTP / WS / request-id / error mapping"]
+  Runtime["packages/runtime<br/>Execution engine<br/>View facade / RuntimeExecutor / DAG / State"]
+  Kernel["packages/kernel<br/>Structure source of truth<br/>Meta registry / ViewDefinition / Schema / Version"]
+  Query["packages/query<br/>Query compiler<br/>AST to SQL"]
+  Permission["packages/permission<br/>Permission engine<br/>AST transform + data scope"]
+  Datasource["packages/datasource<br/>Datasource adapter<br/>Postgres / mutation / org-scope adapters"]
+  Audit["packages/audit<br/>Observability events<br/>Runtime audit sink"]
+  InfraScripts["infra/scripts<br/>migrate.ts / seed.ts"]
+  MetaDb[("meta_db")]
+  BusinessDb[("business_db")]
+  AuditDb[("audit_db")]
+  Client --> BFFServer
+  BFFServer --> BFF
+  BFF --> Runtime
+  BFF --> Kernel
+  Runtime --> Kernel
+  Runtime --> Permission
+  Runtime --> Query
+  Runtime --> Datasource
+  Runtime --> Audit
+  Permission -->|"AST transform / query types"| Query
+  Query -->|"compiled request"| Datasource
+  Kernel --> MetaDb
+  Datasource --> BusinessDb
+  Audit --> AuditDb
+  InfraScripts --> MetaDb
+  InfraScripts --> BusinessDb
+  InfraScripts --> AuditDb
 ```
 
 ## 子包索引
@@ -30,7 +52,7 @@ flowchart LR
 | --- | --- | --- |
 | `packages/runtime` | RuntimeExecutor 执行引擎、DAG/state 执行契约、runtime gateway facade 与 WS event contract。 | [English](./packages/runtime/README.md) \| [中文文档](./packages/runtime/README_zh.md) |
 | `packages/kernel` | 结构元数据契约、MetaSchema 校验、definition registry、diff 与 migration SQL helper。 | [English](./packages/kernel/README.md) \| [中文文档](./packages/kernel/README_zh.md) |
-| `packages/query` | Query DSL 到 SQL 编译。 | [English](./packages/query/README.md) \| [中文文档](./packages/query/README_zh.md) |
+| `packages/query` | Query AST / DSL 到 SQL 编译。 | [English](./packages/query/README.md) \| [中文文档](./packages/query/README_zh.md) |
 | `packages/permission` | RBAC 与组织数据域决策。 | [English](./packages/permission/README.md) \| [中文文档](./packages/permission/README_zh.md) |
 | `packages/datasource` | Postgres datasource 配置与执行 adapter。 | [English](./packages/datasource/README.md) \| [中文文档](./packages/datasource/README_zh.md) |
 | `packages/audit` | 审计契约与可选、非阻塞 runtime observability sink。 | [English](./packages/audit/README.md) \| [中文文档](./packages/audit/README_zh.md) |
@@ -47,6 +69,12 @@ flowchart LR
 - `query` 只负责 AST 到 SQL 编译，禁止依赖 `datasource`、`runtime` 或 `permission`。
 - `bff` 只作为 gateway，不拥有 runtime orchestration、datasource wiring、permission decision、audit wiring 或 DB access。
 - 禁止 deep import，跨包引用必须通过 package entrypoint。
+
+### 编译 / 执行边界
+
+- `packages/query` 拥有 Query AST -> SQL 编译职责，禁止执行 SQL，禁止依赖 `datasource`。
+- `packages/datasource` 拥有物理执行职责，接收 compiled request 或 SQL command，禁止编译 Query AST，禁止依赖 `query`、`permission` 或 `runtime`。
+- `packages/permission` 只拥有 AST transform，仅允许 type-only 依赖 query 的 AST/types，禁止 value import query compiler，禁止编译 SQL，禁止执行 datasource 请求。
 
 ## 运行入口
 

--- a/packages/audit/CHANGELOG.md
+++ b/packages/audit/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- docs(readme): add upstream/downstream relationship notes for the final architecture flow.
 - chore(boundaries): add final Nx layer tags and lock audit as a passive package without workspace dependencies.
 - feat(sink): add an optional Postgres runtime audit sink that degrades without blocking runtime execution.
 - refactor(contracts): own QueryAuditLog and audit status contracts directly.

--- a/packages/audit/CHANGELOG.zh-CN.md
+++ b/packages/audit/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- docs(readme): 补充最终架构协作流中的上下游关系说明。
 - chore(boundaries): 新增最终 Nx layer tags，并将 audit 锁定为无 workspace 依赖的被动观测包。
 - feat(sink): 新增可选 Postgres runtime audit sink，落盘失败不会阻断 runtime execution。
 - refactor(contracts): 由 audit 直接拥有 QueryAuditLog 与 audit status contract。

--- a/packages/audit/README.md
+++ b/packages/audit/README.md
@@ -16,6 +16,8 @@ English | [中文文档](./README_zh.md)
 
 ## Relationship With Other Packages
 
+- Upstream: `runtime`.
+- Downstream: `audit_db` or an external sink; audit has no workspace package dependencies.
 - Owns audit contracts directly; it does not depend on a transitional contracts package.
 - Runtime can emit observability events through an optional `RuntimeAuditObserver`; observer failures must not affect execution semantics.
 - Migration orchestration can report migration audit records through this contract.

--- a/packages/audit/README_zh.md
+++ b/packages/audit/README_zh.md
@@ -16,6 +16,8 @@
 
 ## 与其他包关系
 
+- 上游：`runtime`。
+- 下游：`audit_db` 或外部 sink；audit 不依赖任何 workspace package。
 - 直接拥有 audit contract，不再依赖过渡 `contracts` 包。
 - Runtime 可通过可选 `RuntimeAuditObserver` 发出 observability event；observer 失败不得影响执行语义。
 - Migration orchestration 可通过此 contract 上报 migration audit record。

--- a/packages/bff/CHANGELOG.md
+++ b/packages/bff/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- docs(readme): document BFF upstream/downstream relationships in the final gateway-only topology.
 - fix(ci): build BFF workspace dependencies before package-local tests on clean runners.
 - chore(boundaries): add final Nx layer tags and lock BFF dependency gates to runtime/kernel only.
 - chore(boundaries): seal the gateway-only layout by removing mapper/repository/interface remnants, adding gateway-only config, and tightening dependency guards.

--- a/packages/bff/CHANGELOG.zh-CN.md
+++ b/packages/bff/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- docs(readme): 在最终 gateway-only 拓扑中补充 BFF 上下游关系说明。
 - fix(ci): 在 clean runner 的 BFF package-local test 前先构建 workspace 依赖。
 - chore(boundaries): 新增最终 Nx layer tags，并将 BFF 依赖守护锁定为只能依赖 runtime/kernel。
 - chore(boundaries): 删除 mapper/repository/interface 残留，新增 gateway-only config，并收紧依赖守护，封板 BFF gateway-only 目录。

--- a/packages/bff/README.md
+++ b/packages/bff/README.md
@@ -55,6 +55,9 @@ bff/src/
 
 ## Dependency Direction
 
+- Upstream: `apps/bff-server` and client protocol entrypoints.
+- Downstream: `runtime` for page execution and `kernel` for thin metadata reads.
+
 ```text
 controller/http -> runtime facade
 controller/http -> kernel registry

--- a/packages/bff/README_zh.md
+++ b/packages/bff/README_zh.md
@@ -55,6 +55,9 @@ bff/src/
 
 ## 依赖方向
 
+- 上游：`apps/bff-server` 与 client 协议入口。
+- 下游：`runtime` 负责页面执行，`kernel` 负责 thin metadata reads。
+
 ```text
 controller/http -> runtime facade
 controller/http -> kernel registry

--- a/packages/datasource/CHANGELOG.md
+++ b/packages/datasource/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- docs(readme): clarify datasource upstream/downstream relationships and physical-execution-only boundaries.
 - chore(boundaries): add final Nx layer tags and lock datasource against workspace package dependencies.
 - chore(boundaries): rename Postgres demo runtime adapters to make demo-orders and org-scope boundaries explicit.
 - feat(adapter): add Postgres demo orders mutation and org-scope loaders so runtime owns execution wiring without BFF DB access.

--- a/packages/datasource/CHANGELOG.zh-CN.md
+++ b/packages/datasource/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- docs(readme): 明确 datasource 上下游关系与仅负责物理执行的边界。
 - chore(boundaries): 新增最终 Nx layer tags，并禁止 datasource 依赖 workspace package。
 - chore(boundaries): 重命名 Postgres demo runtime adapters，显式标记 demo-orders 与 org-scope 边界。
 - feat(adapter): 新增 Postgres demo orders mutation 与 org-scope loader，让 runtime 拥有执行装配且 BFF 不再访问 DB。

--- a/packages/datasource/README.md
+++ b/packages/datasource/README.md
@@ -14,6 +14,8 @@ English | [中文文档](./README_zh.md)
 
 ## Relationship With Other Packages
 
+- Upstream: `runtime`.
+- Downstream: `business_db`; datasource has no workspace package dependencies.
 - `runtime` consumes datasource adapters through a stable execution contract.
 - Runtime wires concrete Postgres adapters for page execution; BFF does not depend on this package.
 - `query` produces SQL that a datasource adapter can execute.
@@ -41,6 +43,9 @@ pnpm --filter @zhongmiao/meta-lc-datasource test
 ## Boundary Notes
 
 - Keep adapter code focused on database execution and lifecycle.
+- Receives compiled request / SQL command.
+- Must not compile Query AST.
+- Must not depend on query / permission / runtime.
 - Demo business mutations and org-scope reads belong here as Postgres adapter edges, not in BFF.
 - Keep demo adapters explicitly named with `postgres-demo-*` or `postgres-org-scope*` so business adapter semantics do not become implicit datasource orchestration.
 - Do not add HTTP controller or runtime orchestration here.

--- a/packages/datasource/README_zh.md
+++ b/packages/datasource/README_zh.md
@@ -14,6 +14,8 @@
 
 ## 与其他包关系
 
+- 上游：`runtime`。
+- 下游：`business_db`；datasource 不依赖任何 workspace package。
 - `runtime` 通过稳定 execution contract 消费 datasource adapter。
 - Runtime 为页面执行装配具体 Postgres adapter；BFF 不依赖本包。
 - `query` 生成 datasource adapter 可执行的 SQL。
@@ -41,6 +43,8 @@ pnpm --filter @zhongmiao/meta-lc-datasource test
 ## 边界约束
 
 - adapter 代码只关注数据库执行与生命周期。
+- 接收 compiled request 或 SQL command；不在此包编译 Query AST。
+- 不依赖 `query`、`permission` 或 `runtime`。
 - demo business mutation 与 org-scope 读取属于这里的 Postgres adapter 边界，不属于 BFF。
 - demo adapter 必须显式使用 `postgres-demo-*` 或 `postgres-org-scope*` 命名，避免业务 adapter 语义隐式滑向 datasource 编排。
 - 不在这里加入 HTTP controller 或 runtime orchestration。

--- a/packages/kernel/CHANGELOG.md
+++ b/packages/kernel/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- docs(readme): add kernel upstream/downstream notes for metadata ownership and meta_db persistence.
 - fix(package): align the kernel package main/types entrypoints with the dependency-free clean build output.
 - chore(boundaries): own `DataScopeType` as a local structural literal and remove the permission package dependency so kernel has no workspace dependencies.
 - refactor(meta): own the demo meta registry seeds used by runtime gateway view lookup.

--- a/packages/kernel/CHANGELOG.zh-CN.md
+++ b/packages/kernel/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- docs(readme): 补充 kernel 元数据归属与 meta_db 持久化的上下游关系说明。
 - fix(package): 将 kernel package main/types 入口对齐到无 workspace 依赖后的 clean build 输出路径。
 - chore(boundaries): 将 `DataScopeType` 作为本地结构字面量持有，移除 permission 包依赖，确保 kernel 不依赖任何 workspace package。
 - refactor(meta): 由 kernel 拥有 runtime gateway view lookup 使用的 demo meta registry seed。

--- a/packages/kernel/README.md
+++ b/packages/kernel/README.md
@@ -17,6 +17,8 @@ English | [中文文档](./README_zh.md)
 
 ## Relationship With Other Packages
 
+- Upstream: `bff`, `runtime`, and `infra/scripts`.
+- Downstream: `meta_db`; kernel has no workspace package dependencies.
 - Migration lifecycle scripts reuse kernel migration compile and safety helpers from infra.
 - `bff` reads kernel registry definitions as a thin gateway and must not orchestrate metadata.
 - `query`, `permission`, `datasource`, `runtime`, `audit`, and `bff` must not become kernel dependencies.

--- a/packages/kernel/README_zh.md
+++ b/packages/kernel/README_zh.md
@@ -17,6 +17,8 @@
 
 ## 与其他包关系
 
+- 上游：`bff`、`runtime` 与 `infra/scripts`。
+- 下游：`meta_db`；kernel 不依赖任何 workspace package。
 - Migration lifecycle scripts 在 infra 中复用 kernel 的 migration compile 与 safety helper。
 - `bff` 只能作为 thin gateway 读取 kernel registry definition，不承载 metadata orchestration。
 - `query`、`permission`、`datasource`、`runtime`、`audit`、`bff` 不能成为 kernel 依赖。

--- a/packages/permission/CHANGELOG.md
+++ b/packages/permission/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- docs(readme): clarify permission upstream/downstream relationships and type-only query AST boundary.
 - fix(ci): build query before permission package-local tests on clean runners.
 - chore(boundaries): add final Nx layer tags and lock permission so it can depend on query only.
 - refactor(contracts): own org and data-scope DTO contracts directly.

--- a/packages/permission/CHANGELOG.zh-CN.md
+++ b/packages/permission/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- docs(readme): 明确 permission 上下游关系与仅 type-only 依赖 query AST/types 的边界。
 - fix(ci): 在 clean runner 的 permission package-local test 前先构建 query。
 - chore(boundaries): 新增最终 Nx layer tags，并将 permission 锁定为只能依赖 query。
 - refactor(contracts): 由 permission 直接拥有组织与数据域 DTO contract。

--- a/packages/permission/README.md
+++ b/packages/permission/README.md
@@ -15,11 +15,13 @@ English | [中文文档](./README_zh.md)
 
 ## Relationship With Other Packages
 
-- `bff` loads user/org/policy context and passes it into runtime execution.
+- Upstream: `runtime`.
+- Downstream: `query` types or AST structures when needed.
+- Runtime supplies user/org/policy context for permission transforms during execution.
 - `runtime` calls the permission transform before invoking the query compiler.
 - `query` compiles permission-transformed AST into SQL and params.
 - `permission` owns shared data-scope DTOs used at API boundaries.
-- `audit` can record allow/deny outcomes through BFF integration.
+- `audit` can record allow/deny outcomes when runtime emits observability events.
 
 ## Minimal Flow
 
@@ -42,5 +44,7 @@ pnpm --filter @zhongmiao/meta-lc-permission test
 ## Boundary Notes
 
 - Keep policy evaluation deterministic.
-- Do not fetch users, roles, or organization data directly from this package; BFF integration supplies context.
+- Do not fetch users, roles, or organization data directly from this package; runtime supplies context through execution dependencies.
 - Do not concatenate SQL clauses here; permissions must flow through AST predicates.
+- Must not compile SQL.
+- Must not execute datasource.

--- a/packages/permission/README_zh.md
+++ b/packages/permission/README_zh.md
@@ -15,11 +15,13 @@
 
 ## 与其他包关系
 
-- `bff` 加载 user/org/policy context 后传入 runtime execution。
+- 上游：`runtime`。
+- 下游：按需消费 `query` types 或 AST structures。
+- Runtime 在执行期为 permission transform 提供 user/org/policy context。
 - `runtime` 在调用 query compiler 前执行 permission transform。
 - `query` 将 permission-transformed AST 编译为 SQL 与 params。
 - `permission` 直接拥有 API 边界共享的数据域 DTO。
-- `audit` 可通过 BFF integration 记录 allow/deny 结果。
+- `audit` 可在 runtime 发出 observability event 时记录 allow/deny 结果。
 
 ## 最小闭环
 
@@ -42,5 +44,7 @@ pnpm --filter @zhongmiao/meta-lc-permission test
 ## 边界约束
 
 - 保持 policy evaluation 确定性。
-- 不在此包中直接读取 users、roles 或 organization data；上下文由 BFF integration 提供。
+- 不在此包中直接读取 users、roles 或 organization data；上下文由 runtime execution dependency 提供。
 - 不在此包拼接 SQL clause；权限必须通过 AST predicate 流转。
+- 不在此包编译 SQL。
+- 不在此包执行 datasource 请求。

--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- docs(readme): clarify query upstream/downstream relationships and AST-to-SQL compiler-only boundaries.
 - chore(boundaries): add final Nx layer tags and lock query as a dependency-free AST/SQL compiler package.
 - docs(boundary): document runtime-owned query node contracts after package topology convergence.
 - feat(query-ast): support permission predicate shapes such as `IN`, `IS NULL`, and boolean literals.

--- a/packages/query/CHANGELOG.zh-CN.md
+++ b/packages/query/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- docs(readme): 明确 query 上下游关系与只负责 AST-to-SQL 编译的边界。
 - chore(boundaries): 新增最终 Nx layer tags，并将 query 锁定为无 workspace 依赖的 AST/SQL compiler 包。
 - docs(boundary): 包拓扑收敛后，文档明确 query node contract 由 runtime 拥有。
 - feat(query-ast): 支持 `IN`、`IS NULL` 与 boolean literal 等权限 predicate 形状。

--- a/packages/query/README.md
+++ b/packages/query/README.md
@@ -15,6 +15,8 @@ English | [中文文档](./README_zh.md)
 
 ## Relationship With Other Packages
 
+- Upstream: `runtime` and `permission`.
+- Downstream: none as a package dependency; runtime hands compiled SQL or compiled query requests to `datasource` during execution.
 - `runtime` calls query compilation through its query compiler adapter before datasource execution.
 - `permission` transforms query AST before final SQL compilation.
 - `datasource` executes compiled SQL; `query` does not depend on `datasource`.
@@ -42,5 +44,7 @@ pnpm --filter @zhongmiao/meta-lc-query test
 ## Boundary Notes
 
 - Do not open DB connections here.
+- Must not execute SQL.
+- Must not depend on datasource.
 - Do not add runtime orchestration or BFF page request semantics here.
 - Keep permission policy resolution outside this package; consume permission-transformed AST predicates.

--- a/packages/query/README_zh.md
+++ b/packages/query/README_zh.md
@@ -15,6 +15,8 @@
 
 ## 与其他包关系
 
+- 上游：`runtime` 与 `permission`。
+- 下游：无 package dependency；runtime 在执行期把编译后的 SQL 或 compiled query request 交给 `datasource`。
 - `runtime` 通过 query compiler adapter 在 datasource 执行前调用 query compiler。
 - `permission` 在最终 SQL 编译前 transform query AST。
 - `datasource` 执行编译后的 SQL；`query` 不依赖 `datasource`。
@@ -42,5 +44,7 @@ pnpm --filter @zhongmiao/meta-lc-query test
 ## 边界约束
 
 - 不在这里打开数据库连接。
+- 不在这里执行 SQL。
+- 不依赖 `datasource`。
 - 不在这里新增 runtime orchestration 或 BFF 页面请求语义。
 - 权限策略解析留在包外；本包消费 permission-transformed AST predicates。

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- docs(readme): add runtime upstream/downstream notes for the final execution-engine topology.
 - fix(ci): build runtime workspace dependencies before package-local tests on clean runners.
 - chore(boundaries): add final Nx layer tags and keep runtime as the only package allowed to depend on kernel/query/permission/datasource/audit together.
 - chore(boundaries): rename runtime manager-event tests to interaction-event tests and document RuntimeExecutor as the only bottom execution entry with view/interaction facades above it.

--- a/packages/runtime/CHANGELOG.zh-CN.md
+++ b/packages/runtime/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- docs(readme): 补充最终执行引擎拓扑中的 runtime 上下游关系说明。
 - fix(ci): 在 clean runner 的 runtime package-local test 前先构建 workspace 依赖。
 - chore(boundaries): 新增最终 Nx layer tags，并保持 runtime 是唯一允许同时依赖 kernel/query/permission/datasource/audit 的执行包。
 - chore(boundaries): 将 runtime manager-event 测试命名改为 interaction-event，并明确 RuntimeExecutor 是唯一底层执行入口，view/interaction 位于 facade 层。

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -19,6 +19,8 @@ English | [中文文档](./README_zh.md)
 
 ## Relationship With Other Packages
 
+- Upstream: `bff`.
+- Downstream: `kernel`, `permission`, `query`, `datasource`, and `audit`.
 - Owns execution contracts such as `ExecutionPlan`, `ExecutionNode`, `Expression`, `RuntimeContext`, runtime event, and page topic contracts directly.
 - Consumes structure contracts such as `ViewDefinition` and node definitions from `kernel`.
 - BFF websocket code can publish runtime events compatible with these contracts.

--- a/packages/runtime/README_zh.md
+++ b/packages/runtime/README_zh.md
@@ -19,6 +19,8 @@
 
 ## 与其他包关系
 
+- 上游：`bff`。
+- 下游：`kernel`、`permission`、`query`、`datasource`、`audit`。
 - 直接拥有 `ExecutionPlan`、`ExecutionNode`、`Expression`、`RuntimeContext`、runtime event 与 page topic 等执行契约。
 - 从 `kernel` 消费 `ViewDefinition` 与 node definition 等结构契约。
 - BFF websocket code 可以发布与这些 contract 兼容的 runtime event。


### PR DESCRIPTION
## Summary
- Update root README architecture flow diagram with the final runtime/kernel/query/permission/datasource/audit handoff topology.
- Clarify that the Mermaid graph shows execution flow, not workspace import dependencies.
- Add package upstream/downstream notes across the seven package READMEs.
- Lock README wording for query, datasource, and permission responsibilities.

## Checks
- `git diff --check`
- `pnpm run lint:boundaries`
- `rg "must not depend on datasource|must not compile Query AST|must not execute datasource" README.md README_zh.md packages/*/README*.md`

## Risk / Rollback
- Documentation-only change.
- Rollback by reverting this commit if the wording needs another architecture pass.
