### PR TITLE
[codex] fix: pin internal dependencies in release PR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,7 @@ jobs:
         id: detect
         env:
           BEFORE_SHA: ${{ github.event.before }}
+          HEAD_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           set -euo pipefail
 
@@ -45,8 +46,15 @@ jobs:
             exit 0
           fi
 
+          RELEASE_MARKER="chore(release): prepare ${VERSION}"
+          if [[ "${HEAD_MESSAGE}" != *"${RELEASE_MARKER}"* ]]; then
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            echo "Root version changed from ${OLD_VERSION:-unknown} to ${VERSION}, but this push is not a generated release PR merge (${RELEASE_MARKER}); skipping publish."
+            exit 0
+          fi
+
           if ! grep -Eq "^## ${VERSION} \\([0-9]{4}-[0-9]{2}-[0-9]{2}\\)" CHANGELOG.md; then
-            echo "Root version changed to ${VERSION}, but CHANGELOG.md has no matching release section."
+            echo "Generated release PR merge detected for ${VERSION}, but CHANGELOG.md has no matching release section."
             exit 1
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- fix(release): restrict main-branch publishing to generated release PR merges.
 - fix(release): switch the multi-package release flow to Unreleased draft notes, generated release PRs, and main-branch publishing.
 - docs(sdk): add the SDK release checklist for beta freeze validation.
 - docs(sdk): document factory-first adapter usage, advanced Postgres classes, and consumer deep-import rules.

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- fix(release): 将 main 分支发布限制为 generated release PR 合并触发，避免普通版本恢复误发布。
 - fix(release): 将多包发布流程调整为基于 Unreleased 生成草稿、生成 release PR，并在 main 分支合并后发布。
 - docs(sdk): 新增 SDK 发布 checklist，用于 Beta 封板校验。
 - docs(sdk): 补充 factory-first adapter 使用、Postgres class advanced API 与业务方 deep import 约束。

--- a/scripts/release/prepare-release-pr.mjs
+++ b/scripts/release/prepare-release-pr.mjs
@@ -27,10 +27,13 @@ const internalPackageNames = new Set(
 function updateManifestVersion(filePath) {
   const pkg = JSON.parse(fs.readFileSync(filePath, "utf8"));
   pkg.version = version;
-  if (pkg.peerDependencies && typeof pkg.peerDependencies === "object") {
-    for (const peerName of Object.keys(pkg.peerDependencies)) {
-      if (internalPackageNames.has(peerName)) {
-        pkg.peerDependencies[peerName] = version;
+  for (const dependencyField of ["dependencies", "peerDependencies", "optionalDependencies", "devDependencies"]) {
+    if (!pkg[dependencyField] || typeof pkg[dependencyField] !== "object") {
+      continue;
+    }
+    for (const dependencyName of Object.keys(pkg[dependencyField])) {
+      if (internalPackageNames.has(dependencyName)) {
+        pkg[dependencyField][dependencyName] = version;
       }
     }
   }

--- a/scripts/release/version-consistency.mjs
+++ b/scripts/release/version-consistency.mjs
@@ -8,6 +8,12 @@ const violations = [];
 const rootPackage = JSON.parse(fs.readFileSync(path.join(ROOT, "package.json"), "utf8"));
 const rootVersion = rootPackage.version;
 const workspacePackageNames = new Set();
+const rootChangelog = fs.existsSync(path.join(ROOT, "CHANGELOG.md"))
+  ? fs.readFileSync(path.join(ROOT, "CHANGELOG.md"), "utf8").replace(/\r\n/g, "\n")
+  : "";
+const isReleaseManifestState = new RegExp(`^## ${rootVersion.replaceAll(".", "\\.")} \\(\\d{4}-\\d{2}-\\d{2}\\)`, "m").test(
+  rootChangelog
+);
 
 for (const baseDir of packageDirs) {
   const base = path.join(ROOT, baseDir);
@@ -43,11 +49,15 @@ for (const baseDir of packageDirs) {
     if (pkg.version !== rootVersion) {
       violations.push(`${path.relative(ROOT, packageJsonPath)} must use root version ${rootVersion}.`);
     }
-    for (const [peerName, peerVersion] of Object.entries(pkg.peerDependencies ?? {})) {
-      if (workspacePackageNames.has(peerName) && peerVersion !== rootVersion) {
-        violations.push(
-          `${path.relative(ROOT, packageJsonPath)} must pin internal peerDependency ${peerName} to ${rootVersion}.`
-        );
+    if (isReleaseManifestState) {
+      for (const dependencyField of ["dependencies", "peerDependencies", "optionalDependencies", "devDependencies"]) {
+        for (const [dependencyName, dependencyVersion] of Object.entries(pkg[dependencyField] ?? {})) {
+          if (workspacePackageNames.has(dependencyName) && dependencyVersion !== rootVersion) {
+            violations.push(
+              `${path.relative(ROOT, packageJsonPath)} must pin internal ${dependencyField} ${dependencyName} to ${rootVersion}.`
+            );
+          }
+        }
       }
     }
     if (baseDir === "packages" && pkg.private !== true) {


### PR DESCRIPTION
## Summary
- Updates release PR preparation so internal workspace dependencies are pinned to the target release version across dependencies, peerDependencies, optionalDependencies, and devDependencies.
- Keeps normal development manifests allowed to use workspace protocol, but requires exact internal dependency versions once a release changelog section exists.

## Validation
- `pnpm run version:check`
- temp-dir dry run of `release:prepare-pr -- 0.2.0`, confirming BFF/runtime/kernel-adapter/app internal dependencies become exact `0.2.0`
- `pnpm run test:boundaries`
- `pnpm run lint:boundaries`
- changelog gate
