### PR TITLE
fix(ci): run JavaScript actions on Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   PNPM_VERSION: 10.14.0
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   changelog-gate:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   PNPM_VERSION: 10.14.0
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   detect-release:
@@ -106,7 +107,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm run -s release:publish-packages -- --version "${{ needs.detect-release.outputs.version }}"
       - name: Publish GitHub release
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           RELEASE_TAG: ${{ needs.detect-release.outputs.tag }}
           RELEASE_VERSION: ${{ needs.detect-release.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ on:
 
 env:
   PNPM_VERSION: 10.14.0
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   prepare-release-pr:
@@ -82,7 +83,7 @@ jobs:
 
           echo "name=${BRANCH}" >> "$GITHUB_OUTPUT"
       - name: Upsert draft release
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           RELEASE_TAG: v${{ steps.version.outputs.value }}
           RELEASE_TARGET: ${{ steps.branch.outputs.name || 'main' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- fix(ci): run JavaScript actions on Node.js 24 and update github-script actions.
 - fix(release): restrict main-branch publishing to generated release PR merges.
 - fix(release): switch the multi-package release flow to Unreleased draft notes, generated release PRs, and main-branch publishing.
 - docs(sdk): add the SDK release checklist for beta freeze validation.

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- fix(ci): 将 JavaScript actions 切到 Node.js 24，并升级 github-script action。
 - fix(release): 将 main 分支发布限制为 generated release PR 合并触发，避免普通版本恢复误发布。
 - fix(release): 将多包发布流程调整为基于 Unreleased 生成草稿、生成 release PR，并在 main 分支合并后发布。
 - docs(sdk): 新增 SDK 发布 checklist，用于 Beta 封板校验。


### PR DESCRIPTION
## Summary
- Upgrades `actions/github-script` usages from v7 to v9 so release workflows use the Node.js 24-compatible action runtime.
- Sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` across CI, release prepare, and publish workflows to opt JavaScript actions into Node.js 24 now.

## Validation
- `rg "actions/github-script@v7|Node.js 20|FORCE_JAVASCRIPT_ACTIONS_TO_NODE24" .github/workflows CHANGELOG*.md`
- `pnpm run lint:boundaries`
- `pnpm run version:check`
- `node scripts/check-changelog-gate.mjs "$(git merge-base origin/main HEAD)" HEAD`
