### PR TITLE
[codex] fix: guard publish workflow by release PR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,7 @@ jobs:
         id: detect
         env:
           BEFORE_SHA: ${{ github.event.before }}
+          HEAD_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           set -euo pipefail
 
@@ -45,8 +46,15 @@ jobs:
             exit 0
           fi
 
+          RELEASE_MARKER="chore(release): prepare ${VERSION}"
+          if [[ "${HEAD_MESSAGE}" != *"${RELEASE_MARKER}"* ]]; then
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            echo "Root version changed from ${OLD_VERSION:-unknown} to ${VERSION}, but this push is not a generated release PR merge (${RELEASE_MARKER}); skipping publish."
+            exit 0
+          fi
+
           if ! grep -Eq "^## ${VERSION} \\([0-9]{4}-[0-9]{2}-[0-9]{2}\\)" CHANGELOG.md; then
-            echo "Root version changed to ${VERSION}, but CHANGELOG.md has no matching release section."
+            echo "Generated release PR merge detected for ${VERSION}, but CHANGELOG.md has no matching release section."
             exit 1
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- fix(release): restrict main-branch publishing to generated release PR merges.
 - fix(release): switch the multi-package release flow to Unreleased draft notes, generated release PRs, and main-branch publishing.
 - docs(sdk): add the SDK release checklist for beta freeze validation.
 - docs(sdk): document factory-first adapter usage, advanced Postgres classes, and consumer deep-import rules.

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- fix(release): 将 main 分支发布限制为 generated release PR 合并触发，避免普通版本恢复误发布。
 - fix(release): 将多包发布流程调整为基于 Unreleased 生成草稿、生成 release PR，并在 main 分支合并后发布。
 - docs(sdk): 新增 SDK 发布 checklist，用于 Beta 封板校验。
 - docs(sdk): 补充 factory-first adapter 使用、Postgres class advanced API 与业务方 deep import 约束。


### PR DESCRIPTION
## Summary
- Restricts the main-branch publish workflow to generated release PR merges only.
- A publish run now requires the merge commit message to contain `chore(release): prepare <version>` before it checks changelog sections or publishes packages.
- Non-release version changes, including the pending-release restore from #136, now skip publish instead of failing.

## Validation
- `pnpm run version:check`
- `pnpm run lint:boundaries`
- `node scripts/check-changelog-gate.mjs "$(git merge-base origin/main HEAD)" HEAD`
