### PR TITLE
fix(boundaries): remove BFF kernel dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- fix(boundaries): remove the stale BFF kernel package dependency and document provider-only meta registry access.
 - docs(topology): regenerate package dependency topology from manifest and production source imports.
 - chore(examples): extract the orders demo metadata, SQL seed, and mutation adapter out of core packages into `examples/orders-demo`.
 - docs(readme): sync the final architecture flow, package relationship notes, and compiler/execution boundary wording.

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- fix(boundaries): 移除 BFF 残留 kernel package 依赖，并明确 meta registry 只能通过 provider 注入访问。
 - docs(topology): 基于 manifest 与生产源码 import 重新生成 package dependency topology。
 - chore(examples): 将 orders demo metadata、SQL seed 与 mutation adapter 从核心包抽离到 `examples/orders-demo`。
 - docs(readme): 同步最终架构协作流、子包上下游关系与编译/执行边界口径。

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ flowchart LR
   Client --> BFFServer
   BFFServer --> BFF
   BFF --> Runtime
-  BFF --> Kernel
   Runtime --> Kernel
   Runtime --> Permission
   Runtime --> Query
@@ -56,18 +55,19 @@ flowchart LR
 | `packages/permission` | RBAC and organization data-scope decisions. | [English](./packages/permission/README.md) \| [中文文档](./packages/permission/README_zh.md) |
 | `packages/datasource` | Postgres datasource configuration and execution adapter. | [English](./packages/datasource/README.md) \| [中文文档](./packages/datasource/README_zh.md) |
 | `packages/audit` | Audit contracts and optional non-blocking runtime observability sinks. | [English](./packages/audit/README.md) \| [中文文档](./packages/audit/README_zh.md) |
-| `packages/bff` | NestJS IO Gateway for HTTP/WS DTOs and thin runtime/kernel controller entrypoints. | [English](./packages/bff/README.md) \| [中文文档](./packages/bff/README_zh.md) |
+| `packages/bff` | NestJS IO Gateway for HTTP/WS DTOs, runtime controller entrypoints, request-id, and error mapping. | [English](./packages/bff/README.md) \| [中文文档](./packages/bff/README_zh.md) |
 
 ## Dependency Direction
 
 - `runtime`, `kernel`, `query`, `permission`, `datasource`, `bff`, and `audit` are the seven final architecture packages.
 - Migration lifecycle scripts live under `infra/`; `packages/migration` is intentionally removed.
 - Contracts live in the owning package; `contracts`, `shared`, `platform`, and `migration` packages are intentionally removed.
-- Final workspace dependencies are locked as: app -> bff; bff -> runtime/kernel; runtime -> kernel/query/permission/datasource/audit; permission -> query.
+- Final workspace dependencies are locked as: app -> bff; bff -> runtime; runtime -> kernel/query/permission/datasource/audit; permission -> query.
 - `kernel`, `query`, `datasource`, and `audit` must not depend on any workspace package.
 - `runtime -> kernel` is allowed so runtime can read structure definitions; `kernel -> runtime` and `kernel -> permission` are forbidden.
 - `query` compiles AST to SQL and must not depend on `datasource`, `runtime`, or `permission`.
 - `bff` remains a gateway and must not own runtime orchestration, datasource wiring, permission decisions, audit wiring, or DB access.
+- `bff` must not depend on `kernel`; `/meta/*` may use an injected meta registry provider, and any kernel-backed provider must be composed outside the BFF package.
 - Deep cross-package imports are forbidden; import through package entrypoints.
 
 ### Compiler / Execution Boundaries

--- a/README_zh.md
+++ b/README_zh.md
@@ -30,7 +30,6 @@ flowchart LR
   Client --> BFFServer
   BFFServer --> BFF
   BFF --> Runtime
-  BFF --> Kernel
   Runtime --> Kernel
   Runtime --> Permission
   Runtime --> Query
@@ -56,18 +55,19 @@ flowchart LR
 | `packages/permission` | RBAC 与组织数据域决策。 | [English](./packages/permission/README.md) \| [中文文档](./packages/permission/README_zh.md) |
 | `packages/datasource` | Postgres datasource 配置与执行 adapter。 | [English](./packages/datasource/README.md) \| [中文文档](./packages/datasource/README_zh.md) |
 | `packages/audit` | 审计契约与可选、非阻塞 runtime observability sink。 | [English](./packages/audit/README.md) \| [中文文档](./packages/audit/README_zh.md) |
-| `packages/bff` | NestJS IO Gateway，持有 HTTP/WS DTO 与 thin runtime/kernel controller 入口。 | [English](./packages/bff/README.md) \| [中文文档](./packages/bff/README_zh.md) |
+| `packages/bff` | NestJS IO Gateway，持有 HTTP/WS DTO、runtime controller 入口、request-id 与错误映射。 | [English](./packages/bff/README.md) \| [中文文档](./packages/bff/README_zh.md) |
 
 ## 依赖方向
 
 - `runtime`、`kernel`、`query`、`permission`、`datasource`、`bff`、`audit` 是最终 7 个架构层包。
 - migration lifecycle scripts 下沉到 `infra/`；`packages/migration` 已被删除。
 - contract 由所属包拥有；`contracts`、`shared`、`platform`、`migration` 包已被删除。
-- 最终 workspace 依赖锁定为：app -> bff；bff -> runtime/kernel；runtime -> kernel/query/permission/datasource/audit；permission -> query。
+- 最终 workspace 依赖锁定为：app -> bff；bff -> runtime；runtime -> kernel/query/permission/datasource/audit；permission -> query。
 - `kernel`、`query`、`datasource`、`audit` 禁止依赖任何 workspace package。
 - 允许 `runtime -> kernel` 读取结构定义；禁止 `kernel -> runtime` 与 `kernel -> permission`。
 - `query` 只负责 AST 到 SQL 编译，禁止依赖 `datasource`、`runtime` 或 `permission`。
 - `bff` 只作为 gateway，不拥有 runtime orchestration、datasource wiring、permission decision、audit wiring 或 DB access。
+- `bff` 禁止依赖 `kernel`；`/meta/*` 可以使用注入的 meta registry provider，任何 kernel-backed provider 都必须在 BFF package 外部装配。
 - 禁止 deep import，跨包引用必须通过 package entrypoint。
 
 ### 编译 / 执行边界

--- a/docs/package-dependency-topology.md
+++ b/docs/package-dependency-topology.md
@@ -27,7 +27,6 @@ flowchart TD
   query["@zhongmiao/meta-lc-query<br/>packages/query"]
   runtime["@zhongmiao/meta-lc-runtime<br/>packages/runtime"]
 
-  bff --> kernel
   bff --> runtime
   bff_server --> bff
   permission --> query
@@ -40,7 +39,7 @@ flowchart TD
 
 ## Source Import 拓扑
 
-这张图表示当前生产源码真实 import 关系。它可能比 manifest 图更窄，例如 `bff` manifest 允许依赖 `kernel`，但当前 `packages/bff/src/**/*.ts` 没有直接 import `kernel`。
+这张图表示当前生产源码真实 import 关系。封板口径要求 `bff` 不直接 import `kernel`；`/meta/*` 如需 kernel-backed 数据，必须通过 BFF 包外注入的 meta registry provider 装配。
 
 ```mermaid
 flowchart TD
@@ -113,8 +112,8 @@ flowchart TD
 
 1. `@zhongmiao/meta-lc-bff-server`
 2. `@zhongmiao/meta-lc-bff`
-3. `@zhongmiao/meta-lc-runtime`, `@zhongmiao/meta-lc-kernel`
-4. `@zhongmiao/meta-lc-permission`, `@zhongmiao/meta-lc-datasource`, `@zhongmiao/meta-lc-audit`
+3. `@zhongmiao/meta-lc-runtime`
+4. `@zhongmiao/meta-lc-kernel`, `@zhongmiao/meta-lc-permission`, `@zhongmiao/meta-lc-datasource`, `@zhongmiao/meta-lc-audit`
 5. `@zhongmiao/meta-lc-query`
 
 当前生产源码包 import 图没有发现环。
@@ -123,8 +122,9 @@ flowchart TD
 
 - `runtime` 是唯一执行核心，持有 `ExecutionPlan`、`ExecutionNode`、`Expression`、`RuntimeContext` 等执行契约。
 - `kernel` 是结构真源，持有 `MetaSchema`、`ViewDefinition`、`NodeDefinition`、`DatasourceDefinition`、`PermissionPolicy`。
-- `bff` 是 IO Gateway，只持有 HTTP/WS DTO、controller、bootstrap wiring、gateway config、gateway cache 与 thin Kernel integration。
-- `bff` 只能依赖 `runtime` 与 `kernel`；不得直接依赖 `query`、`permission`、`datasource` 或 `pg`。
+- `bff` 是 IO Gateway，只持有 HTTP/WS DTO、controller、bootstrap wiring、gateway config、gateway cache 与 provider-backed meta registry integration。
+- `bff` 只能依赖 `runtime`；不得直接依赖 `kernel`、`query`、`permission`、`datasource`、`audit` 或 `pg`。
+- `/meta/*` 保留只读 HTTP envelope，但必须通过注入的 meta registry provider 读取数据；kernel-backed provider 只能在 BFF package 外部装配。
 - `datasource` 与 `audit` 不得反向依赖 `runtime`；`query` 不得依赖 `datasource`。
 - `kernel`、`query`、`datasource`、`audit` 禁止依赖任何 workspace package；`kernel` 可持有 meta DB persistence，但不得依赖 `runtime`、`query`、`permission`、`datasource`、`audit` 或 `bff`。
 - `permission` 只能 type-only 依赖 `query` 的 AST/types；禁止 value import query compiler，禁止编译 SQL 或执行 datasource。

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -42,7 +42,7 @@ export default [
             },
             {
               sourceTag: "layer:bff",
-              onlyDependOnLibsWithTags: ["layer:runtime", "layer:kernel"]
+              onlyDependOnLibsWithTags: ["layer:runtime"]
             },
             {
               sourceTag: "layer:runtime",
@@ -96,7 +96,7 @@ export default [
                 "@types/pg"
               ],
               message:
-                "BFF is gateway-only. It must only call runtime/kernel and must not import query, permission, datasource, audit, or pg."
+                "BFF is gateway-only. It must only call runtime and must not import kernel, query, permission, datasource, audit, or pg."
             }
           ]
         }

--- a/packages/bff/CHANGELOG.md
+++ b/packages/bff/CHANGELOG.md
@@ -2,13 +2,14 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- fix(boundaries): remove the stale kernel dependency from BFF and make meta registry reads provider-only.
 - refactor(gateway): allow injecting runtime runners and meta registry providers so orders demo wiring lives outside the core BFF package.
 - docs(readme): document BFF upstream/downstream relationships in the final gateway-only topology.
 - fix(ci): build BFF workspace dependencies before package-local tests on clean runners.
-- chore(boundaries): add final Nx layer tags and lock BFF dependency gates to runtime/kernel only.
+- chore(boundaries): add final Nx layer tags and lock BFF dependency gates to runtime only.
 - chore(boundaries): seal the gateway-only layout by removing mapper/repository/interface remnants, adding gateway-only config, and tightening dependency guards.
 - refactor(boundaries): remove BFF contracts and data execution dependencies so view controllers only call the runtime gateway facade.
-- refactor(gateway): remove the BFF application layer so controllers act as thin runtime/kernel gateways with infra wiring only.
+- refactor(gateway): remove the BFF application layer so controllers act as thin runtime gateways with provider wiring only.
 - refactor(contracts): consume runtime, kernel, and permission-owned contracts instead of a transitional contracts package.
 - feat(observability): persist runtime audit events through a BFF infra observer without blocking view execution.
 - refactor(meta): read view, datasource, and permission definitions through an injectable Kernel-backed registry provider.

--- a/packages/bff/CHANGELOG.zh-CN.md
+++ b/packages/bff/CHANGELOG.zh-CN.md
@@ -2,13 +2,14 @@
 
 ## [Unreleased]
 
+- fix(boundaries): 移除 BFF 残留 kernel 依赖，并将 meta registry 读取收紧为 provider-only。
 - refactor(gateway): 支持注入 runtime runner 与 meta registry provider，让 orders demo wiring 留在核心 BFF 包之外。
 - docs(readme): 在最终 gateway-only 拓扑中补充 BFF 上下游关系说明。
 - fix(ci): 在 clean runner 的 BFF package-local test 前先构建 workspace 依赖。
-- chore(boundaries): 新增最终 Nx layer tags，并将 BFF 依赖守护锁定为只能依赖 runtime/kernel。
+- chore(boundaries): 新增最终 Nx layer tags，并将 BFF 依赖守护锁定为只能依赖 runtime。
 - chore(boundaries): 删除 mapper/repository/interface 残留，新增 gateway-only config，并收紧依赖守护，封板 BFF gateway-only 目录。
 - refactor(boundaries): 删除 BFF contracts 与数据执行依赖，让 view controller 只调用 runtime gateway facade。
-- refactor(gateway): 删除 BFF application 层，让 controller 只作为 thin runtime/kernel gateway，并仅保留 infra wiring。
+- refactor(gateway): 删除 BFF application 层，让 controller 只作为 thin runtime gateway，并仅保留 provider wiring。
 - refactor(contracts): BFF 改为消费 runtime、kernel、permission 所属 contract，不再依赖过渡 contracts 包。
 - feat(observability): 通过 BFF infra observer 持久化 runtime audit event，且不阻塞 view execution。
 - refactor(meta): 通过可注入的 Kernel-backed registry provider 读取 view、datasource 与 permission definition。

--- a/packages/bff/README.md
+++ b/packages/bff/README.md
@@ -8,7 +8,7 @@ English | [中文文档](./README_zh.md)
 
 BFF invokes the Runtime gateway facade for page execution. Runtime performs view lookup, execution context construction, datasource wiring, permission context resolution, audit observation, and `RuntimeExecutor` execution.
 
-`/meta/*` remains a thin read-only Kernel gateway. It returns HTTP envelopes only and does not publish metadata, execute registry migrations, or participate in page execution.
+`/meta/*` remains a read-only HTTP envelope backed by an injected meta registry provider. BFF must not import `kernel`; any kernel-backed provider must be composed outside the BFF package.
 
 The Nest module can accept injected runtime runners and meta registry providers for examples, but the default core BFF module stays demo-free.
 
@@ -40,7 +40,7 @@ bff/src/
 - `controller/http/**` is the HTTP API entry layer.
 - `controller/ws/**` is the WebSocket entry layer. Runtime WebSocket files must stay under `controller/ws/runtime/**`.
 - `infra/cache/**` owns gateway cache only.
-- `infra/integration/**` owns thin Kernel metadata registry integration only.
+- `infra/integration/**` owns provider-backed metadata registry integration only.
 - `config/**` owns gateway protocol configuration only: HTTP/CORS/request-id/timeout, WebSocket path/replay, gateway cache, provider token, and log-level knobs.
 - `common/constants/**` owns package-level constants and provider tokens.
 - `common/**` owns small framework-level helpers and exception utilities only.
@@ -58,11 +58,12 @@ bff/src/
 ## Dependency Direction
 
 - Upstream: `apps/bff-server` and client protocol entrypoints.
-- Downstream: `runtime` for page execution and `kernel` for thin metadata reads.
+- Downstream package dependency: `runtime` only.
+- Meta reads: `/meta/*` uses an injected meta registry provider; kernel-backed providers are composed outside this package.
 
 ```text
 controller/http -> runtime facade
-controller/http -> kernel registry
+controller/http -> injected meta registry provider
 controller/ws -> runtime WS contracts
 ```
 
@@ -74,7 +75,7 @@ controller/ws -> runtime WS contracts
 flowchart LR
   Http["HTTP / WS / CLI request"] --> Entry["controller/*"]
   Entry --> Runtime["Runtime gateway facade"]
-  Entry --> Kernel["Thin Kernel meta gateway"]
+  Entry --> MetaProvider["Injected meta registry provider"]
   Entry --> Response["HTTP response / WS event"]
 ```
 
@@ -95,4 +96,4 @@ pnpm --filter @zhongmiao/meta-lc-bff start
 - Runtime datasource, permission, audit, and org-scope wiring must stay inside runtime or the owning packages.
 - Demo runtime runners and metadata providers belong in `examples/*`, not in BFF source.
 - Do not restore legacy `/query` or `/mutation` endpoints; page data requests must use `POST /view/:name`.
-- Do not add `application/**`, `contracts/**`, `domain/**`, `mapper/**`, `infra/repository/**`, or `infra/interfaces/**`; BFF is only a Gateway invoking Runtime and exposing thin Kernel metadata reads.
+- Do not add `application/**`, `contracts/**`, `domain/**`, `mapper/**`, `infra/repository/**`, or `infra/interfaces/**`; BFF is only a Gateway invoking Runtime and exposing provider-backed metadata reads.

--- a/packages/bff/README_zh.md
+++ b/packages/bff/README_zh.md
@@ -8,7 +8,7 @@
 
 BFF 对页面执行只调用 Runtime gateway facade。Runtime 负责 view lookup、execution context 构建、datasource wiring、permission context resolution、audit observation 与 `RuntimeExecutor` 执行。
 
-`/meta/*` 保留为只读的 thin Kernel gateway。它只返回 HTTP envelope，不发布 metadata、不执行 registry migration，也不参与页面执行。
+`/meta/*` 保留为只读 HTTP envelope，并由注入的 meta registry provider 提供数据。BFF 禁止 import `kernel`；任何 kernel-backed provider 都必须在 BFF package 外部装配。
 
 Nest module 可以为 examples 接收注入的 runtime runner 与 meta registry provider，但默认核心 BFF module 不内置 demo。
 
@@ -40,7 +40,7 @@ bff/src/
 - `controller/http/**` 是 HTTP API 入口层。
 - `controller/ws/**` 是 WebSocket 入口层。Runtime WebSocket 文件必须固定在 `controller/ws/runtime/**`。
 - `infra/cache/**` 只放 gateway cache。
-- `infra/integration/**` 只放 thin Kernel metadata registry integration。
+- `infra/integration/**` 只放 provider-backed metadata registry integration。
 - `config/**` 只放 gateway 协议层配置：HTTP/CORS/request-id/timeout、WebSocket path/replay、gateway cache、provider token 与 log level。
 - `common/constants/**` 放包级常量和 provider token。
 - `common/**` 只放少量框架级 helper 和异常工具。
@@ -58,11 +58,12 @@ bff/src/
 ## 依赖方向
 
 - 上游：`apps/bff-server` 与 client 协议入口。
-- 下游：`runtime` 负责页面执行，`kernel` 负责 thin metadata reads。
+- 下游 package 依赖：仅 `runtime`。
+- Meta 读取：`/meta/*` 使用注入的 meta registry provider；kernel-backed provider 在本包外部装配。
 
 ```text
 controller/http -> runtime facade
-controller/http -> kernel registry
+controller/http -> injected meta registry provider
 controller/ws -> runtime WS contracts
 ```
 
@@ -74,7 +75,7 @@ controller/ws -> runtime WS contracts
 flowchart LR
   Http["HTTP / WS / CLI request"] --> Entry["controller/*"]
   Entry --> Runtime["Runtime gateway facade"]
-  Entry --> Kernel["Thin Kernel meta gateway"]
+  Entry --> MetaProvider["Injected meta registry provider"]
   Entry --> Response["HTTP response / WS event"]
 ```
 
@@ -95,4 +96,4 @@ pnpm --filter @zhongmiao/meta-lc-bff start
 - Runtime datasource、permission、audit 与 org-scope wiring 必须留在 runtime 或所属包内。
 - demo runtime runner 与 metadata provider 必须放在 `examples/*`，不能进入 BFF source。
 - 禁止恢复 `/query`、`/mutation` 旧入口；页面级数据请求必须走 `POST /view/:name`。
-- 禁止新增 `application/**`、`contracts/**`、`domain/**`、`mapper/**`、`infra/repository/**` 或 `infra/interfaces/**`；BFF 只能作为 Gateway 调用 Runtime 并暴露 thin Kernel metadata reads。
+- 禁止新增 `application/**`、`contracts/**`、`domain/**`、`mapper/**`、`infra/repository/**` 或 `infra/interfaces/**`；BFF 只能作为 Gateway 调用 Runtime 并暴露 provider-backed metadata reads。

--- a/packages/bff/package.json
+++ b/packages/bff/package.json
@@ -15,7 +15,6 @@
     "@nestjs/platform-express": "^10.4.22",
     "@nestjs/platform-socket.io": "^10.4.22",
     "@nestjs/websockets": "^10.4.22",
-    "@zhongmiao/meta-lc-kernel": "workspace:*",
     "@zhongmiao/meta-lc-runtime": "workspace:*",
     "redis": "^4.7.1",
     "reflect-metadata": "^0.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,9 +94,6 @@ importers:
       '@nestjs/websockets':
         specifier: ^10.4.22
         version: 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@nestjs/platform-socket.io@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@zhongmiao/meta-lc-kernel':
-        specifier: workspace:*
-        version: link:../kernel
       '@zhongmiao/meta-lc-runtime':
         specifier: workspace:*
         version: link:../runtime

--- a/scripts/check-boundaries.mjs
+++ b/scripts/check-boundaries.mjs
@@ -58,6 +58,7 @@ const FORBIDDEN_AUDIT_DEPS = [
   '@zhongmiao/meta-lc-datasource'
 ];
 const FORBIDDEN_BFF_DEPS = [
+  '@zhongmiao/meta-lc-kernel',
   '@zhongmiao/meta-lc-datasource',
   '@zhongmiao/meta-lc-permission',
   '@zhongmiao/meta-lc-query',
@@ -427,9 +428,9 @@ function checkBffGatewayConfig(rel, content, violations) {
 function checkBffMetaRegistryGateway(rel, content, violations) {
   if (rel !== 'packages/bff/src/infra/integration/meta-registry.service.ts') return;
 
-  for (const dep of ['@zhongmiao/meta-lc-runtime', '@zhongmiao/meta-lc-query', '@zhongmiao/meta-lc-datasource', '@zhongmiao/meta-lc-permission', '@zhongmiao/meta-lc-audit', 'pg']) {
+  for (const dep of ['@zhongmiao/meta-lc-kernel', '@zhongmiao/meta-lc-runtime', '@zhongmiao/meta-lc-query', '@zhongmiao/meta-lc-datasource', '@zhongmiao/meta-lc-permission', '@zhongmiao/meta-lc-audit', 'pg']) {
     if (content.includes(dep)) {
-      violations.push(`${rel}: BFF meta registry gateway may only depend on kernel.`);
+      violations.push(`${rel}: BFF meta registry gateway must use injected providers and must not import workspace packages.`);
     }
   }
 }

--- a/scripts/check-boundaries.test.mjs
+++ b/scripts/check-boundaries.test.mjs
@@ -254,6 +254,7 @@ test('rejects BFF data dependencies while allowing thin controller-to-infra dele
     'packages/bff/package.json': packageJson({
       dependencies: {
         '@zhongmiao/meta-lc-datasource': 'workspace:*',
+        '@zhongmiao/meta-lc-kernel': 'workspace:*',
         '@zhongmiao/meta-lc-permission': 'workspace:*',
         '@zhongmiao/meta-lc-query': 'workspace:*',
         '@zhongmiao/meta-lc-audit': 'workspace:*',
@@ -275,6 +276,7 @@ test('rejects BFF data dependencies while allowing thin controller-to-infra dele
 
   assert.deepEqual(checkWorkspace(workspace), [
     'packages/bff/package.json: BFF dependency "@zhongmiao/meta-lc-datasource" is forbidden in dependencies.',
+    'packages/bff/package.json: BFF dependency "@zhongmiao/meta-lc-kernel" is forbidden in dependencies.',
     'packages/bff/package.json: BFF dependency "@zhongmiao/meta-lc-permission" is forbidden in dependencies.',
     'packages/bff/package.json: BFF dependency "@zhongmiao/meta-lc-query" is forbidden in dependencies.',
     'packages/bff/package.json: BFF dependency "@zhongmiao/meta-lc-audit" is forbidden in dependencies.',
@@ -309,16 +311,17 @@ test('allows gateway-only BFF config and rejects data config keywords', () => {
   ]);
 });
 
-test('keeps BFF meta registry as a kernel-only gateway', () => {
+test('keeps BFF meta registry provider-only without workspace imports', () => {
   const workspace = createWorkspace({
     'packages/bff/src/infra/integration/meta-registry.service.ts': [
-      'import { executeRuntimeGatewayView } from "@zhongmiao/meta-lc-runtime";',
+      'import { MetaKernelService } from "@zhongmiao/meta-lc-kernel";',
       'export class MetaRegistryService {}'
     ].join('\n')
   });
 
   assert.deepEqual(checkWorkspace(workspace), [
-    'packages/bff/src/infra/integration/meta-registry.service.ts: BFF meta registry gateway may only depend on kernel.'
+    'packages/bff/src/infra/integration/meta-registry.service.ts: BFF meta registry gateway must use injected providers and must not import workspace packages.',
+    'packages/bff/src/infra/integration/meta-registry.service.ts: BFF cannot depend on @zhongmiao/meta-lc-kernel.'
   ]);
 });
 

--- a/scripts/generate-package-dependency-topology.mjs
+++ b/scripts/generate-package-dependency-topology.mjs
@@ -144,7 +144,7 @@ ${renderMermaid(manifestEdges)}
 
 ## Source Import 拓扑
 
-这张图表示当前生产源码真实 import 关系。它可能比 manifest 图更窄，例如 \`bff\` manifest 允许依赖 \`kernel\`，但当前 \`packages/bff/src/**/*.ts\` 没有直接 import \`kernel\`。
+这张图表示当前生产源码真实 import 关系。封板口径要求 \`bff\` 不直接 import \`kernel\`；\`/meta/*\` 如需 kernel-backed 数据，必须通过 BFF 包外注入的 meta registry provider 装配。
 
 ${renderMermaid(sourceEdges)}
 
@@ -158,8 +158,8 @@ ${renderSourceDetails()}
 
 1. \`@zhongmiao/meta-lc-bff-server\`
 2. \`@zhongmiao/meta-lc-bff\`
-3. \`@zhongmiao/meta-lc-runtime\`, \`@zhongmiao/meta-lc-kernel\`
-4. \`@zhongmiao/meta-lc-permission\`, \`@zhongmiao/meta-lc-datasource\`, \`@zhongmiao/meta-lc-audit\`
+3. \`@zhongmiao/meta-lc-runtime\`
+4. \`@zhongmiao/meta-lc-kernel\`, \`@zhongmiao/meta-lc-permission\`, \`@zhongmiao/meta-lc-datasource\`, \`@zhongmiao/meta-lc-audit\`
 5. \`@zhongmiao/meta-lc-query\`
 
 当前生产源码包 import 图没有发现环。
@@ -168,8 +168,9 @@ ${renderSourceDetails()}
 
 - \`runtime\` 是唯一执行核心，持有 \`ExecutionPlan\`、\`ExecutionNode\`、\`Expression\`、\`RuntimeContext\` 等执行契约。
 - \`kernel\` 是结构真源，持有 \`MetaSchema\`、\`ViewDefinition\`、\`NodeDefinition\`、\`DatasourceDefinition\`、\`PermissionPolicy\`。
-- \`bff\` 是 IO Gateway，只持有 HTTP/WS DTO、controller、bootstrap wiring、gateway config、gateway cache 与 thin Kernel integration。
-- \`bff\` 只能依赖 \`runtime\` 与 \`kernel\`；不得直接依赖 \`query\`、\`permission\`、\`datasource\` 或 \`pg\`。
+- \`bff\` 是 IO Gateway，只持有 HTTP/WS DTO、controller、bootstrap wiring、gateway config、gateway cache 与 provider-backed meta registry integration。
+- \`bff\` 只能依赖 \`runtime\`；不得直接依赖 \`kernel\`、\`query\`、\`permission\`、\`datasource\`、\`audit\` 或 \`pg\`。
+- \`/meta/*\` 保留只读 HTTP envelope，但必须通过注入的 meta registry provider 读取数据；kernel-backed provider 只能在 BFF package 外部装配。
 - \`datasource\` 与 \`audit\` 不得反向依赖 \`runtime\`；\`query\` 不得依赖 \`datasource\`。
 - \`kernel\`、\`query\`、\`datasource\`、\`audit\` 禁止依赖任何 workspace package；\`kernel\` 可持有 meta DB persistence，但不得依赖 \`runtime\`、\`query\`、\`permission\`、\`datasource\`、\`audit\` 或 \`bff\`。
 - \`permission\` 只能 type-only 依赖 \`query\` 的 AST/types；禁止 value import query compiler，禁止编译 SQL 或执行 datasource。


### PR DESCRIPTION
## Summary
- Remove the stale `@zhongmiao/meta-lc-kernel` dependency from `@zhongmiao/meta-lc-bff`.
- Regenerate package dependency topology so BFF only points to runtime.
- Tighten ESLint/boundary gates and docs around provider-only `/meta/*` access.

## Checks
- `pnpm run lint:boundaries`
- `pnpm run test:boundaries`
- `pnpm lint`
- `pnpm --filter @zhongmiao/meta-lc-bff test`
- `pnpm -r build`
- `pnpm -r test`
- `git diff --check`
- `pnpm run changelog:gate -- origin/main HEAD`

## Risk / Rollback
- Low risk: source code already avoided kernel imports; this removes the stale manifest dependency and locks the intended boundary.
- Rollback by reverting the commit if external composition unexpectedly relied on BFF declaring kernel as a dependency.