### PR TITLE
fix(release): remove draft wording from notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ English | [中文文档](CHANGELOG.zh-CN.md)
 
 ## [Unreleased]
 
+- fix(release): remove draft-only wording from GitHub release notes and group notes by root/package sections.
 - fix(ci): fail PR and release lint checks when ESLint reports warnings.
 
 ## 0.2.0 (2026-04-28)

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- fix(release): 移除 GitHub release notes 中的 draft-only 文案，并按 root/package 分组展示发布说明。
 - fix(ci): 当 ESLint 报告 warning 时，让 PR 与 release lint 检查失败。
 
 ## 0.2.0 (2026-04-28)

--- a/scripts/release/compose-draft-from-unreleased.mjs
+++ b/scripts/release/compose-draft-from-unreleased.mjs
@@ -43,22 +43,22 @@ if (outputJson) {
 }
 
 const lines = [
-  `# Release Draft: ${rootPackage.name}@${version}`,
+  "## Release Summary",
   "",
-  "## Package Topology",
   `- root package: ${rootPackage.name}@${version}`,
   `- workspace packages: ${catalog.map((pkg) => pkg.name).join(", ")}`,
+  `- packages with changelog entries: ${packages.length}`,
   ""
 ];
 
 if (rootNotes.unreleasedEn) {
-  lines.push("## Platform Notes", "", rootNotes.unreleasedEn, "");
+  lines.push("## Root Changelog (Unreleased)", "", "### CHANGELOG.md", rootNotes.unreleasedEn, "");
 }
 
 if (packages.length > 0) {
-  lines.push("## Package Notes", "");
+  lines.push("## Package Changes", "");
   for (const pkg of packages) {
-    lines.push(`### ${pkg.name}`, "");
+    lines.push(`### ${pkg.name} -> ${version}`, "");
     if (pkg.unreleasedEn) {
       lines.push(pkg.unreleasedEn, "");
     } else {

--- a/scripts/release/compose-draft-from-version.mjs
+++ b/scripts/release/compose-draft-from-version.mjs
@@ -23,24 +23,24 @@ if (!rootNotes && packages.length === 0) {
 }
 
 const lines = [
-  `# Release Draft: ${rootPackage.name}@${version}`,
+  "## Release Summary",
   "",
-  "## Package Topology",
   `- root package: ${rootPackage.name}@${version}`,
   `- workspace packages: ${loadWorkspacePackages()
     .map((pkg) => pkg.name)
     .join(", ")}`,
+  `- packages with changelog entries: ${packages.length}`,
   ""
 ];
 
 if (rootNotes) {
-  lines.push("## Platform Notes", "", rootNotes, "");
+  lines.push("## Root Changelog", "", "### CHANGELOG.md", rootNotes, "");
 }
 
 if (packages.length > 0) {
-  lines.push("## Package Notes", "");
+  lines.push("## Package Changes", "");
   for (const pkg of packages) {
-    lines.push(`### ${pkg.name}`, "");
+    lines.push(`### ${pkg.name} -> ${version}`, "");
     if (pkg.versionNotesEn) {
       lines.push(pkg.versionNotesEn, "");
     } else {


### PR DESCRIPTION
## Summary
- Removes draft-only wording from generated GitHub release notes.
- Groups generated notes into Release Summary, Root Changelog, and Package Changes so the same body is suitable after the draft is published.
- Keeps both Unreleased-based and version-based note generation aligned.

## Validation
- [x] `node --check scripts/release/compose-draft-from-unreleased.mjs`
- [x] `node --check scripts/release/compose-draft-from-version.mjs`
- [x] `pnpm run -s release:draft-notes -- --version 0.2.1`
- [x] `pnpm run -s release:draft-notes:version -- --version 0.2.0`
- [x] `pnpm run lint:boundaries`
- [x] changelog gate

## Risk / Rollback
- Low risk: release note formatting only. Rollback by restoring the previous compose script headings.
