### PR TITLE
[codex] fix: generate 0.2.0 release draft from archived changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
-## 0.2.0-beta.0 (2026-04-28)
+## 0.2.0 (2026-04-28)
 
 - docs(sdk): add the SDK release checklist for beta freeze validation.
 - docs(sdk): document factory-first adapter usage, advanced Postgres classes, and consumer deep-import rules.

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## 0.2.0-beta.0 (2026-04-28)
+## 0.2.0 (2026-04-28)
 
 - docs(sdk): 新增 SDK 发布 checklist，用于 Beta 封板校验。
 - docs(sdk): 补充 factory-first adapter 使用、Postgres class advanced API 与业务方 deep import 约束。

--- a/apps/bff-server/package.json
+++ b/apps/bff-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zhongmiao/meta-lc-bff-server",
-  "version": "0.2.0-beta.0",
+  "version": "0.2.0",
   "private": true,
   "type": "commonjs",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meta-lc-platform",
-  "version": "0.2.0-beta.0",
+  "version": "0.2.0",
   "private": true,
   "packageManager": "pnpm@10.14.0",
   "scripts": {

--- a/packages/audit/CHANGELOG.md
+++ b/packages/audit/CHANGELOG.md
@@ -2,7 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
-## 0.2.0-beta.0 (2026-04-28)
+## 0.2.0 (2026-04-28)
 
 - docs(sdk): mark Postgres sink factories as factory-first and the sink class as advanced API.
 - feat(factory): add an audit sink factory contract plus Postgres sink function and class factories.

--- a/packages/audit/CHANGELOG.zh-CN.md
+++ b/packages/audit/CHANGELOG.zh-CN.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## 0.2.0-beta.0 (2026-04-28)
+## 0.2.0 (2026-04-28)
 
 - docs(sdk): 明确 Postgres sink factory-first 使用方式，并将 sink class 标记为 advanced API。
 - feat(factory): 新增 audit sink factory contract，并提供 Postgres sink 函数式与 class factory。

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zhongmiao/meta-lc-audit",
-  "version": "0.2.0-beta.0",
+  "version": "0.2.0",
   "private": false,
   "type": "commonjs",
   "scripts": {

--- a/packages/bff/CHANGELOG.md
+++ b/packages/bff/CHANGELOG.md
@@ -2,7 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
-## 0.2.0-beta.0 (2026-04-28)
+## 0.2.0 (2026-04-28)
 
 - chore(public-api): consume runtime contracts from the `@zhongmiao/meta-lc-runtime/core` subpath.
 - fix(ci): keep the orders demo gateway e2e path running from built package entrypoints.

--- a/packages/bff/CHANGELOG.zh-CN.md
+++ b/packages/bff/CHANGELOG.zh-CN.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## 0.2.0-beta.0 (2026-04-28)
+## 0.2.0 (2026-04-28)
 
 - chore(public-api): BFF 改为从 `@zhongmiao/meta-lc-runtime/core` subpath 消费 runtime contract。
 - fix(ci): 让 orders demo gateway e2e 继续通过已构建的 package 入口运行。

--- a/packages/bff/package.json
+++ b/packages/bff/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zhongmiao/meta-lc-bff",
-  "version": "0.2.0-beta.0",
+  "version": "0.2.0",
   "private": true,
   "type": "commonjs",
   "scripts": {

--- a/packages/datasource/CHANGELOG.md
+++ b/packages/datasource/CHANGELOG.md
@@ -2,7 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
-## 0.2.0-beta.0 (2026-04-28)
+## 0.2.0 (2026-04-28)
 
 - docs(sdk): mark Postgres datasource factories as factory-first and the adapter class as advanced API.
 - feat(factory): add a datasource adapter factory contract and Postgres adapter class factory.

--- a/packages/datasource/CHANGELOG.zh-CN.md
+++ b/packages/datasource/CHANGELOG.zh-CN.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## 0.2.0-beta.0 (2026-04-28)
+## 0.2.0 (2026-04-28)
 
 - docs(sdk): 明确 Postgres datasource factory-first 使用方式，并将 adapter class 标记为 advanced API。
 - feat(factory): 新增 datasource adapter factory contract 与 Postgres adapter class factory。

--- a/packages/datasource/package.json
+++ b/packages/datasource/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zhongmiao/meta-lc-datasource",
-  "version": "0.2.0-beta.0",
+  "version": "0.2.0",
   "private": false,
   "type": "commonjs",
   "scripts": {

--- a/packages/kernel-adapter-postgres/CHANGELOG.md
+++ b/packages/kernel-adapter-postgres/CHANGELOG.md
@@ -2,7 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
-## 0.2.0-beta.0 (2026-04-28)
+## 0.2.0 (2026-04-28)
 
 - chore(package): make `pg` an optional peer dependency for the Postgres kernel adapter.
 - feat(factory): add a class-based Postgres MetaKernel repository factory implementing the kernel contract.

--- a/packages/kernel-adapter-postgres/CHANGELOG.zh-CN.md
+++ b/packages/kernel-adapter-postgres/CHANGELOG.zh-CN.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## 0.2.0-beta.0 (2026-04-28)
+## 0.2.0 (2026-04-28)
 
 - chore(package): 将 Postgres kernel adapter 的 `pg` 调整为 optional peer dependency。
 - feat(factory): 新增 class-based Postgres MetaKernel repository factory，实现 kernel contract。

--- a/packages/kernel-adapter-postgres/package.json
+++ b/packages/kernel-adapter-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zhongmiao/meta-lc-kernel-adapter-postgres",
-  "version": "0.2.0-beta.0",
+  "version": "0.2.0",
   "private": false,
   "type": "commonjs",
   "scripts": {

--- a/packages/kernel/CHANGELOG.md
+++ b/packages/kernel/CHANGELOG.md
@@ -2,7 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
-## 0.2.0-beta.0 (2026-04-28)
+## 0.2.0 (2026-04-28)
 
 - docs(sdk): document kernel domain/application deep-import constraints for SDK consumers.
 - chore(public-api): stop exporting the services barrel from application and wrap migration safety through a facade.

--- a/packages/kernel/CHANGELOG.zh-CN.md
+++ b/packages/kernel/CHANGELOG.zh-CN.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## 0.2.0-beta.0 (2026-04-28)
+## 0.2.0 (2026-04-28)
 
 - docs(sdk): 补充 SDK consumer 禁止 deep import kernel domain/application 的约束。
 - chore(public-api): application 不再导出 services barrel，并通过 facade 包装 migration safety。

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zhongmiao/meta-lc-kernel",
-  "version": "0.2.0-beta.0",
+  "version": "0.2.0",
   "private": false,
   "type": "commonjs",
   "scripts": {

--- a/packages/permission/CHANGELOG.md
+++ b/packages/permission/CHANGELOG.md
@@ -2,7 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
-## 0.2.0-beta.0 (2026-04-28)
+## 0.2.0 (2026-04-28)
 
 - chore(public-api): narrow the package root to core contracts and explicit permission engine entrypoints.
 - docs(readme): clarify permission upstream/downstream relationships and type-only query AST boundary.

--- a/packages/permission/CHANGELOG.zh-CN.md
+++ b/packages/permission/CHANGELOG.zh-CN.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## 0.2.0-beta.0 (2026-04-28)
+## 0.2.0 (2026-04-28)
 
 - chore(public-api): 将 package root 收窄为 core contract 与明确的 permission engine 入口。
 - docs(readme): 明确 permission 上下游关系与仅 type-only 依赖 query AST/types 的边界。

--- a/packages/permission/package.json
+++ b/packages/permission/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zhongmiao/meta-lc-permission",
-  "version": "0.2.0-beta.0",
+  "version": "0.2.0",
   "private": false,
   "type": "commonjs",
   "scripts": {

--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -2,7 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
-## 0.2.0-beta.0 (2026-04-28)
+## 0.2.0 (2026-04-28)
 
 - chore(public-api): narrow the package root to core contracts and explicit query compiler entrypoints.
 - docs(readme): clarify query upstream/downstream relationships and AST-to-SQL compiler-only boundaries.

--- a/packages/query/CHANGELOG.zh-CN.md
+++ b/packages/query/CHANGELOG.zh-CN.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## 0.2.0-beta.0 (2026-04-28)
+## 0.2.0 (2026-04-28)
 
 - chore(public-api): 将 package root 收窄为 core contract 与明确的 query compiler 入口。
 - docs(readme): 明确 query 上下游关系与只负责 AST-to-SQL 编译的边界。

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zhongmiao/meta-lc-query",
-  "version": "0.2.0-beta.0",
+  "version": "0.2.0",
   "private": false,
   "type": "commonjs",
   "scripts": {

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -2,7 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
-## 0.2.0-beta.0 (2026-04-28)
+## 0.2.0 (2026-04-28)
 
 - docs(sdk): document runtime facade/core entry usage and internal implementation deep-import constraints.
 - chore(public-api): make the runtime root facade-only and expose runtime contracts through the `./core` subpath.

--- a/packages/runtime/CHANGELOG.zh-CN.md
+++ b/packages/runtime/CHANGELOG.zh-CN.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## 0.2.0-beta.0 (2026-04-28)
+## 0.2.0 (2026-04-28)
 
 - docs(sdk): 补充 runtime facade/core 入口用法与内部实现 deep import 约束。
 - chore(public-api): runtime root 收窄为仅 facade 入口，并通过 `./core` subpath 暴露 runtime contract。

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zhongmiao/meta-lc-runtime",
-  "version": "0.2.0-beta.0",
+  "version": "0.2.0",
   "private": false,
   "type": "commonjs",
   "scripts": {

--- a/scripts/release/changelog-utils.mjs
+++ b/scripts/release/changelog-utils.mjs
@@ -6,13 +6,13 @@ export function readFile(filePath) {
   return fs.readFileSync(filePath, "utf8").replace(/\r\n/g, "\n");
 }
 
-export function extractUnreleased(content) {
+function extractSection(content, isTargetHeader) {
   const lines = content.replace(/\r\n/g, "\n").split("\n");
   const buffer = [];
   let inSection = false;
 
   for (const line of lines) {
-    if (line.trim() === UNRELEASED_HEADER) {
+    if (isTargetHeader(line.trim())) {
       inSection = true;
       continue;
     }
@@ -27,11 +27,26 @@ export function extractUnreleased(content) {
   return buffer.join("\n").trim();
 }
 
+export function extractUnreleased(content) {
+  return extractSection(content, (line) => line === UNRELEASED_HEADER);
+}
+
+export function extractVersion(content, version) {
+  return extractSection(content, (line) => line === `## ${version}` || line.startsWith(`## ${version} (`));
+}
+
 export function readUnreleasedFromFile(filePath) {
   if (!fs.existsSync(filePath)) {
     return "";
   }
   return extractUnreleased(readFile(filePath));
+}
+
+export function readVersionFromFile(filePath, version) {
+  if (!version || !fs.existsSync(filePath)) {
+    return "";
+  }
+  return extractVersion(readFile(filePath), version);
 }
 
 export function finalizeUnreleasedSection(filePath, version, date) {

--- a/scripts/release/compose-draft-from-unreleased.mjs
+++ b/scripts/release/compose-draft-from-unreleased.mjs
@@ -8,11 +8,11 @@ const requestedVersion = versionFlagIndex >= 0 ? args[versionFlagIndex + 1] : ""
 
 const rootPackage = JSON.parse(fs.readFileSync("package.json", "utf8"));
 const version = requestedVersion || rootPackage.version;
-const rootNotes = loadRootReleaseNotes();
-const packages = loadWorkspacePackages().filter((pkg) => pkg.unreleasedEn || pkg.unreleasedZh);
+const rootNotes = loadRootReleaseNotes(version);
+const packages = loadWorkspacePackages(version).filter((pkg) => pkg.unreleasedEn || pkg.unreleasedZh);
 
 if (!rootNotes.unreleasedEn && !rootNotes.unreleasedZh && packages.length === 0) {
-  console.error("No unreleased changelog content found.");
+  console.error("No unreleased or versioned changelog content found.");
   process.exit(1);
 }
 

--- a/scripts/release/package-catalog.mjs
+++ b/scripts/release/package-catalog.mjs
@@ -1,11 +1,15 @@
 import fs from "node:fs";
 import path from "node:path";
-import { readUnreleasedFromFile } from "./changelog-utils.mjs";
+import { readUnreleasedFromFile, readVersionFromFile } from "./changelog-utils.mjs";
 
 const ROOT = process.cwd();
 const PACKAGES_DIR = path.join(ROOT, "packages");
 
-export function loadWorkspacePackages() {
+function readReleaseNotes(filePath, version) {
+  return readUnreleasedFromFile(filePath) || readVersionFromFile(filePath, version);
+}
+
+export function loadWorkspacePackages(version = "") {
   return fs
     .readdirSync(PACKAGES_DIR, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
@@ -23,18 +27,18 @@ export function loadWorkspacePackages() {
         packageJsonPath: path.relative(ROOT, packageJsonPath),
         changelogPathEn: path.relative(ROOT, changelogPathEn),
         changelogPathZh: path.relative(ROOT, changelogPathZh),
-        unreleasedEn: readUnreleasedFromFile(changelogPathEn),
-        unreleasedZh: readUnreleasedFromFile(changelogPathZh)
+        unreleasedEn: readReleaseNotes(changelogPathEn, version),
+        unreleasedZh: readReleaseNotes(changelogPathZh, version)
       };
     })
     .sort((left, right) => left.name.localeCompare(right.name));
 }
 
-export function loadRootReleaseNotes() {
+export function loadRootReleaseNotes(version = "") {
   return {
     changelogPathEn: "CHANGELOG.md",
     changelogPathZh: "CHANGELOG.zh-CN.md",
-    unreleasedEn: readUnreleasedFromFile(path.join(ROOT, "CHANGELOG.md")),
-    unreleasedZh: readUnreleasedFromFile(path.join(ROOT, "CHANGELOG.zh-CN.md"))
+    unreleasedEn: readReleaseNotes(path.join(ROOT, "CHANGELOG.md"), version),
+    unreleasedZh: readReleaseNotes(path.join(ROOT, "CHANGELOG.zh-CN.md"), version)
   };
 }


### PR DESCRIPTION
## Summary
- Move the SDK release line from `0.2.0-beta.0` to the formal `0.2.0` version across manifests and archived changelog headings.
- Teach the release draft composer to fall back to an already archived changelog section when `[Unreleased]` is empty.
- Preserve existing release behavior: no npm publish, no GitHub release creation, no stale draft/tag cleanup in this PR.

## Validation
- `pnpm install --lockfile-only`
- `pnpm run release:draft-notes -- --version 0.2.0`
- `pnpm run -s release:draft-notes:json -- --version 0.2.0`
- `node scripts/release/compose-draft-from-unreleased.mjs --version 9.9.9` returns the expected failure message
- `pnpm run test:boundaries`
- `pnpm run lint:boundaries`
- `pnpm -r build`
- `pnpm -r test`
- `pnpm lint` (0 errors, 17 existing warnings)
- `pnpm query-gate`
- `node scripts/check-changelog-gate.mjs "$(git merge-base origin/main HEAD)" HEAD`
- `pnpm run version:check`

## Notes
- Existing `v0.1.0` stale draft and `v0.2.0-rc` tag are intentionally untouched.
- Release notes remain sourced from changelog content, not GitHub autogenerated notes.
