### PR TITLE
fix(release): include package notes in version draft

### DIFF
--- a/scripts/release/compose-draft-from-version.mjs
+++ b/scripts/release/compose-draft-from-version.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import { readVersionFromFile } from "./changelog-utils.mjs";
+import { loadWorkspacePackages } from "./package-catalog.mjs";
 
 const args = process.argv.slice(2);
 const versionFlagIndex = args.indexOf("--version");
@@ -7,11 +8,45 @@ const requestedVersion = versionFlagIndex >= 0 ? args[versionFlagIndex + 1] : ""
 const rootPackage = JSON.parse(fs.readFileSync("package.json", "utf8"));
 const version = requestedVersion || rootPackage.version;
 
-const notes = readVersionFromFile("CHANGELOG.md", version);
-if (!notes) {
-  console.error(`No root changelog section found for ${version}.`);
+const rootNotes = readVersionFromFile("CHANGELOG.md", version);
+const packages = loadWorkspacePackages()
+  .map((pkg) => ({
+    ...pkg,
+    versionNotesEn: readVersionFromFile(pkg.changelogPathEn, version),
+    versionNotesZh: readVersionFromFile(pkg.changelogPathZh, version)
+  }))
+  .filter((pkg) => pkg.versionNotesEn || pkg.versionNotesZh);
+
+if (!rootNotes && packages.length === 0) {
+  console.error(`No changelog sections found for ${version}.`);
   process.exit(1);
 }
 
-const lines = [`# Release Draft: ${rootPackage.name}@${version}`, "", notes];
+const lines = [
+  `# Release Draft: ${rootPackage.name}@${version}`,
+  "",
+  "## Package Topology",
+  `- root package: ${rootPackage.name}@${version}`,
+  `- workspace packages: ${loadWorkspacePackages()
+    .map((pkg) => pkg.name)
+    .join(", ")}`,
+  ""
+];
+
+if (rootNotes) {
+  lines.push("## Platform Notes", "", rootNotes, "");
+}
+
+if (packages.length > 0) {
+  lines.push("## Package Notes", "");
+  for (const pkg of packages) {
+    lines.push(`### ${pkg.name}`, "");
+    if (pkg.versionNotesEn) {
+      lines.push(pkg.versionNotesEn, "");
+    } else {
+      lines.push("- Chinese-only changelog content present; see the zh-CN changelog.", "");
+    }
+  }
+}
+
 process.stdout.write(`${lines.join("\n").trimEnd()}\n`);


### PR DESCRIPTION
## Summary
- Updates version-based release draft generation to include package changelog sections as well as root platform notes.
- Keeps the finalized release draft format aligned with the Unreleased draft format: package topology, platform notes, and package notes.

## Validation
- temp-dir dry run of `release:prepare-pr -- 0.2.0` followed by `release:draft-notes:version -- --version 0.2.0`
- confirmed the generated draft includes 8 package note sections
- `pnpm run version:check`
- `pnpm run lint:boundaries`
- changelog gate
