### PR TITLE
docs(topology): add runtime execution handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- docs(topology): add a runtime execution handoff diagram beside package dependency topology.
 - fix(boundaries): remove the stale BFF kernel package dependency and document provider-only meta registry access.
 - docs(topology): regenerate package dependency topology from manifest and production source imports.
 - chore(examples): extract the orders demo metadata, SQL seed, and mutation adapter out of core packages into `examples/orders-demo`.

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- docs(topology): 在 package dependency topology 旁补充 runtime execution handoff 图。
 - fix(boundaries): 移除 BFF 残留 kernel package 依赖，并明确 meta registry 只能通过 provider 注入访问。
 - docs(topology): 基于 manifest 与生产源码 import 重新生成 package dependency topology。
 - chore(examples): 将 orders demo metadata、SQL seed 与 mutation adapter 从核心包抽离到 `examples/orders-demo`。

--- a/docs/package-dependency-topology.md
+++ b/docs/package-dependency-topology.md
@@ -106,6 +106,26 @@ flowchart TD
   - type-only: `packages/runtime/src/application/executor/query-executor.ts`
   - value: `packages/runtime/src/infra/adapter/query.adapter.ts`
 
+## Runtime 执行流 / Execution Handoff
+
+这张图表示 runtime 执行链路中的产物流转，不表示 workspace package import dependency。`Query --> Datasource` 只表示 query compiler 产生 compiled SQL/request 后，由 runtime 交给 datasource adapter 执行；`packages/query` 仍然禁止依赖 `packages/datasource`。
+
+```mermaid
+flowchart LR
+  Runtime["@zhongmiao/meta-lc-runtime<br/>RuntimeExecutor"]
+  Permission["@zhongmiao/meta-lc-permission<br/>AST transform"]
+  Query["@zhongmiao/meta-lc-query<br/>AST to SQL"]
+  Datasource["@zhongmiao/meta-lc-datasource<br/>execute"]
+  BusinessDb[("business_db")]
+
+  Runtime --> Permission
+  Permission -->|"query AST / type-only contract"| Query
+  Runtime --> Query
+  Query -->|"compiled SQL/request handoff"| Datasource
+  Runtime --> Datasource
+  Datasource --> BusinessDb
+```
+
 ## 分层视图
 
 按 package manifest 依赖方向从入口到基础包看：

--- a/scripts/generate-package-dependency-topology.mjs
+++ b/scripts/generate-package-dependency-topology.mjs
@@ -152,6 +152,26 @@ ${renderMermaid(sourceEdges)}
 
 ${renderSourceDetails()}
 
+## Runtime 执行流 / Execution Handoff
+
+这张图表示 runtime 执行链路中的产物流转，不表示 workspace package import dependency。\`Query --> Datasource\` 只表示 query compiler 产生 compiled SQL/request 后，由 runtime 交给 datasource adapter 执行；\`packages/query\` 仍然禁止依赖 \`packages/datasource\`。
+
+\`\`\`mermaid
+flowchart LR
+  Runtime["@zhongmiao/meta-lc-runtime<br/>RuntimeExecutor"]
+  Permission["@zhongmiao/meta-lc-permission<br/>AST transform"]
+  Query["@zhongmiao/meta-lc-query<br/>AST to SQL"]
+  Datasource["@zhongmiao/meta-lc-datasource<br/>execute"]
+  BusinessDb[("business_db")]
+
+  Runtime --> Permission
+  Permission -->|"query AST / type-only contract"| Query
+  Runtime --> Query
+  Query -->|"compiled SQL/request handoff"| Datasource
+  Runtime --> Datasource
+  Datasource --> BusinessDb
+\`\`\`
+
 ## 分层视图
 
 按 package manifest 依赖方向从入口到基础包看：


### PR DESCRIPTION
## Summary
- Add a Runtime execution handoff diagram to the generated package topology doc.
- Make `Query -> Datasource` visible as compiled SQL/request handoff, not package import dependency.
- Keep manifest/source import topology and boundary rules unchanged.

## Checks
- `pnpm docs:topology`
- `pnpm run lint:boundaries`
- `pnpm run test:boundaries`
- `git diff --check`
- `pnpm run changelog:gate -- origin/main HEAD`

## Risk / Rollback
- Low risk: documentation and generator-only change.
- Rollback by reverting the docs/topology commit if the added diagram wording is not desired.