### PR TITLE
docs: regenerate package dependency topology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- docs(topology): regenerate package dependency topology from manifest and production source imports.
 - chore(examples): extract the orders demo metadata, SQL seed, and mutation adapter out of core packages into `examples/orders-demo`.
 - docs(readme): sync the final architecture flow, package relationship notes, and compiler/execution boundary wording.
 - fix(ci): build workspace dependencies before package-local tests so clean CI runners can resolve package entrypoints.

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- docs(topology): 基于 manifest 与生产源码 import 重新生成 package dependency topology。
 - chore(examples): 将 orders demo metadata、SQL seed 与 mutation adapter 从核心包抽离到 `examples/orders-demo`。
 - docs(readme): 同步最终架构协作流、子包上下游关系与编译/执行边界口径。
 - fix(ci): 在 package-local test 前先构建 workspace 依赖，确保 clean CI runner 能解析各包入口。

--- a/docs/package-dependency-topology.md
+++ b/docs/package-dependency-topology.md
@@ -2,39 +2,114 @@
 
 生成口径：
 
+- 生成脚本：`pnpm docs:topology` / `node scripts/generate-package-dependency-topology.mjs`。
 - 范围：`pnpm-workspace.yaml` 中的 `packages/*` 与 `apps/*`。
-- 主图：只统计生产代码 `src/**/*.ts`。
-- 边方向：`A --> B` 表示 **A 的源码 import/export/require 了 B**。
+- `examples/*`、`infra/*`、`scripts/*` 不参与生产 package 拓扑。
+- Manifest 图：统计 `package.json` 中的 workspace `dependencies` / `peerDependencies`。
+- Source 图：只统计生产代码 `src/**/*.ts` 的 workspace `import` / `export from` / `require` / dynamic `import()`。
+- 边方向：`A --> B` 表示 **A 依赖 B**。
+- `type-only` 表示当前源码边只来自 `import type` / `export type from`。
 - `packages/migration` 已删除；migration lifecycle 下沉到 `infra/` scripts，并复用 `kernel` 内部能力。
 - `packages/contracts`、`packages/shared`、`packages/platform` 已删除；contract 归属具体架构层包。
 
-## 拓扑图
+## Manifest 依赖拓扑
+
+这张图表示 package manifest 声明的 workspace 依赖，也是边界规则允许的包级依赖形态。
 
 ```mermaid
 flowchart TD
   bff_server["@zhongmiao/meta-lc-bff-server<br/>apps/bff-server"]
+  audit["@zhongmiao/meta-lc-audit<br/>packages/audit"]
   bff["@zhongmiao/meta-lc-bff<br/>packages/bff"]
-  runtime["@zhongmiao/meta-lc-runtime<br/>packages/runtime"]
+  datasource["@zhongmiao/meta-lc-datasource<br/>packages/datasource"]
   kernel["@zhongmiao/meta-lc-kernel<br/>packages/kernel"]
   permission["@zhongmiao/meta-lc-permission<br/>packages/permission"]
   query["@zhongmiao/meta-lc-query<br/>packages/query"]
-  datasource["@zhongmiao/meta-lc-datasource<br/>packages/datasource"]
-  audit["@zhongmiao/meta-lc-audit<br/>packages/audit"]
+  runtime["@zhongmiao/meta-lc-runtime<br/>packages/runtime"]
 
-  bff_server --> bff
   bff --> kernel
   bff --> runtime
+  bff_server --> bff
+  permission --> query
   runtime --> audit
   runtime --> datasource
   runtime --> kernel
   runtime --> permission
   runtime --> query
-  permission --> query
 ```
+
+## Source Import 拓扑
+
+这张图表示当前生产源码真实 import 关系。它可能比 manifest 图更窄，例如 `bff` manifest 允许依赖 `kernel`，但当前 `packages/bff/src/**/*.ts` 没有直接 import `kernel`。
+
+```mermaid
+flowchart TD
+  bff_server["@zhongmiao/meta-lc-bff-server<br/>apps/bff-server"]
+  audit["@zhongmiao/meta-lc-audit<br/>packages/audit"]
+  bff["@zhongmiao/meta-lc-bff<br/>packages/bff"]
+  datasource["@zhongmiao/meta-lc-datasource<br/>packages/datasource"]
+  kernel["@zhongmiao/meta-lc-kernel<br/>packages/kernel"]
+  permission["@zhongmiao/meta-lc-permission<br/>packages/permission"]
+  query["@zhongmiao/meta-lc-query<br/>packages/query"]
+  runtime["@zhongmiao/meta-lc-runtime<br/>packages/runtime"]
+
+  bff --> runtime
+  bff_server --> bff
+  permission -->|"type-only"| query
+  runtime -->|"type-only"| audit
+  runtime --> datasource
+  runtime --> kernel
+  runtime --> permission
+  runtime --> query
+```
+
+## Source Import 明细
+
+- `@zhongmiao/meta-lc-bff` -> `@zhongmiao/meta-lc-runtime`
+  - value: `packages/bff/src/bootstrap/app.module.ts`
+  - value: `packages/bff/src/controller/http/view.controller.ts`
+  - type-only: `packages/bff/src/controller/ws/runtime/broadcast.bus.ts`
+  - type-only: `packages/bff/src/controller/ws/runtime/replay.store.ts`
+  - type-only: `packages/bff/src/controller/ws/runtime/runtime-ws.interface.ts`
+  - type-only: `packages/bff/src/controller/ws/runtime/runtime-ws.type.ts`
+  - value: `packages/bff/src/controller/ws/runtime/ws.gateway.ts`
+- `@zhongmiao/meta-lc-bff-server` -> `@zhongmiao/meta-lc-bff`
+  - value: `apps/bff-server/src/main.ts`
+- `@zhongmiao/meta-lc-permission` -> `@zhongmiao/meta-lc-query` (type-only)
+  - type-only: `packages/permission/src/domain/permission-ast-transform.ts`
+- `@zhongmiao/meta-lc-runtime` -> `@zhongmiao/meta-lc-audit` (type-only)
+  - type-only: `packages/runtime/src/application/executor/query-executor.ts`
+  - type-only: `packages/runtime/src/application/executor/runtime-audit.ts`
+  - type-only: `packages/runtime/src/application/executor/runtime-executor.ts`
+  - type-only: `packages/runtime/src/application/executor/runtime-view-executor.ts`
+  - type-only: `packages/runtime/src/types/shared.types.ts`
+- `@zhongmiao/meta-lc-runtime` -> `@zhongmiao/meta-lc-datasource`
+  - type-only: `packages/runtime/src/application/executor/query-executor.ts`
+  - type-only: `packages/runtime/src/application/executor/runtime-executor.ts`
+  - value: `packages/runtime/src/application/executor/runtime-view-executor.ts`
+  - type-only: `packages/runtime/src/infra/adapter/query.adapter.ts`
+  - type-only: `packages/runtime/src/types/shared.types.ts`
+- `@zhongmiao/meta-lc-runtime` -> `@zhongmiao/meta-lc-kernel`
+  - type-only: `packages/runtime/src/application/compiler/plan-builder.ts`
+  - type-only: `packages/runtime/src/application/compiler/view-compiler.ts`
+  - type-only: `packages/runtime/src/application/executor/merge-executor.ts`
+  - type-only: `packages/runtime/src/application/executor/mutation-executor.ts`
+  - type-only: `packages/runtime/src/application/executor/node-executor.ts`
+  - type-only: `packages/runtime/src/application/executor/query-executor.ts`
+  - value: `packages/runtime/src/application/executor/runtime-view-executor.ts`
+  - type-only: `packages/runtime/src/application/executor/runtime-view-executor.ts`
+  - type-only: `packages/runtime/src/types/shared.types.ts`
+- `@zhongmiao/meta-lc-runtime` -> `@zhongmiao/meta-lc-permission`
+  - type-only: `packages/runtime/src/application/executor/query-executor.ts`
+  - type-only: `packages/runtime/src/application/executor/runtime-view-executor.ts`
+  - value: `packages/runtime/src/infra/adapter/query.adapter.ts`
+- `@zhongmiao/meta-lc-runtime` -> `@zhongmiao/meta-lc-query`
+  - type-only: `packages/runtime/src/application/executor/query-executor.ts`
+  - value: `packages/runtime/src/infra/adapter/query.adapter.ts`
 
 ## 分层视图
 
-按 import 方向从入口到基础包看：
+按 package manifest 依赖方向从入口到基础包看：
 
 1. `@zhongmiao/meta-lc-bff-server`
 2. `@zhongmiao/meta-lc-bff`
@@ -42,7 +117,7 @@ flowchart TD
 4. `@zhongmiao/meta-lc-permission`, `@zhongmiao/meta-lc-datasource`, `@zhongmiao/meta-lc-audit`
 5. `@zhongmiao/meta-lc-query`
 
-当前生产代码包依赖图没有发现环。
+当前生产源码包 import 图没有发现环。
 
 ## 架构结论
 
@@ -52,6 +127,7 @@ flowchart TD
 - `bff` 只能依赖 `runtime` 与 `kernel`；不得直接依赖 `query`、`permission`、`datasource` 或 `pg`。
 - `datasource` 与 `audit` 不得反向依赖 `runtime`；`query` 不得依赖 `datasource`。
 - `kernel`、`query`、`datasource`、`audit` 禁止依赖任何 workspace package；`kernel` 可持有 meta DB persistence，但不得依赖 `runtime`、`query`、`permission`、`datasource`、`audit` 或 `bff`。
-- `permission` 只能依赖 `query`；kernel 的 `PermissionPolicy.scope` 与 permission runtime data-scope 类型只共享字符串语义，不共享包依赖。
+- `permission` 只能 type-only 依赖 `query` 的 AST/types；禁止 value import query compiler，禁止编译 SQL 或执行 datasource。
+- `Query --> Datasource` 只允许表示 runtime 执行链路中的 compiled SQL/request handoff，不表示 `packages/query` import `packages/datasource`。
 - `infra/` 承载 bootstrap SQL、docker、query-gate 等运维脚本，不作为 workspace package。
 - `examples/` 承载业务 demo，不参与生产 package import 拓扑。`examples/orders-demo` 可以依赖核心 packages；核心 packages 与 apps 不得依赖 `examples/*`，删除 `examples/` 后 `packages/*` 仍必须能 build/test。

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "infra:migrate": "node --experimental-strip-types infra/scripts/migrate.ts",
     "infra:seed": "node --experimental-strip-types infra/scripts/seed.ts",
     "test:examples:orders-demo": "pnpm --filter @zhongmiao/meta-lc-datasource build && node --experimental-strip-types --test \"examples/orders-demo/tests/*.test.ts\"",
+    "docs:topology": "node scripts/generate-package-dependency-topology.mjs",
     "test:boundaries": "node --test scripts/check-boundaries.test.mjs",
     "lint:boundaries": "node scripts/check-boundaries.mjs",
     "changeset": "changeset",

--- a/scripts/generate-package-dependency-topology.mjs
+++ b/scripts/generate-package-dependency-topology.mjs
@@ -1,0 +1,225 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const outputPath = path.join(root, "docs", "package-dependency-topology.md");
+const projectRoots = ["apps", "packages"];
+
+const projects = readProjects();
+const projectsByPackageName = new Map(projects.map((project) => [project.packageName, project]));
+const manifestEdges = collectManifestEdges();
+const sourceEdges = collectSourceEdges();
+
+fs.writeFileSync(outputPath, renderDocument(), "utf8");
+console.log(`Updated ${path.relative(root, outputPath)}`);
+
+function readProjects() {
+  const result = [];
+  for (const rootName of projectRoots) {
+    const rootDir = path.join(root, rootName);
+    if (!fs.existsSync(rootDir)) continue;
+
+    for (const entry of sortedDirents(rootDir)) {
+      if (!entry.isDirectory()) continue;
+      const packageJsonPath = path.join(rootDir, entry.name, "package.json");
+      if (!fs.existsSync(packageJsonPath)) continue;
+
+      const manifest = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+      result.push({
+        id: toMermaidId(entry.name),
+        directory: `${rootName}/${entry.name}`,
+        packageName: manifest.name,
+        manifest,
+        srcDir: path.join(rootDir, entry.name, "src")
+      });
+    }
+  }
+
+  return result.sort((left, right) => left.directory.localeCompare(right.directory));
+}
+
+function collectManifestEdges() {
+  const edges = [];
+  for (const project of projects) {
+    const deps = {
+      ...(project.manifest.dependencies ?? {}),
+      ...(project.manifest.peerDependencies ?? {})
+    };
+    for (const dependencyName of Object.keys(deps).sort()) {
+      const target = projectsByPackageName.get(dependencyName);
+      if (!target) continue;
+      edges.push({ from: project, to: target, typeOnly: false });
+    }
+  }
+  return sortEdges(edges);
+}
+
+function collectSourceEdges() {
+  const edges = new Map();
+  for (const project of projects) {
+    for (const file of walkSourceFiles(project.srcDir)) {
+      const content = fs.readFileSync(file, "utf8");
+      for (const item of findImports(content)) {
+        const target = projectsByPackageName.get(item.specifier);
+        if (!target || target.packageName === project.packageName) continue;
+
+        const key = `${project.packageName}->${target.packageName}`;
+        const existing = edges.get(key) ?? {
+          from: project,
+          to: target,
+          typeOnly: true,
+          files: []
+        };
+        existing.typeOnly = existing.typeOnly && item.typeOnly;
+        addSourceFile(existing, file, item.typeOnly);
+        edges.set(key, existing);
+      }
+    }
+  }
+  return sortEdges([...edges.values()]);
+}
+
+function addSourceFile(edge, file, typeOnly) {
+  const sourceFile = {
+    file: normalizePath(path.relative(root, file)),
+    typeOnly
+  };
+  if (edge.files.some((item) => item.file === sourceFile.file && item.typeOnly === sourceFile.typeOnly)) {
+    return;
+  }
+  edge.files.push(sourceFile);
+}
+
+function findImports(content) {
+  const imports = [];
+  const importPattern =
+    /import\s+(type\s+)?(?:[^'";]*?\s+from\s+)?["']([^"']+)["']|export\s+(type\s+)?[^'";]*?\s+from\s+["']([^"']+)["']|require\(\s*["']([^"']+)["']\s*\)|import\(\s*["']([^"']+)["']\s*\)/g;
+  let match;
+  while ((match = importPattern.exec(content)) !== null) {
+    imports.push({
+      typeOnly: Boolean(match[1] || match[3]),
+      specifier: match[2] || match[4] || match[5] || match[6]
+    });
+  }
+  return imports;
+}
+
+function walkSourceFiles(dir, files = []) {
+  if (!fs.existsSync(dir)) return files;
+  for (const entry of sortedDirents(dir)) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (["dist", "node_modules"].includes(entry.name)) continue;
+      walkSourceFiles(full, files);
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".ts")) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function renderDocument() {
+  return `# meta-lc-platform 包依赖拓扑图
+
+生成口径：
+
+- 生成脚本：\`pnpm docs:topology\` / \`node scripts/generate-package-dependency-topology.mjs\`。
+- 范围：\`pnpm-workspace.yaml\` 中的 \`packages/*\` 与 \`apps/*\`。
+- \`examples/*\`、\`infra/*\`、\`scripts/*\` 不参与生产 package 拓扑。
+- Manifest 图：统计 \`package.json\` 中的 workspace \`dependencies\` / \`peerDependencies\`。
+- Source 图：只统计生产代码 \`src/**/*.ts\` 的 workspace \`import\` / \`export from\` / \`require\` / dynamic \`import()\`。
+- 边方向：\`A --> B\` 表示 **A 依赖 B**。
+- \`type-only\` 表示当前源码边只来自 \`import type\` / \`export type from\`。
+- \`packages/migration\` 已删除；migration lifecycle 下沉到 \`infra/\` scripts，并复用 \`kernel\` 内部能力。
+- \`packages/contracts\`、\`packages/shared\`、\`packages/platform\` 已删除；contract 归属具体架构层包。
+
+## Manifest 依赖拓扑
+
+这张图表示 package manifest 声明的 workspace 依赖，也是边界规则允许的包级依赖形态。
+
+${renderMermaid(manifestEdges)}
+
+## Source Import 拓扑
+
+这张图表示当前生产源码真实 import 关系。它可能比 manifest 图更窄，例如 \`bff\` manifest 允许依赖 \`kernel\`，但当前 \`packages/bff/src/**/*.ts\` 没有直接 import \`kernel\`。
+
+${renderMermaid(sourceEdges)}
+
+## Source Import 明细
+
+${renderSourceDetails()}
+
+## 分层视图
+
+按 package manifest 依赖方向从入口到基础包看：
+
+1. \`@zhongmiao/meta-lc-bff-server\`
+2. \`@zhongmiao/meta-lc-bff\`
+3. \`@zhongmiao/meta-lc-runtime\`, \`@zhongmiao/meta-lc-kernel\`
+4. \`@zhongmiao/meta-lc-permission\`, \`@zhongmiao/meta-lc-datasource\`, \`@zhongmiao/meta-lc-audit\`
+5. \`@zhongmiao/meta-lc-query\`
+
+当前生产源码包 import 图没有发现环。
+
+## 架构结论
+
+- \`runtime\` 是唯一执行核心，持有 \`ExecutionPlan\`、\`ExecutionNode\`、\`Expression\`、\`RuntimeContext\` 等执行契约。
+- \`kernel\` 是结构真源，持有 \`MetaSchema\`、\`ViewDefinition\`、\`NodeDefinition\`、\`DatasourceDefinition\`、\`PermissionPolicy\`。
+- \`bff\` 是 IO Gateway，只持有 HTTP/WS DTO、controller、bootstrap wiring、gateway config、gateway cache 与 thin Kernel integration。
+- \`bff\` 只能依赖 \`runtime\` 与 \`kernel\`；不得直接依赖 \`query\`、\`permission\`、\`datasource\` 或 \`pg\`。
+- \`datasource\` 与 \`audit\` 不得反向依赖 \`runtime\`；\`query\` 不得依赖 \`datasource\`。
+- \`kernel\`、\`query\`、\`datasource\`、\`audit\` 禁止依赖任何 workspace package；\`kernel\` 可持有 meta DB persistence，但不得依赖 \`runtime\`、\`query\`、\`permission\`、\`datasource\`、\`audit\` 或 \`bff\`。
+- \`permission\` 只能 type-only 依赖 \`query\` 的 AST/types；禁止 value import query compiler，禁止编译 SQL 或执行 datasource。
+- \`Query --> Datasource\` 只允许表示 runtime 执行链路中的 compiled SQL/request handoff，不表示 \`packages/query\` import \`packages/datasource\`。
+- \`infra/\` 承载 bootstrap SQL、docker、query-gate 等运维脚本，不作为 workspace package。
+- \`examples/\` 承载业务 demo，不参与生产 package import 拓扑。\`examples/orders-demo\` 可以依赖核心 packages；核心 packages 与 apps 不得依赖 \`examples/*\`，删除 \`examples/\` 后 \`packages/*\` 仍必须能 build/test。
+`;
+}
+
+function renderMermaid(edges) {
+  const nodeLines = projects.map(
+    (project) => `  ${project.id}["${project.packageName}<br/>${project.directory}"]`
+  );
+  const edgeLines = edges.map((edge) => {
+    const label = edge.typeOnly ? ' -->|"type-only"| ' : " --> ";
+    return `  ${edge.from.id}${label}${edge.to.id}`;
+  });
+  return ["```mermaid", "flowchart TD", ...nodeLines, "", ...edgeLines, "```"].join("\n");
+}
+
+function renderSourceDetails() {
+  if (sourceEdges.length === 0) return "- 当前生产源码没有 workspace import。";
+
+  return sourceEdges
+    .map((edge) => {
+      const edgeLabel = `- \`${edge.from.packageName}\` -> \`${edge.to.packageName}\`${edge.typeOnly ? " (type-only)" : ""}`;
+      const files = edge.files
+        .map((item) => `  - ${item.typeOnly ? "type-only" : "value"}: \`${item.file}\``)
+        .join("\n");
+      return `${edgeLabel}\n${files}`;
+    })
+    .join("\n");
+}
+
+function sortEdges(edges) {
+  return edges.sort((left, right) =>
+    `${left.from.packageName}->${left.to.packageName}`.localeCompare(
+      `${right.from.packageName}->${right.to.packageName}`
+    )
+  );
+}
+
+function sortedDirents(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function toMermaidId(value) {
+  return value.replace(/[^a-zA-Z0-9_]/g, "_");
+}
+
+function normalizePath(value) {
+  return value.split(path.sep).join("/");
+}


### PR DESCRIPTION
## Summary

- Add `pnpm docs:topology` to regenerate package dependency topology from workspace manifests and production source imports.
- Regenerate `docs/package-dependency-topology.md` with separate manifest dependency and source import graphs.
- Clarify type-only edges and the distinction between package imports and runtime execution handoff.

## Checks

- `pnpm docs:topology`
- `pnpm run lint:boundaries`
- `pnpm run test:boundaries`
- `pnpm lint` (passes with existing warnings only)
- `git diff --check`
- `pnpm run changelog:gate -- origin/main HEAD`

## Risk / Rollback

- Documentation/script-only change. Runtime/package behavior is unchanged.
- Rollback by reverting this PR if the generated topology format is not desired.
