### PR TITLE
fix(release): link exact workspace dependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+link-workspace-packages=true
+prefer-workspace-packages=true


### PR DESCRIPTION
## Summary
- Adds pnpm workspace linking config so release PR manifests can pin internal dependencies to exact versions without CI trying to fetch unpublished packages from npm.
- Keeps exact internal dependency versions in generated release PRs while preserving install/build validation before publish.

## Validation
- simulated `release:prepare-pr -- 0.2.0` in a temp checkout, confirming internal dependencies become exact `0.2.0`
- `pnpm install --lockfile-only` succeeds after the simulated release PR manifest rewrite
- `pnpm run version:check`
- `pnpm run lint:boundaries`
