### PR TITLE
[codex] fix: switch to release pr publish flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   changelog-gate:
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' && !startsWith(github.head_ref, 'chore/release-') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -59,84 +59,3 @@ jobs:
           LC_DB_AUDIT_NAME: ${{ vars.LC_DB_AUDIT_NAME }}
           LC_DB_SSL: ${{ vars.LC_DB_SSL || 'false' }}
         run: pnpm query-gate
-
-  draft-release:
-    if: ${{ github.event_name == 'push' }}
-    needs:
-      - build-test
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-node@v5
-        with:
-          node-version: 24
-          package-manager-cache: false
-      - run: corepack enable
-      - run: corepack prepare "pnpm@${PNPM_VERSION}" --activate
-      - run: pnpm install --frozen-lockfile
-      - name: Compose release draft
-        id: notes
-        run: |
-          set +e
-          NOTES="$(pnpm run -s release:draft-notes)"
-          EXIT_CODE="$?"
-          set -e
-
-          if [[ "${EXIT_CODE}" -ne 0 ]]; then
-            echo "skipped=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          VERSION="$(pnpm run -s release:next-version)"
-          TAG="v${VERSION}"
-          {
-            echo "skipped=false"
-            echo "tag=${TAG}"
-            echo "body<<EOF_BODY"
-            printf '%s\n' "${NOTES}"
-            echo "EOF_BODY"
-          } >> "$GITHUB_OUTPUT"
-      - name: Upsert draft release
-        if: ${{ steps.notes.outputs.skipped != 'true' }}
-        uses: actions/github-script@v7
-        env:
-          RELEASE_TAG: ${{ steps.notes.outputs.tag }}
-          RELEASE_BODY: ${{ steps.notes.outputs.body }}
-        with:
-          script: |
-            const tag = process.env.RELEASE_TAG;
-            const body = process.env.RELEASE_BODY || '';
-            const releases = await github.paginate(github.rest.repos.listReleases, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              per_page: 100
-            });
-            const existing = releases.find((release) => release.tag_name === tag && release.draft);
-            if (existing) {
-              await github.rest.repos.updateRelease({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                release_id: existing.id,
-                tag_name: tag,
-                target_commitish: 'main',
-                name: tag,
-                body,
-                draft: true,
-                prerelease: false
-              });
-            } else {
-              await github.rest.repos.createRelease({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                tag_name: tag,
-                target_commitish: 'main',
-                name: tag,
-                body,
-                draft: true,
-                prerelease: false
-              });
-            }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,129 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  PNPM_VERSION: 10.14.0
+
+jobs:
+  detect-release:
+    runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.detect.outputs.should_publish }}
+      version: ${{ steps.detect.outputs.version }}
+      tag: ${{ steps.detect.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Detect release version bump
+        id: detect
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          VERSION="$(node -p "require('./package.json').version")"
+          TAG="v${VERSION}"
+          OLD_VERSION=""
+
+          if git cat-file -e "${BEFORE_SHA}:package.json" 2>/dev/null; then
+            OLD_VERSION="$(git show "${BEFORE_SHA}:package.json" | node -e "let data=''; process.stdin.on('data', c => data += c); process.stdin.on('end', () => console.log(JSON.parse(data).version));")"
+          fi
+
+          {
+            echo "version=${VERSION}"
+            echo "tag=${TAG}"
+          } >> "$GITHUB_OUTPUT"
+
+          if [[ "${OLD_VERSION}" == "${VERSION}" ]]; then
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            echo "Root version did not change (${VERSION}); skipping publish."
+            exit 0
+          fi
+
+          if ! grep -Eq "^## ${VERSION} \\([0-9]{4}-[0-9]{2}-[0-9]{2}\\)" CHANGELOG.md; then
+            echo "Root version changed to ${VERSION}, but CHANGELOG.md has no matching release section."
+            exit 1
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            echo "${TAG} already exists; skipping publish."
+            exit 0
+          fi
+
+          echo "should_publish=true" >> "$GITHUB_OUTPUT"
+
+  publish:
+    if: ${{ needs.detect-release.outputs.should_publish == 'true' }}
+    needs:
+      - detect-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          package-manager-cache: false
+          registry-url: https://registry.npmjs.org
+      - run: corepack enable
+      - run: corepack prepare "pnpm@${PNPM_VERSION}" --activate
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm version:check
+      - run: pnpm -r build
+      - run: pnpm -r test
+      - run: pnpm lint
+      - name: query-gate
+        env:
+          NODE_ENV: development
+          LC_DB_HOST: ${{ vars.LC_DB_HOST }}
+          LC_DB_PORT: ${{ vars.LC_DB_PORT || '5432' }}
+          LC_DB_USER: ${{ secrets.LC_DB_USER }}
+          LC_DB_PASSWORD: ${{ secrets.LC_DB_PASSWORD }}
+          LC_DB_META_NAME: ${{ vars.LC_DB_META_NAME }}
+          LC_DB_BUSINESS_NAME: ${{ vars.LC_DB_BUSINESS_NAME }}
+          LC_DB_AUDIT_NAME: ${{ vars.LC_DB_AUDIT_NAME }}
+          LC_DB_SSL: ${{ vars.LC_DB_SSL || 'false' }}
+        run: pnpm query-gate
+      - name: Publish npm packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: pnpm run -s release:publish-packages -- --version "${{ needs.detect-release.outputs.version }}"
+      - name: Publish GitHub release
+        uses: actions/github-script@v7
+        env:
+          RELEASE_TAG: ${{ needs.detect-release.outputs.tag }}
+          RELEASE_VERSION: ${{ needs.detect-release.outputs.version }}
+        with:
+          script: |
+            const tag = process.env.RELEASE_TAG;
+            const version = process.env.RELEASE_VERSION;
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100
+            });
+            const release = releases.find((item) => item.tag_name === tag && item.draft);
+            if (!release) {
+              core.setFailed(`Draft release ${tag} was not found. Run the Release Prepare workflow before merging the release PR.`);
+              return;
+            }
+            await github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: release.id,
+              tag_name: tag,
+              target_commitish: context.sha,
+              name: tag,
+              body: release.body || `Release ${version}`,
+              draft: false,
+              prerelease: false
+            });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release Prepare
 
 on:
   workflow_dispatch:
@@ -10,95 +10,14 @@ on:
       finalize_changelog:
         description: finalize root/package changelogs into the requested version
         required: false
-        default: false
+        default: true
         type: boolean
 
 env:
   PNPM_VERSION: 10.14.0
 
 jobs:
-  prepare:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-node@v5
-        with:
-          node-version: 24
-          package-manager-cache: false
-      - run: corepack enable
-      - run: corepack prepare "pnpm@${PNPM_VERSION}" --activate
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm version:check
-      - run: mkdir -p .tmp
-      - run: pnpm run -s release:draft-notes:json -- --version "${{ inputs.version }}" > .tmp/release-metadata.json
-      - run: pnpm run -s release:draft-notes -- --version "${{ inputs.version }}" > .tmp/release-draft.md
-      - uses: actions/upload-artifact@v4
-        with:
-          name: release-metadata
-          path: |
-            .tmp/release-metadata.json
-            .tmp/release-draft.md
-
-  draft-release:
-    needs:
-      - prepare
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: release-metadata
-          path: .tmp
-      - uses: actions/github-script@v7
-        env:
-          RELEASE_TAG: v${{ inputs.version }}
-          RELEASE_BODY_FILE: .tmp/release-draft.md
-        with:
-          script: |
-            const fs = require('node:fs');
-            const tag = process.env.RELEASE_TAG;
-            const body = fs.readFileSync(process.env.RELEASE_BODY_FILE, 'utf8');
-            const releases = await github.paginate(github.rest.repos.listReleases, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              per_page: 100
-            });
-            const existing = releases.find((release) => release.tag_name === tag && release.draft);
-            if (existing) {
-              await github.rest.repos.updateRelease({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                release_id: existing.id,
-                tag_name: tag,
-                target_commitish: 'main',
-                name: tag,
-                body,
-                draft: true,
-                prerelease: false
-              });
-            } else {
-              await github.rest.repos.createRelease({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                tag_name: tag,
-                target_commitish: 'main',
-                name: tag,
-                body,
-                draft: true,
-                prerelease: false
-              });
-            }
-
-  finalize-changelog:
-    if: ${{ inputs.finalize_changelog }}
-    needs:
-      - prepare
-      - draft-release
+  prepare-release-pr:
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -115,33 +34,119 @@ jobs:
       - run: corepack enable
       - run: corepack prepare "pnpm@${PNPM_VERSION}" --activate
       - run: pnpm install --frozen-lockfile
-      - uses: actions/download-artifact@v4
-        with:
-          name: release-metadata
-          path: .tmp
-      - run: pnpm run -s release:finalize-unreleased -- .tmp/release-metadata.json
-      - name: Create changelog PR
+      - run: pnpm version:check
+      - run: mkdir -p .tmp
+      - name: Resolve release version
+        id: version
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          if git diff --quiet -- CHANGELOG.md CHANGELOG.zh-CN.md packages/*/CHANGELOG.md packages/*/CHANGELOG.zh-CN.md; then
-            echo "No changelog changes detected."
-            exit 0
+          VERSION="${INPUT_VERSION}"
+
+          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release version must be a formal semver version like 0.2.0."
+            exit 1
           fi
 
-          VERSION="${{ inputs.version }}"
-          BRANCH="chore/changelog-finalize-${VERSION}-${GITHUB_RUN_ID}"
+          echo "value=${VERSION}" >> "$GITHUB_OUTPUT"
+      - name: Compose release metadata from Unreleased
+        run: |
+          pnpm run -s release:draft-notes:json -- --version "${{ steps.version.outputs.value }}" > .tmp/release-metadata.json
+          pnpm run -s release:draft-notes -- --version "${{ steps.version.outputs.value }}" > .tmp/release-draft.md
+      - name: Prepare release PR files
+        if: ${{ inputs.finalize_changelog }}
+        run: |
+          pnpm run -s release:prepare-pr -- .tmp/release-metadata.json
+          pnpm install --lockfile-only
+          pnpm version:check
+          pnpm run -s release:draft-notes:version -- --version "${{ steps.version.outputs.value }}" > .tmp/release-draft.md
+      - name: Create release branch
+        if: ${{ inputs.finalize_changelog }}
+        id: branch
+        env:
+          VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          if git diff --quiet; then
+            echo "No release PR changes detected."
+            exit 1
+          fi
+
+          BRANCH="chore/release-${VERSION}-${GITHUB_RUN_ID}"
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -c "${BRANCH}"
-          git add CHANGELOG.md CHANGELOG.zh-CN.md packages/*/CHANGELOG.md packages/*/CHANGELOG.zh-CN.md
-          git commit -m "chore(changelog): finalize ${VERSION} release logs"
+          git add package.json pnpm-lock.yaml CHANGELOG.md CHANGELOG.zh-CN.md apps/*/package.json packages/*/package.json packages/*/CHANGELOG.md packages/*/CHANGELOG.zh-CN.md
+          git commit -m "chore(release): prepare ${VERSION}"
           git push --set-upstream origin "${BRANCH}"
 
-          PR_URL="$(gh pr create \
-            --title "chore(changelog): finalize ${VERSION} release logs" \
-            --body "Automated changelog finalize after release draft for ${VERSION}." \
+          echo "name=${BRANCH}" >> "$GITHUB_OUTPUT"
+      - name: Upsert draft release
+        uses: actions/github-script@v7
+        env:
+          RELEASE_TAG: v${{ steps.version.outputs.value }}
+          RELEASE_TARGET: ${{ steps.branch.outputs.name || 'main' }}
+          RELEASE_BODY_FILE: .tmp/release-draft.md
+        with:
+          script: |
+            const fs = require('node:fs');
+            const tag = process.env.RELEASE_TAG;
+            const target = process.env.RELEASE_TARGET;
+            const body = fs.readFileSync(process.env.RELEASE_BODY_FILE, 'utf8');
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100
+            });
+            const existing = releases.find((release) => release.tag_name === tag && release.draft);
+            if (existing) {
+              await github.rest.repos.updateRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                release_id: existing.id,
+                tag_name: tag,
+                target_commitish: target,
+                name: tag,
+                body,
+                draft: true,
+                prerelease: false
+              });
+            } else {
+              await github.rest.repos.createRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag_name: tag,
+                target_commitish: target,
+                name: tag,
+                body,
+                draft: true,
+                prerelease: false
+              });
+            }
+      - name: Create release PR
+        if: ${{ inputs.finalize_changelog }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.value }}
+          BRANCH: ${{ steps.branch.outputs.name }}
+        run: |
+          BODY_FILE=".tmp/release-pr-body.md"
+
+          cat > "${BODY_FILE}" <<EOF
+          ## Summary
+          - Finalizes the ${VERSION} release changelogs from \`[Unreleased]\`.
+          - Updates root, package, and app workspace versions to ${VERSION}.
+          - Synchronizes draft release \`v${VERSION}\` from the finalized root changelog.
+
+          ## Validation
+          CI should run package/build verification for this release PR. The changelog gate is intentionally skipped for generated release branches.
+
+          ## Publish
+          Merge this PR to \`main\` to trigger the main-branch release workflow. The release tag is finalized against the merged \`main\` commit after npm publish succeeds.
+          EOF
+
+          gh pr create \
+            --title "chore(release): prepare ${VERSION}" \
+            --body-file "${BODY_FILE}" \
             --base main \
-            --head "${BRANCH}")"
-          gh pr merge --auto --squash "${PR_URL}"
+            --head "${BRANCH}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
-## 0.2.0 (2026-04-28)
-
+- fix(release): switch the multi-package release flow to Unreleased draft notes, generated release PRs, and main-branch publishing.
 - docs(sdk): add the SDK release checklist for beta freeze validation.
 - docs(sdk): document factory-first adapter usage, advanced Postgres classes, and consumer deep-import rules.
 - chore(sdk): narrow runtime/kernel public APIs and standardize Postgres adapter factories.
@@ -62,7 +61,6 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - feat(bff): add a configurable Runtime WebSocket broadcast bus with Redis pub/sub fanout.
 - feat(bff): add Runtime WebSocket operations status and health visibility.
 - feat(bff): add Redis Stream cursor replay for Runtime WebSocket updates.
-
 ## 0.1.0 (2026-04-18)
 
 - Initial internal baseline for the Meta-Driven middleware monorepo.

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -2,8 +2,7 @@
 
 ## [Unreleased]
 
-## 0.2.0 (2026-04-28)
-
+- fix(release): 将多包发布流程调整为基于 Unreleased 生成草稿、生成 release PR，并在 main 分支合并后发布。
 - docs(sdk): 新增 SDK 发布 checklist，用于 Beta 封板校验。
 - docs(sdk): 补充 factory-first adapter 使用、Postgres class advanced API 与业务方 deep import 约束。
 - chore(sdk): 收窄 runtime/kernel public API，并统一 Postgres adapter factory 策略。
@@ -62,7 +61,6 @@
 - feat(bff): 新增可配置的 Runtime WebSocket broadcast bus 与 Redis pub/sub fanout。
 - feat(bff): 新增 Runtime WebSocket 运维状态与健康检查可见性。
 - feat(bff): 新增 Runtime WebSocket 更新的 Redis Stream cursor replay。
-
 ## 0.1.0 (2026-04-18)
 
 - Meta-Driven middleware monorepo 的首个内部基线版本。

--- a/apps/bff-server/package.json
+++ b/apps/bff-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zhongmiao/meta-lc-bff-server",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "private": true,
   "type": "commonjs",
   "scripts": {
@@ -21,6 +21,8 @@
   "main": "dist/apps/bff-server/src/main.js",
   "types": "dist/apps/bff-server/src/main.d.ts",
   "nx": {
-    "tags": ["layer:app"]
+    "tags": [
+      "layer:app"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meta-lc-platform",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "private": true,
   "packageManager": "pnpm@10.14.0",
   "scripts": {
@@ -23,7 +23,10 @@
     "release:status": "changeset status --verbose",
     "release:draft-notes": "node scripts/release/compose-draft-from-unreleased.mjs",
     "release:draft-notes:json": "node scripts/release/compose-draft-from-unreleased.mjs --json",
+    "release:draft-notes:version": "node scripts/release/compose-draft-from-version.mjs",
     "release:finalize-unreleased": "node scripts/release/finalize-unreleased-changelogs.mjs",
+    "release:prepare-pr": "node scripts/release/prepare-release-pr.mjs",
+    "release:publish-packages": "node scripts/release/publish-selected-packages.mjs",
     "release:next-version": "node -p \"require('./package.json').version\"",
     "version:check": "node scripts/release/version-consistency.mjs",
     "changelog:gate": "node scripts/check-changelog-gate.mjs"

--- a/packages/audit/CHANGELOG.md
+++ b/packages/audit/CHANGELOG.md
@@ -2,8 +2,6 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
-## 0.2.0 (2026-04-28)
-
 - docs(sdk): mark Postgres sink factories as factory-first and the sink class as advanced API.
 - feat(factory): add an audit sink factory contract plus Postgres sink function and class factories.
 - chore(boundaries): lock package exports and deep-import rules around the audit root and Postgres secondary entry.
@@ -17,7 +15,6 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - refactor(package-structure): reorganize src into layered domain/application/infra/interface/types/utils directories and update public entrypoints.
 - docs(readme): add bilingual package README and minimal architecture flow.
 - chore(package): adopt the `@zhongmiao/meta-lc-audit` scoped package identity for release governance.
-
 ## 0.1.0 (2026-04-18)
 
 - Initial audit persistence baseline for query, mutation, migration, and access logs.

--- a/packages/audit/CHANGELOG.zh-CN.md
+++ b/packages/audit/CHANGELOG.zh-CN.md
@@ -2,8 +2,6 @@
 
 ## [Unreleased]
 
-## 0.2.0 (2026-04-28)
-
 - docs(sdk): 明确 Postgres sink factory-first 使用方式，并将 sink class 标记为 advanced API。
 - feat(factory): 新增 audit sink factory contract，并提供 Postgres sink 函数式与 class factory。
 - chore(boundaries): 围绕 audit root 与 Postgres secondary entry 锁定 package exports 和 deep import 规则。
@@ -17,7 +15,6 @@
 - refactor(package-structure): 将 src 重整为 domain/application/infra/interface/types/utils 分层目录，并同步更新对外入口。
 - docs(readme): 新增双语子包 README 与最小架构流程图。
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-audit` 正式包名。
-
 ## 0.1.0 (2026-04-18)
 
 - query、mutation、migration 与 access 审计落盘能力的首个基线版本。

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zhongmiao/meta-lc-audit",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "private": false,
   "type": "commonjs",
   "scripts": {

--- a/packages/bff/CHANGELOG.md
+++ b/packages/bff/CHANGELOG.md
@@ -2,8 +2,6 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
-## 0.2.0 (2026-04-28)
-
 - chore(public-api): consume runtime contracts from the `@zhongmiao/meta-lc-runtime/core` subpath.
 - fix(ci): keep the orders demo gateway e2e path running from built package entrypoints.
 - fix(boundaries): remove the stale kernel dependency from BFF and make meta registry reads provider-only.
@@ -39,7 +37,6 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - feat(gateway): add a configurable runtime WebSocket broadcast bus with Redis pub/sub fanout.
 - feat(gateway): add runtime WebSocket operations status and health visibility.
 - feat(gateway): add Redis Stream cursor replay for runtime WebSocket updates.
-
 ## 0.1.0 (2026-04-18)
 
 - Initial middleware orchestration baseline for BFF query, mutation, bootstrap, and audit flows.

--- a/packages/bff/CHANGELOG.zh-CN.md
+++ b/packages/bff/CHANGELOG.zh-CN.md
@@ -2,8 +2,6 @@
 
 ## [Unreleased]
 
-## 0.2.0 (2026-04-28)
-
 - chore(public-api): BFF 改为从 `@zhongmiao/meta-lc-runtime/core` subpath 消费 runtime contract。
 - fix(ci): 让 orders demo gateway e2e 继续通过已构建的 package 入口运行。
 - fix(boundaries): 移除 BFF 残留 kernel 依赖，并将 meta registry 读取收紧为 provider-only。
@@ -39,7 +37,6 @@
 - feat(gateway): 新增可配置的 runtime WebSocket broadcast bus 与 Redis pub/sub fanout。
 - feat(gateway): 新增 runtime WebSocket 运维状态与健康检查可见性。
 - feat(gateway): 新增 runtime WebSocket 更新的 Redis Stream cursor replay。
-
 ## 0.1.0 (2026-04-18)
 
 - BFF query、mutation、bootstrap 与 audit 编排层的首个基线版本。

--- a/packages/bff/package.json
+++ b/packages/bff/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zhongmiao/meta-lc-bff",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "private": true,
   "type": "commonjs",
   "scripts": {

--- a/packages/datasource/CHANGELOG.md
+++ b/packages/datasource/CHANGELOG.md
@@ -2,8 +2,6 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
-## 0.2.0 (2026-04-28)
-
 - docs(sdk): mark Postgres datasource factories as factory-first and the adapter class as advanced API.
 - feat(factory): add a datasource adapter factory contract and Postgres adapter class factory.
 - chore(boundaries): lock package exports and deep-import rules around the datasource root and Postgres secondary entry.
@@ -17,7 +15,6 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - refactor(package-structure): reorganize src into layered domain/application/infra/interface/types/utils directories and update public entrypoints.
 - docs(readme): add bilingual package README and minimal architecture flow.
 - chore(package): adopt the `@zhongmiao/meta-lc-datasource` scoped package identity for release governance.
-
 ## 0.1.0 (2026-04-18)
 
 - Initial datasource execution adapter baseline for PostgreSQL-backed middleware flows.

--- a/packages/datasource/CHANGELOG.zh-CN.md
+++ b/packages/datasource/CHANGELOG.zh-CN.md
@@ -2,8 +2,6 @@
 
 ## [Unreleased]
 
-## 0.2.0 (2026-04-28)
-
 - docs(sdk): 明确 Postgres datasource factory-first 使用方式，并将 adapter class 标记为 advanced API。
 - feat(factory): 新增 datasource adapter factory contract 与 Postgres adapter class factory。
 - chore(boundaries): 围绕 datasource root 与 Postgres secondary entry 锁定 package exports 和 deep import 规则。
@@ -17,7 +15,6 @@
 - refactor(package-structure): 将 src 重整为 domain/application/infra/interface/types/utils 分层目录，并同步更新对外入口。
 - docs(readme): 新增双语子包 README 与最小架构流程图。
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-datasource` 正式包名。
-
 ## 0.1.0 (2026-04-18)
 
 - PostgreSQL 数据执行适配层的首个基线版本。

--- a/packages/datasource/package.json
+++ b/packages/datasource/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zhongmiao/meta-lc-datasource",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "private": false,
   "type": "commonjs",
   "scripts": {

--- a/packages/kernel-adapter-postgres/CHANGELOG.md
+++ b/packages/kernel-adapter-postgres/CHANGELOG.md
@@ -2,14 +2,11 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
-## 0.2.0 (2026-04-28)
-
 - chore(package): make `pg` an optional peer dependency for the Postgres kernel adapter.
 - feat(factory): add a class-based Postgres MetaKernel repository factory implementing the kernel contract.
 - refactor(package): split the Postgres repository implementation into semantic repository, factory, schema, mapper, interface, type, and utility modules without widening the public API.
 - chore(package): adopt the kernel-adapter-postgres package name to keep it scoped to the kernel Postgres repository adapter.
 - chore(package): add the kernel-adapter-postgres changelog baseline for the Postgres MetaKernel repository implementation package.
-
 ## 0.1.0 (2026-04-18)
 
 - Initial private persistence integration package baseline.

--- a/packages/kernel-adapter-postgres/CHANGELOG.zh-CN.md
+++ b/packages/kernel-adapter-postgres/CHANGELOG.zh-CN.md
@@ -2,14 +2,11 @@
 
 ## [Unreleased]
 
-## 0.2.0 (2026-04-28)
-
 - chore(package): 将 Postgres kernel adapter 的 `pg` 调整为 optional peer dependency。
 - feat(factory): 新增 class-based Postgres MetaKernel repository factory，实现 kernel contract。
 - refactor(package): 将 Postgres repository 实现拆成 repository、factory、schema、mapper、interface、type 与 utility 模块，同时不扩大 public API。
 - chore(package): 采用 kernel-adapter-postgres 包名，明确它只承载 kernel Postgres repository adapter。
 - chore(package): 为承载 Postgres MetaKernel repository 实现的 kernel-adapter-postgres 包补充 changelog 基线。
-
 ## 0.1.0 (2026-04-18)
 
 - 私有持久化集成包的首个基线版本。

--- a/packages/kernel-adapter-postgres/package.json
+++ b/packages/kernel-adapter-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zhongmiao/meta-lc-kernel-adapter-postgres",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "private": false,
   "type": "commonjs",
   "scripts": {

--- a/packages/kernel/CHANGELOG.md
+++ b/packages/kernel/CHANGELOG.md
@@ -2,8 +2,6 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
-## 0.2.0 (2026-04-28)
-
 - docs(sdk): document kernel domain/application deep-import constraints for SDK consumers.
 - chore(public-api): stop exporting the services barrel from application and wrap migration safety through a facade.
 - feat(core): add a MetaKernel repository factory contract for adapter implementations.
@@ -24,7 +22,6 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - feat(api-generator): add a stable route manifest generator and extend compiler fixture coverage to API outputs.
 - feat(permission-generator): add a stable permission manifest generator and complete compiler fixture coverage.
 - feat(schema): add tenant, app, rule, and permission metadata to the versioned MetaSchema contract.
-
 ## 0.1.0 (2026-04-18)
 
 - Initial kernel baseline for snapshot, diff, and migration DSL source of truth.

--- a/packages/kernel/CHANGELOG.zh-CN.md
+++ b/packages/kernel/CHANGELOG.zh-CN.md
@@ -2,8 +2,6 @@
 
 ## [Unreleased]
 
-## 0.2.0 (2026-04-28)
-
 - docs(sdk): 补充 SDK consumer 禁止 deep import kernel domain/application 的约束。
 - chore(public-api): application 不再导出 services barrel，并通过 facade 包装 migration safety。
 - feat(core): 新增 MetaKernel repository factory contract，供 adapter implementation 实现。
@@ -24,7 +22,6 @@
 - feat(api-generator): 新增稳定 route manifest 生成器，并将 compiler fixture 覆盖扩展到 API 输出。
 - feat(permission-generator): 新增稳定 permission manifest 生成器，完成 compiler fixture 覆盖。
 - feat(schema): 将 tenant、app、rule 与 permission 元数据纳入可版本化 MetaSchema 契约。
-
 ## 0.1.0 (2026-04-18)
 
 - Snapshot、diff 与 migration DSL 唯一真源内核的首个基线版本。

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zhongmiao/meta-lc-kernel",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "private": false,
   "type": "commonjs",
   "scripts": {

--- a/packages/permission/CHANGELOG.md
+++ b/packages/permission/CHANGELOG.md
@@ -2,8 +2,6 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
-## 0.2.0 (2026-04-28)
-
 - chore(public-api): narrow the package root to core contracts and explicit permission engine entrypoints.
 - docs(readme): clarify permission upstream/downstream relationships and type-only query AST boundary.
 - fix(ci): build query before permission package-local tests on clean runners.
@@ -13,7 +11,6 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - refactor(package-structure): reorganize src into layered domain/application/infra/interface/types/utils directories and update public entrypoints.
 - docs(readme): add bilingual package README and minimal architecture flow.
 - chore(package): adopt the `@zhongmiao/meta-lc-permission` scoped package identity for release governance.
-
 ## 0.1.0 (2026-04-18)
 
 - Initial permission baseline for tenant, role, and org-scope enforcement.

--- a/packages/permission/CHANGELOG.zh-CN.md
+++ b/packages/permission/CHANGELOG.zh-CN.md
@@ -2,8 +2,6 @@
 
 ## [Unreleased]
 
-## 0.2.0 (2026-04-28)
-
 - chore(public-api): 将 package root 收窄为 core contract 与明确的 permission engine 入口。
 - docs(readme): 明确 permission 上下游关系与仅 type-only 依赖 query AST/types 的边界。
 - fix(ci): 在 clean runner 的 permission package-local test 前先构建 query。
@@ -13,7 +11,6 @@
 - refactor(package-structure): 将 src 重整为 domain/application/infra/interface/types/utils 分层目录，并同步更新对外入口。
 - docs(readme): 新增双语子包 README 与最小架构流程图。
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-permission` 正式包名。
-
 ## 0.1.0 (2026-04-18)
 
 - 租户、角色与组织域权限执行链的首个基线版本。

--- a/packages/permission/package.json
+++ b/packages/permission/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zhongmiao/meta-lc-permission",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "private": false,
   "type": "commonjs",
   "scripts": {

--- a/packages/query/CHANGELOG.md
+++ b/packages/query/CHANGELOG.md
@@ -2,8 +2,6 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
-## 0.2.0 (2026-04-28)
-
 - chore(public-api): narrow the package root to core contracts and explicit query compiler entrypoints.
 - docs(readme): clarify query upstream/downstream relationships and AST-to-SQL compiler-only boundaries.
 - chore(boundaries): add final Nx layer tags and lock query as a dependency-free AST/SQL compiler package.
@@ -13,7 +11,6 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - refactor(package-structure): reorganize src into layered domain/application/infra/interface/types/utils directories and update public entrypoints.
 - docs(readme): add bilingual package README and minimal architecture flow.
 - chore(package): adopt the `@zhongmiao/meta-lc-query` scoped package identity for release governance.
-
 ## 0.1.0 (2026-04-18)
 
 - Initial query compiler baseline for platform middleware.

--- a/packages/query/CHANGELOG.zh-CN.md
+++ b/packages/query/CHANGELOG.zh-CN.md
@@ -2,8 +2,6 @@
 
 ## [Unreleased]
 
-## 0.2.0 (2026-04-28)
-
 - chore(public-api): 将 package root 收窄为 core contract 与明确的 query compiler 入口。
 - docs(readme): 明确 query 上下游关系与只负责 AST-to-SQL 编译的边界。
 - chore(boundaries): 新增最终 Nx layer tags，并将 query 锁定为无 workspace 依赖的 AST/SQL compiler 包。
@@ -13,7 +11,6 @@
 - refactor(package-structure): 将 src 重整为 domain/application/infra/interface/types/utils 分层目录，并同步更新对外入口。
 - docs(readme): 新增双语子包 README 与最小架构流程图。
 - chore(package): 为 release 治理切换到 `@zhongmiao/meta-lc-query` 正式包名。
-
 ## 0.1.0 (2026-04-18)
 
 - 平台中间件查询编译器的首个基线版本。

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zhongmiao/meta-lc-query",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "private": false,
   "type": "commonjs",
   "scripts": {

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -2,8 +2,6 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
-## 0.2.0 (2026-04-28)
-
 - docs(sdk): document runtime facade/core entry usage and internal implementation deep-import constraints.
 - chore(public-api): make the runtime root facade-only and expose runtime contracts through the `./core` subpath.
 - refactor(public-api): make the runtime package root export only `core` and the SDK-facing `application/facades` entry.
@@ -38,7 +36,6 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 - feat(runtime): add a manager-first orchestration plan that combines refresh planning, rule effects, next state, manager commands, and WebSocket topics.
 - feat(runtime): add a manager adapter execution contract for orchestrator command plans.
 - feat(runtime): add a helper that converts manager execution results into WebSocket update events.
-
 ## 0.1.0 (2026-04-18)
 
 - Initial runtime parser and template resolver baseline for Phase 4 execution planning.

--- a/packages/runtime/CHANGELOG.zh-CN.md
+++ b/packages/runtime/CHANGELOG.zh-CN.md
@@ -2,8 +2,6 @@
 
 ## [Unreleased]
 
-## 0.2.0 (2026-04-28)
-
 - docs(sdk): 补充 runtime facade/core 入口用法与内部实现 deep import 约束。
 - chore(public-api): runtime root 收窄为仅 facade 入口，并通过 `./core` subpath 暴露 runtime contract。
 - refactor(public-api): 将 runtime package root 固定为仅导出 `core` 与 SDK-facing 的 `application/facades` 入口。
@@ -38,7 +36,6 @@
 - feat(runtime): 新增 manager-first orchestration plan，统一 refresh planning、rule effects、next state、manager commands 与 WebSocket topics。
 - feat(runtime): 新增 manager adapter 执行契约，用于执行 orchestrator command plan。
 - feat(runtime): 新增 helper，将 manager 执行结果转换为 WebSocket 更新事件。
-
 ## 0.1.0 (2026-04-18)
 
 - Phase 4 runtime parser 与模板解析器的首个基线版本。

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zhongmiao/meta-lc-runtime",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "private": false,
   "type": "commonjs",
   "scripts": {

--- a/scripts/release/compose-draft-from-unreleased.mjs
+++ b/scripts/release/compose-draft-from-unreleased.mjs
@@ -8,11 +8,11 @@ const requestedVersion = versionFlagIndex >= 0 ? args[versionFlagIndex + 1] : ""
 
 const rootPackage = JSON.parse(fs.readFileSync("package.json", "utf8"));
 const version = requestedVersion || rootPackage.version;
-const rootNotes = loadRootReleaseNotes(version);
-const packages = loadWorkspacePackages(version).filter((pkg) => pkg.unreleasedEn || pkg.unreleasedZh);
+const rootNotes = loadRootReleaseNotes();
+const packages = loadWorkspacePackages().filter((pkg) => pkg.unreleasedEn || pkg.unreleasedZh);
 
 if (!rootNotes.unreleasedEn && !rootNotes.unreleasedZh && packages.length === 0) {
-  console.error("No unreleased or versioned changelog content found.");
+  console.error("No unreleased changelog content found.");
   process.exit(1);
 }
 

--- a/scripts/release/compose-draft-from-version.mjs
+++ b/scripts/release/compose-draft-from-version.mjs
@@ -1,0 +1,17 @@
+import fs from "node:fs";
+import { readVersionFromFile } from "./changelog-utils.mjs";
+
+const args = process.argv.slice(2);
+const versionFlagIndex = args.indexOf("--version");
+const requestedVersion = versionFlagIndex >= 0 ? args[versionFlagIndex + 1] : "";
+const rootPackage = JSON.parse(fs.readFileSync("package.json", "utf8"));
+const version = requestedVersion || rootPackage.version;
+
+const notes = readVersionFromFile("CHANGELOG.md", version);
+if (!notes) {
+  console.error(`No root changelog section found for ${version}.`);
+  process.exit(1);
+}
+
+const lines = [`# Release Draft: ${rootPackage.name}@${version}`, "", notes];
+process.stdout.write(`${lines.join("\n").trimEnd()}\n`);

--- a/scripts/release/finalize-unreleased-changelogs.mjs
+++ b/scripts/release/finalize-unreleased-changelogs.mjs
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import { finalizeUnreleasedSection } from "./changelog-utils.mjs";
 
-const [metadataPath] = process.argv.slice(2);
+const [metadataPath] = process.argv.slice(2).filter((arg) => arg !== "--");
 if (!metadataPath) {
   console.error("Usage: finalize-unreleased-changelogs.mjs <metadata-json-path>");
   process.exit(1);

--- a/scripts/release/package-catalog.mjs
+++ b/scripts/release/package-catalog.mjs
@@ -1,15 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
-import { readUnreleasedFromFile, readVersionFromFile } from "./changelog-utils.mjs";
+import { readUnreleasedFromFile } from "./changelog-utils.mjs";
 
 const ROOT = process.cwd();
 const PACKAGES_DIR = path.join(ROOT, "packages");
 
-function readReleaseNotes(filePath, version) {
-  return readUnreleasedFromFile(filePath) || readVersionFromFile(filePath, version);
-}
-
-export function loadWorkspacePackages(version = "") {
+export function loadWorkspacePackages() {
   return fs
     .readdirSync(PACKAGES_DIR, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
@@ -27,18 +23,18 @@ export function loadWorkspacePackages(version = "") {
         packageJsonPath: path.relative(ROOT, packageJsonPath),
         changelogPathEn: path.relative(ROOT, changelogPathEn),
         changelogPathZh: path.relative(ROOT, changelogPathZh),
-        unreleasedEn: readReleaseNotes(changelogPathEn, version),
-        unreleasedZh: readReleaseNotes(changelogPathZh, version)
+        unreleasedEn: readUnreleasedFromFile(changelogPathEn),
+        unreleasedZh: readUnreleasedFromFile(changelogPathZh)
       };
     })
     .sort((left, right) => left.name.localeCompare(right.name));
 }
 
-export function loadRootReleaseNotes(version = "") {
+export function loadRootReleaseNotes() {
   return {
     changelogPathEn: "CHANGELOG.md",
     changelogPathZh: "CHANGELOG.zh-CN.md",
-    unreleasedEn: readReleaseNotes(path.join(ROOT, "CHANGELOG.md"), version),
-    unreleasedZh: readReleaseNotes(path.join(ROOT, "CHANGELOG.zh-CN.md"), version)
+    unreleasedEn: readUnreleasedFromFile(path.join(ROOT, "CHANGELOG.md")),
+    unreleasedZh: readUnreleasedFromFile(path.join(ROOT, "CHANGELOG.zh-CN.md"))
   };
 }

--- a/scripts/release/prepare-release-pr.mjs
+++ b/scripts/release/prepare-release-pr.mjs
@@ -1,0 +1,73 @@
+import fs from "node:fs";
+import path from "node:path";
+import { finalizeUnreleasedSection } from "./changelog-utils.mjs";
+import { loadWorkspacePackages } from "./package-catalog.mjs";
+
+const [metadataPath] = process.argv.slice(2).filter((arg) => arg !== "--");
+if (!metadataPath) {
+  console.error("Usage: prepare-release-pr.mjs <metadata-json-path>");
+  process.exit(1);
+}
+
+const metadata = JSON.parse(fs.readFileSync(metadataPath, "utf8"));
+const version = String(metadata.version || "").trim();
+if (!version) {
+  console.error("Release metadata must include a version.");
+  process.exit(1);
+}
+
+const ROOT = process.cwd();
+const date = new Date().toISOString().slice(0, 10);
+const internalPackageNames = new Set(
+  listWorkspaceManifests("packages")
+    .map((manifestPath) => JSON.parse(fs.readFileSync(manifestPath, "utf8")).name)
+    .filter(Boolean)
+);
+
+function updateManifestVersion(filePath) {
+  const pkg = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  pkg.version = version;
+  if (pkg.peerDependencies && typeof pkg.peerDependencies === "object") {
+    for (const peerName of Object.keys(pkg.peerDependencies)) {
+      if (internalPackageNames.has(peerName)) {
+        pkg.peerDependencies[peerName] = version;
+      }
+    }
+  }
+  fs.writeFileSync(filePath, `${JSON.stringify(pkg, null, 2)}\n`, "utf8");
+}
+
+function listWorkspaceManifests(baseDir) {
+  const basePath = path.join(ROOT, baseDir);
+  if (!fs.existsSync(basePath)) {
+    return [];
+  }
+  return fs
+    .readdirSync(basePath, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(basePath, entry.name, "package.json"))
+    .filter((filePath) => fs.existsSync(filePath));
+}
+
+updateManifestVersion(path.join(ROOT, "package.json"));
+for (const manifestPath of [...listWorkspaceManifests("packages"), ...listWorkspaceManifests("apps")]) {
+  updateManifestVersion(manifestPath);
+}
+
+let changedChangelogs = false;
+for (const filePath of ["CHANGELOG.md", "CHANGELOG.zh-CN.md"]) {
+  changedChangelogs = finalizeUnreleasedSection(filePath, version, date) || changedChangelogs;
+}
+
+for (const pkg of loadWorkspacePackages()) {
+  for (const filePath of [pkg.changelogPathEn, pkg.changelogPathZh]) {
+    changedChangelogs = finalizeUnreleasedSection(filePath, version, date) || changedChangelogs;
+  }
+}
+
+if (!changedChangelogs) {
+  console.error("No unreleased changelog content was finalized.");
+  process.exit(1);
+}
+
+console.log(`Prepared release PR changes for ${version}.`);

--- a/scripts/release/publish-selected-packages.mjs
+++ b/scripts/release/publish-selected-packages.mjs
@@ -1,0 +1,122 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const args = process.argv.slice(2);
+const dryRun = args.includes("--dry-run");
+const versionFlagIndex = args.indexOf("--version");
+const requestedVersion = versionFlagIndex >= 0 ? args[versionFlagIndex + 1] : "";
+
+const ROOT = process.cwd();
+const rootPackage = JSON.parse(fs.readFileSync(path.join(ROOT, "package.json"), "utf8"));
+const releaseVersion = requestedVersion || rootPackage.version;
+
+function listPackageManifests() {
+  const packagesPath = path.join(ROOT, "packages");
+  return fs
+    .readdirSync(packagesPath, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(packagesPath, entry.name, "package.json"))
+    .filter((filePath) => fs.existsSync(filePath));
+}
+
+function isPublished(name, version) {
+  try {
+    execFileSync("npm", ["view", `${name}@${version}`, "version"], {
+      cwd: ROOT,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"]
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const packages = listPackageManifests()
+  .map((manifestPath) => {
+    const pkg = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+    return {
+      dir: path.dirname(manifestPath),
+      manifestPath,
+      name: pkg.name,
+      version: pkg.version,
+      private: pkg.private === true,
+      publishConfig: pkg.publishConfig,
+      dependencies: {
+        ...(pkg.dependencies ?? {}),
+        ...(pkg.peerDependencies ?? {})
+      }
+    };
+  })
+  .filter((pkg) => !pkg.private);
+
+const byName = new Map(packages.map((pkg) => [pkg.name, pkg]));
+const sortedPackages = [];
+const visiting = new Set();
+const visited = new Set();
+
+function visit(pkg) {
+  if (visited.has(pkg.name)) {
+    return;
+  }
+  if (visiting.has(pkg.name)) {
+    console.error(`Workspace dependency cycle detected at ${pkg.name}.`);
+    process.exit(1);
+  }
+  visiting.add(pkg.name);
+  for (const dependencyName of Object.keys(pkg.dependencies)) {
+    const dependency = byName.get(dependencyName);
+    if (dependency) {
+      visit(dependency);
+    }
+  }
+  visiting.delete(pkg.name);
+  visited.add(pkg.name);
+  sortedPackages.push(pkg);
+}
+
+for (const pkg of packages) {
+  visit(pkg);
+}
+
+for (const pkg of sortedPackages) {
+  if (pkg.version !== releaseVersion) {
+    console.error(`${path.relative(ROOT, pkg.manifestPath)} has version ${pkg.version}, expected ${releaseVersion}.`);
+    process.exit(1);
+  }
+  if (pkg.publishConfig?.access !== "public") {
+    console.error(`${pkg.name} must set publishConfig.access to public before publishing.`);
+    process.exit(1);
+  }
+  if (!fs.existsSync(path.join(pkg.dir, "dist"))) {
+    console.error(`${pkg.name} is missing dist output. Run pnpm -r build before publishing.`);
+    process.exit(1);
+  }
+}
+
+if (packages.length === 0) {
+  console.log("No publishable packages found.");
+  process.exit(0);
+}
+
+for (const pkg of sortedPackages) {
+  if (isPublished(pkg.name, pkg.version)) {
+    console.log(`skip ${pkg.name}@${pkg.version}: already published`);
+    continue;
+  }
+
+  const command = ["publish", "--access", "public", "--tag", "latest", "--no-git-checks"];
+  if (dryRun) {
+    command.push("--dry-run");
+  }
+
+  console.log(`${dryRun ? "dry-run publish" : "publish"} ${pkg.name}@${pkg.version}`);
+  const result = spawnSync("pnpm", command, {
+    cwd: pkg.dir,
+    stdio: "inherit"
+  });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}

--- a/scripts/release/version-consistency.mjs
+++ b/scripts/release/version-consistency.mjs
@@ -5,6 +5,26 @@ const ROOT = process.cwd();
 const expectedPrefix = "@zhongmiao/meta-lc-";
 const packageDirs = ["packages", "apps"];
 const violations = [];
+const rootPackage = JSON.parse(fs.readFileSync(path.join(ROOT, "package.json"), "utf8"));
+const rootVersion = rootPackage.version;
+const workspacePackageNames = new Set();
+
+for (const baseDir of packageDirs) {
+  const base = path.join(ROOT, baseDir);
+  for (const entry of fs.readdirSync(base, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const packageJsonPath = path.join(base, entry.name, "package.json");
+    if (!fs.existsSync(packageJsonPath)) {
+      continue;
+    }
+    const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+    if (pkg.name) {
+      workspacePackageNames.add(pkg.name);
+    }
+  }
+}
 
 for (const baseDir of packageDirs) {
   const base = path.join(ROOT, baseDir);
@@ -19,6 +39,27 @@ for (const baseDir of packageDirs) {
     const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
     if (!String(pkg.name || "").startsWith(expectedPrefix)) {
       violations.push(`${path.relative(ROOT, packageJsonPath)} must use the ${expectedPrefix}* prefix.`);
+    }
+    if (pkg.version !== rootVersion) {
+      violations.push(`${path.relative(ROOT, packageJsonPath)} must use root version ${rootVersion}.`);
+    }
+    for (const [peerName, peerVersion] of Object.entries(pkg.peerDependencies ?? {})) {
+      if (workspacePackageNames.has(peerName) && peerVersion !== rootVersion) {
+        violations.push(
+          `${path.relative(ROOT, packageJsonPath)} must pin internal peerDependency ${peerName} to ${rootVersion}.`
+        );
+      }
+    }
+    if (baseDir === "packages" && pkg.private !== true) {
+      if (pkg.publishConfig?.access !== "public") {
+        violations.push(`${path.relative(ROOT, packageJsonPath)} must set publishConfig.access to public.`);
+      }
+      const files = Array.isArray(pkg.files) ? pkg.files : [];
+      for (const requiredFile of ["dist", "README.md", "README_zh.md", "CHANGELOG.md", "CHANGELOG.zh-CN.md"]) {
+        if (!files.includes(requiredFile)) {
+          violations.push(`${path.relative(ROOT, packageJsonPath)} must include ${requiredFile} in files.`);
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Restores the platform to a pending-release state: root, packages, and the BFF app are back to `0.1.1`, and the former `0.2.0` notes are back under `[Unreleased]`.
- Reworks the manual Release Prepare workflow to match the desired release PR flow: enter `0.2.0`, keep `finalize_changelog` checked, create a release PR, and sync the draft release body from the finalized root changelog section.
- Adds a main-branch Publish workflow that runs after the release PR merge, publishes only public SDK packages, then publishes the GitHub release from the existing draft.

## Flow
1. Run **Release Prepare** on `main` with `version=0.2.0` and `finalize_changelog=true`.
2. The workflow creates a release branch/PR, updates versions/changelogs, and upserts draft release `v0.2.0` using the release PR root changelog section.
3. The generated release PR runs build/package validation but skips the changelog gate.
4. Merge the release PR to `main` to run the real release CI: build, test, lint, query-gate, npm publish, then publish the GitHub release.

## Validation
- `pnpm install --lockfile-only`
- `pnpm run test:boundaries`
- `pnpm run lint:boundaries`
- `pnpm -r build`
- `pnpm -r test`
- `pnpm lint` (warnings only, no errors)
- `pnpm query-gate`
- `node scripts/check-changelog-gate.mjs "$(git merge-base origin/main HEAD)" HEAD`
- `pnpm run version:check`
- `pnpm run -s release:draft-notes -- --version 0.2.0`
- temp-dir dry run of `release:prepare-pr` + `release:draft-notes:version` for `0.2.0`
- `pnpm run -s release:publish-packages -- --version 0.1.1 --dry-run`

## Notes
- The draft release uses the `v0.2.0` release tag name during prepare; the actual release/tag is finalized against the merged `main` commit after publish succeeds.
- Existing stale GitHub drafts/tags are intentionally untouched.
